### PR TITLE
use distroless base image

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.19-alpine as builder
+FROM --platform=$BUILDPLATFORM golang:1.20-bullseye as builder
 
 ENV GO111MODULE=on CGO_ENABLED=0
 WORKDIR /work
@@ -9,11 +9,10 @@ RUN --mount=target=. \
     --mount=type=cache,target=/go/pkg \
     GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /out/storage .
 
-FROM alpine
+FROM gcr.io/distroless/static-debian11:nonroot
 
-RUN addgroup -S ks && adduser -S ks -G ks
-USER ks
-WORKDIR /home/ks/
+USER nonroot
+WORKDIR /home/nonroot/
 
 COPY --from=builder /out/storage /usr/bin/storage
 


### PR DESCRIPTION
this one requires a modification in the Helm chart:
```
securityContext:
  fsGroup: 65532
  runAsUser: 65532
```
there might be issues with existing files in /data because they were previously created with user `ks`