### PR TITLE
add top level permissions: read-all for openssf

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,5 +1,5 @@
 name: build-image
-
+permissions: read-all
 on:
     workflow_dispatch:
       inputs:

--- a/.github/workflows/pr-created.yaml
+++ b/.github/workflows/pr-created.yaml
@@ -1,4 +1,5 @@
 name: pull_request_created
+permissions: read-all
 on:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]

--- a/.github/workflows/pr-merged.yaml
+++ b/.github/workflows/pr-merged.yaml
@@ -1,16 +1,17 @@
 name: build
+permissions: read-all
 on:
   pull_request_target:
     types: [closed]
-    branches: 
+    branches:
     - 'main'
     paths-ignore:
       - '**.md' ### Ignore running when README.MD changed.
       - '.github/workflows/*' ### Ignore running when files under path: .github/workflows/* changed.
-      
+
 jobs:
   pr-merged:
-    if: ${{ github.event.pull_request.merged == true }} ## Skip if not merged 
+    if: ${{ github.event.pull_request.merged == true }} ## Skip if not merged
     uses: kubescape/workflows/.github/workflows/incluster-comp-pr-merged.yaml@main
     with:
       IMAGE_NAME: quay.io/${{ github.repository_owner }}/storage

--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -1,4 +1,5 @@
 name: d-publish-image
+permissions: read-all
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This PR adds 'read-all' permissions to several GitHub workflow files. This change is aimed at providing top-level permissions for the OpenSSF project. The affected workflows include 'build.yaml', 'pr-created.yaml', 'pr-merged.yaml', and 'publish-image.yaml'.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`.github/workflows/build.yaml`: Added 'read-all' permissions to the workflow.
`.github/workflows/pr-created.yaml`: Added 'read-all' permissions to the workflow.
`.github/workflows/pr-merged.yaml`: Added 'read-all' permissions to the workflow.
`.github/workflows/publish-image.yaml`: Added 'read-all' permissions to the workflow.
</details>
