### PR TITLE
fix: reject Protobuf requests

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -118,6 +118,12 @@ func (c completedConfig) New() (*WardleServer, error) {
 	}
 
 	apiGroupInfo := genericapiserver.NewDefaultAPIGroupInfo(softwarecomposition.GroupName, Scheme, metav1.ParameterCodec, Codecs)
+	// Since our types don’t implement the Protobuf marshaling interface,
+	// but the default APIServer serializer advertizes it by default, a lot
+	// of unexpected things might fail. One example is that deleting an
+	// arbitrary namespace will fail while this APIServer is running (see
+	// https://github.com/kubernetes/kubernetes/issues/86666).
+	apiGroupInfo.NegotiatedSerializer = NewNoProtobufSerializer(Codecs)
 
 	storageImpl := file.NewStorageImpl(afero.NewOsFs(), "/tmp")
 	v1beta1storage := map[string]rest.Storage{}

--- a/pkg/apiserver/serializer.go
+++ b/pkg/apiserver/serializer.go
@@ -1,0 +1,26 @@
+package apiserver
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// NewNoProtobufSerializer returns a decorated originalSerializer that will reject the Protobuf content type.
+func NewNoProtobufSerializer(originalSerializer runtime.NegotiatedSerializer) runtime.NegotiatedSerializer {
+	return noProtobufNegotiatedSerializer{NegotiatedSerializer: originalSerializer}
+}
+
+// noProtobufNegotiatedSerializer is a negotiated seriazlier that rejects the Protobuf content type
+type noProtobufNegotiatedSerializer struct {
+	runtime.NegotiatedSerializer
+}
+
+func (s noProtobufNegotiatedSerializer) SupportedMediaTypes() []runtime.SerializerInfo {
+	base := s.NegotiatedSerializer.SupportedMediaTypes()
+	filtered := []runtime.SerializerInfo{}
+	for _, info := range base {
+		if info.MediaType != runtime.ContentTypeProtobuf {
+			filtered = append(filtered, info)
+		}
+	}
+	return filtered
+}

--- a/pkg/apiserver/serializer_test.go
+++ b/pkg/apiserver/serializer_test.go
@@ -1,0 +1,89 @@
+package apiserver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type stubSerializer struct {
+	supportedTypes []runtime.SerializerInfo
+}
+
+func newStubSerializer(supportedTypes []runtime.SerializerInfo) *stubSerializer {
+	return &stubSerializer{supportedTypes: supportedTypes}
+}
+
+func (s *stubSerializer) SupportedMediaTypes() []runtime.SerializerInfo {
+	return s.supportedTypes
+}
+
+func (s *stubSerializer) EncoderForVersion(serializer runtime.Encoder, gv runtime.GroupVersioner) runtime.Encoder {
+	return nil
+}
+
+func (s *stubSerializer) DecoderToVersion(serializer runtime.Decoder, gv runtime.GroupVersioner) runtime.Decoder {
+	return nil
+}
+
+func TestNoProtobufSerializerSupportedMediaTypes(t *testing.T) {
+	tt := []struct {
+		name                 string
+		originalContentTypes []runtime.SerializerInfo
+		wantContentTypes     []runtime.SerializerInfo
+		wantStrictlyEqual    bool
+	}{
+		{
+			name: "Wrapping an original Protobuf-only serializer should return no supported types",
+			originalContentTypes: []runtime.SerializerInfo{
+				{MediaType: runtime.ContentTypeProtobuf},
+			},
+			wantContentTypes: []runtime.SerializerInfo{},
+		},
+		{
+			name: "Wrapping an original serializer should return original types",
+			originalContentTypes: []runtime.SerializerInfo{
+				{MediaType: runtime.ContentTypeProtobuf},
+				{MediaType: runtime.ContentTypeJSON},
+				{MediaType: runtime.ContentTypeYAML},
+			},
+			wantContentTypes: []runtime.SerializerInfo{
+				{MediaType: runtime.ContentTypeJSON},
+				{MediaType: runtime.ContentTypeYAML},
+			},
+		},
+		{
+			name: "Wrapping an original serializer with no Protobuf returns a slice matching the original",
+			originalContentTypes: []runtime.SerializerInfo{
+				{MediaType: runtime.ContentTypeJSON},
+				{MediaType: runtime.ContentTypeYAML},
+			},
+			wantContentTypes: []runtime.SerializerInfo{
+				{MediaType: runtime.ContentTypeJSON},
+				{MediaType: runtime.ContentTypeYAML},
+			},
+			wantStrictlyEqual: false,
+		},
+		{
+			name:                 "Wrapping an original serializer with no supported types returns an empty slice",
+			originalContentTypes: []runtime.SerializerInfo{},
+			wantContentTypes:     []runtime.SerializerInfo{},
+			wantStrictlyEqual:    true,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			originalSerializer := newStubSerializer(tc.originalContentTypes)
+			s := NewNoProtobufSerializer(originalSerializer)
+
+			got := s.SupportedMediaTypes()
+
+			assert.ElementsMatch(t, tc.wantContentTypes, got)
+			if tc.wantStrictlyEqual {
+				assert.Equal(t, tc.wantContentTypes, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# What this PR changes?

Prior to this PR, the types that this APIServer declared did not support Protobuf, yet the default APIServer configuration advertised it as supported. This led to certain requests made in Protobuf format fail and could lead to error messages in the server logs and unexpected issues in the cluster. One of the issues we have found is not being able to delete namespaces when the APIServer was running (see https://github.com/kubernetes/kubernetes/issues/86666).

This PR introduces a default serializer that rejects the Protobuf content type, thus not advertizing support for it, making clients fall back to other supported content types.
