### PR TITLE
Revert "fix: return already exists error"

### DIFF
--- a/pkg/registry/file/storage.go
+++ b/pkg/registry/file/storage.go
@@ -168,12 +168,6 @@ func (s *StorageImpl) writeFiles(ctx context.Context, key string, obj runtime.Ob
 	return nil
 }
 
-// Exists checks if an object with a given key exists
-func (s *StorageImpl) Exists(key string) (bool) {
-	count, _ := s.Count(key)
-	return count >= 1
-}
-
 // Create adds a new object at a key even when it already exists. 'ttl' is time-to-live
 // in seconds (and is ignored). If no error is returned and out is not nil, out will be
 // set to the read value from database.
@@ -187,13 +181,6 @@ func (s *StorageImpl) Create(ctx context.Context, key string, obj, out runtime.O
 		logger.L().Ctx(ctx).Error(msg)
 		return errors.New(msg)
 	}
-
-	// Attempts to create an existing object should return an error
-	if s.Exists(key) {
-		return storage.NewKeyExistsError(key, 0)
-	}
-
-
 	// write files
 	if err := s.writeFiles(ctx, key, obj, out); err != nil {
 		logger.L().Ctx(ctx).Error("write files failed", helpers.Error(err), helpers.String("key", key))

--- a/pkg/registry/file/storage_test.go
+++ b/pkg/registry/file/storage_test.go
@@ -85,68 +85,6 @@ func TestStorageImpl_Count(t *testing.T) {
 	}
 }
 
-func TestStorageImpl_Exists(t *testing.T) {
-	type args struct {
-		key string
-		obj runtime.Object
-		out runtime.Object
-		in4 uint64
-	}
-	tests := []struct {
-		name             string
-		readonly         bool
-		prerequisiteObjs []args
-		inputObjs        []args
-		wantErr          bool
-		want             runtime.Object
-	}{
-		{
-			name: "creating an existing object should return an error",
-			prerequisiteObjs: []args{
-				{
-					key: "/spdx.softwarecomposition.kubescape.io/sbomspdxv2p3s/kubescape/toto",
-					obj: &v1beta1.SBOMSPDXv2p3{
-						ObjectMeta: v1.ObjectMeta{
-							Name: "toto",
-						},
-					},
-				},
-			},
-			inputObjs: []args{
-				{
-					key: "/spdx.softwarecomposition.kubescape.io/sbomspdxv2p3s/kubescape/toto",
-					obj: &v1beta1.SBOMSPDXv2p3{
-						ObjectMeta: v1.ObjectMeta{
-							Name: "toto",
-						},
-					},
-				},
-			},
-			wantErr: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			fs := afero.NewMemMapFs()
-			s := NewStorageImpl(fs, DefaultStorageRoot)
-
-			for _, o := range tt.prerequisiteObjs {
-				err := s.Create(context.TODO(), o.key, o.obj, o.out, o.in4)
-				if err != nil {
-					t.Fatalf("error when creating prerequisite objects: %v", err)
-				}
-			}
-
-			for _, o := range tt.inputObjs {
-				err := s.Create(context.TODO(), o.key, o.obj, o.out, o.in4)
-				if tt.wantErr {
-					assert.Error(t, err)
-				}
-			}
-		})
-	}
-}
-
 func TestStorageImpl_Create(t *testing.T) {
 	type args struct {
 		key string

--- a/pkg/registry/file/vulnerabilitysummarystorage_test.go
+++ b/pkg/registry/file/vulnerabilitysummarystorage_test.go
@@ -424,15 +424,14 @@ func TestVulnSummaryStorageImpl_Get(t *testing.T) {
 			createObj: true, wantErr: false,
 		},
 	}
+	realStorage := NewStorageImpl(afero.NewMemMapFs(), "/")
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			realStorage := NewStorageImpl(afero.NewMemMapFs(), "/")
-
 			if tt.createObj {
 				for i := range tt.args.keyCreatedObj {
 					err := realStorage.Create(context.TODO(), tt.args.keyCreatedObj[i], tt.args.createdObj[i], nil, 0)
-					assert.Equal(t, nil, err)
+					assert.Equal(t, err, nil)
 				}
 			}
 			s := NewVulnerabilitySummaryStorage(&realStorage)


### PR DESCRIPTION
# Overview

Commit b528275d4e819e61fdd57448598b5e2141bbc84e introduced a bug which prevented resources from updating and failed the [system tests](https://github.com/kubescape/storage/actions/runs/6641795154/job/18070792161).

This PR reverts the commit. It keeps the filesystem limit fix functioning.
