### PR TITLE
fix: return already exists error

### DIFF
--- a/pkg/registry/file/storage.go
+++ b/pkg/registry/file/storage.go
@@ -168,6 +168,12 @@ func (s *StorageImpl) writeFiles(ctx context.Context, key string, obj runtime.Ob
 	return nil
 }
 
+// Exists checks if an object with a given key exists
+func (s *StorageImpl) Exists(key string) (bool) {
+	count, _ := s.Count(key)
+	return count >= 1
+}
+
 // Create adds a new object at a key even when it already exists. 'ttl' is time-to-live
 // in seconds (and is ignored). If no error is returned and out is not nil, out will be
 // set to the read value from database.
@@ -181,6 +187,13 @@ func (s *StorageImpl) Create(ctx context.Context, key string, obj, out runtime.O
 		logger.L().Ctx(ctx).Error(msg)
 		return errors.New(msg)
 	}
+
+	// Attempts to create an existing object should return an error
+	if s.Exists(key) {
+		return storage.NewKeyExistsError(key, 0)
+	}
+
+
 	// write files
 	if err := s.writeFiles(ctx, key, obj, out); err != nil {
 		logger.L().Ctx(ctx).Error("write files failed", helpers.Error(err), helpers.String("key", key))

--- a/pkg/registry/file/storage_test.go
+++ b/pkg/registry/file/storage_test.go
@@ -85,6 +85,68 @@ func TestStorageImpl_Count(t *testing.T) {
 	}
 }
 
+func TestStorageImpl_Exists(t *testing.T) {
+	type args struct {
+		key string
+		obj runtime.Object
+		out runtime.Object
+		in4 uint64
+	}
+	tests := []struct {
+		name             string
+		readonly         bool
+		prerequisiteObjs []args
+		inputObjs        []args
+		wantErr          bool
+		want             runtime.Object
+	}{
+		{
+			name: "creating an existing object should return an error",
+			prerequisiteObjs: []args{
+				{
+					key: "/spdx.softwarecomposition.kubescape.io/sbomspdxv2p3s/kubescape/toto",
+					obj: &v1beta1.SBOMSPDXv2p3{
+						ObjectMeta: v1.ObjectMeta{
+							Name: "toto",
+						},
+					},
+				},
+			},
+			inputObjs: []args{
+				{
+					key: "/spdx.softwarecomposition.kubescape.io/sbomspdxv2p3s/kubescape/toto",
+					obj: &v1beta1.SBOMSPDXv2p3{
+						ObjectMeta: v1.ObjectMeta{
+							Name: "toto",
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := afero.NewMemMapFs()
+			s := NewStorageImpl(fs, DefaultStorageRoot)
+
+			for _, o := range tt.prerequisiteObjs {
+				err := s.Create(context.TODO(), o.key, o.obj, o.out, o.in4)
+				if err != nil {
+					t.Fatalf("error when creating prerequisite objects: %v", err)
+				}
+			}
+
+			for _, o := range tt.inputObjs {
+				err := s.Create(context.TODO(), o.key, o.obj, o.out, o.in4)
+				if tt.wantErr {
+					assert.Error(t, err)
+				}
+			}
+		})
+	}
+}
+
 func TestStorageImpl_Create(t *testing.T) {
 	type args struct {
 		key string

--- a/pkg/registry/file/vulnerabilitysummarystorage_test.go
+++ b/pkg/registry/file/vulnerabilitysummarystorage_test.go
@@ -424,14 +424,15 @@ func TestVulnSummaryStorageImpl_Get(t *testing.T) {
 			createObj: true, wantErr: false,
 		},
 	}
-	realStorage := NewStorageImpl(afero.NewMemMapFs(), "/")
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			realStorage := NewStorageImpl(afero.NewMemMapFs(), "/")
+
 			if tt.createObj {
 				for i := range tt.args.keyCreatedObj {
 					err := realStorage.Create(context.TODO(), tt.args.keyCreatedObj[i], tt.args.createdObj[i], nil, 0)
-					assert.Equal(t, err, nil)
+					assert.Equal(t, nil, err)
 				}
 			}
 			s := NewVulnerabilitySummaryStorage(&realStorage)


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
This pull request introduces an 'AlreadyExists' error handling in the generic storage implementation. It adds a new function 'Exists' to check if an object with a given key already exists in the storage. If an attempt is made to create an object that already exists, a 'KeyExistsError' is returned. The changes are covered with corresponding unit tests.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`pkg/registry/file/storage.go`: Added a new function 'Exists' to check if an object with a given key already exists in the storage. Modified the 'Create' function to return a 'KeyExistsError' if an attempt is made to create an object that already exists.
`pkg/registry/file/storage_test.go`: Added a new test 'TestStorageImpl_Exists' to verify the functionality of the 'Exists' function and the error handling in the 'Create' function.
`pkg/registry/file/vulnerabilitysummarystorage_test.go`: Minor changes to the test setup, creating a new instance of 'StorageImpl' for each test run.
</details>

___
## User Description:
# What this PR changes

This commit adds an AlreadyExists error to the generic storage implementaiton.

Clients that rely on the Storage returning this error would now be fixed.
