### PR TITLE
fix: increase ETCD msg size limit further

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -33,7 +33,7 @@ import (
 	vmstorage "github.com/kubescape/storage/pkg/registry/softwarecomposition/vulnerabilitymanifest"
 )
 
-const maxRequestBodyBytes = 25 * 1024 * 1024
+const maxRequestBodyBytes = 1024 * 1024 * 1024
 
 var (
 	// Scheme defines methods for serializing and deserializing API objects.

--- a/vendor/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
+++ b/vendor/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"math"
 
 	grpcprom "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"go.etcd.io/etcd/client/pkg/v3/logutil"
@@ -293,8 +294,8 @@ var newETCD3Client = func(c storagebackend.TransportConfig) (*clientv3.Client, e
 		TLS:                  tlsConfig,
 		Logger:               etcd3ClientLogger,
 
-		MaxCallRecvMsgSize: 25 * 1024 * 1024,
-		MaxCallSendMsgSize: 25 * 1024 * 1024,
+		MaxCallRecvMsgSize: math.MaxInt32,
+		MaxCallSendMsgSize: math.MaxInt32,
 	}
 
 	return clientv3.New(cfg)


### PR DESCRIPTION
# What this PR changes?
- Remove gRPC message size limits
- Increase write request body max bytes to 1 GiB