### PR TITLE
The returned order in the list is not always the same

### DIFF
--- a/pkg/registry/file/vulnarabilitysummarystoarge_test.go
+++ b/pkg/registry/file/vulnarabilitysummarystoarge_test.go
@@ -277,15 +277,9 @@ func TestVulnSummaryStorageImpl_GetList(t *testing.T) {
 					// copy the timestamp since it is created when generated, so it can be known at the test begin
 					o.Items[i].CreationTimestamp = tt.args.createdObj[i].CreationTimestamp
 				}
-				for i := range o.Items {
-					foundMatch := false
-					for j := range tt.args.expectedObj.Items {
-						if reflect.DeepEqual(o.Items[i], tt.args.expectedObj.Items[j]) {
-							foundMatch = true
-						}
-					}
-					assert.Equal(t, foundMatch, true)
-				}
+				assert.Equal(t, tt.args.expectedObj.TypeMeta, o.TypeMeta)
+				assert.Equal(t, tt.args.expectedObj.ListMeta, o.ListMeta)
+				assert.ElementsMatch(t, tt.args.expectedObj.Items, o.Items)
 			}
 		})
 	}

--- a/pkg/registry/file/vulnarabilitysummarystoarge_test.go
+++ b/pkg/registry/file/vulnarabilitysummarystoarge_test.go
@@ -2,6 +2,7 @@ package file
 
 import (
 	"context"
+	"reflect"
 	"testing"
 
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition"
@@ -276,7 +277,15 @@ func TestVulnSummaryStorageImpl_GetList(t *testing.T) {
 					// copy the timestamp since it is created when generated, so it can be known at the test begin
 					o.Items[i].CreationTimestamp = tt.args.createdObj[i].CreationTimestamp
 				}
-				assert.Equal(t, tt.args.expectedObj, o)
+				for i := range o.Items {
+					foundMatch := false
+					for j := range tt.args.expectedObj.Items {
+						if reflect.DeepEqual(o.Items[i], tt.args.expectedObj.Items[j]) {
+							foundMatch = true
+						}
+					}
+					assert.Equal(t, foundMatch, true)
+				}
 			}
 		})
 	}

--- a/pkg/registry/file/vulnarabilitysummarystoarge_test.go
+++ b/pkg/registry/file/vulnarabilitysummarystoarge_test.go
@@ -2,7 +2,6 @@ package file
 
 import (
 	"context"
-	"reflect"
 	"testing"
 
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition"


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
This PR addresses an issue in the unit test 'TestVulnSummaryStorageImpl_GetList' where the returned order in the list was not always the same, causing the test to fail intermittently. The fix involves changing the assertion to check for deep equality of list items regardless of their order.

___
## PR Main Files Walkthrough:
`pkg/registry/file/vulnarabilitysummarystoarge_test.go`: Modified the assertion in 'TestVulnSummaryStorageImpl_GetList' test to check for deep equality of list items regardless of their order. This is done by iterating over the items and checking if each item exists in the expected list, instead of directly comparing the two lists.

___
## User Description:
Sorry, we do not accept changes directly against this repository. Please see
CONTRIBUTING.md for information on where and how to contribute instead.
