### PR TITLE
chore: extract etcd into a separate Deployment behind a Service

### DIFF
--- a/artifacts/example/deployment.yaml
+++ b/artifacts/example/deployment.yaml
@@ -20,7 +20,63 @@ spec:
       - name: wardle-server
         image: vklokun/kube-sample-apiserver:0.1.38
         imagePullPolicy: Always
-        args: [ "--etcd-servers=http://localhost:2379" ]
+        args: [ "--etcd-servers=http://kubescape-aa-storage-etcd:2379" ]
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kubescape-aa-storage-etcd
+  namespace: wardle
+  labels:
+    app.kubernetes.io/name: "etcd"
+    app.kubernetes.io/component: "database"
+    app.kubernetes.io/part-of: "kubescape-aa-storage"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: "etcd"
+      app.kubernetes.io/component: "database"
+      app.kubernetes.io/part-of: "kubescape-aa-storage"
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: "etcd"
+        app.kubernetes.io/component: "database"
+        app.kubernetes.io/part-of: "kubescape-aa-storage"
+    spec:
+      containers:
       - name: etcd
         image: gcr.io/etcd-development/etcd:v3.5.7
-        args: ["etcd", "--max-request-bytes=25165824" ]
+        args:
+          - "etcd"
+          - "--listen-client-urls=http://0.0.0.0:2379"
+          - "--advertise-client-urls=http://0.0.0.0:2379"
+          - "--max-request-bytes=25165824"
+        ports:
+          - name: "etcd-port"
+            protocol: "TCP"
+            containerPort: 2379
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: "kubescape-aa-storage-etcd"
+  namespace: "wardle"
+  labels:
+    app.kubernetes.io/name: "etcd"
+    app.kubernetes.io/component: "database"
+    app.kubernetes.io/part-of: "kubescape-aa-storage"
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: "etcd"
+    app.kubernetes.io/component: "database"
+    app.kubernetes.io/part-of: "kubescape-aa-storage"
+  ports:
+  - name: "etcd-port"
+    protocol: "TCP"
+    port: 2379
+    targetPort: "etcd-port"


### PR DESCRIPTION
# What this PR changes?

This PR extracts the etcd instance that is the backing storage for the Kubescape Aggregated APIServer into a separate service to help us show a more realistic example of deployment.