### PR TITLE
Load account from env var

### DIFF
--- a/main.go
+++ b/main.go
@@ -39,7 +39,7 @@ func main() {
 	if otelHost, present := os.LookupEnv("OTEL_COLLECTOR_SVC"); present {
 		ctx = logger.InitOtel("storage",
 			os.Getenv("RELEASE"),
-			clusterData.AccountID,
+			os.Getenv("ACCOUNT_ID"),
 			clusterData.ClusterName,
 			url.URL{Host: otelHost})
 		defer logger.ShutdownOtel(ctx)


### PR DESCRIPTION
Instead of loading the account from a config map, we will load it from an env var, since account has been moved to a secret.
Not applying the same approach as other components since when importing the `github.com/kubescape/backend` package we have dependencies issues