### PR TITLE
adding syscalls to application profile

### DIFF
--- a/pkg/apis/softwarecomposition/types.go
+++ b/pkg/apis/softwarecomposition/types.go
@@ -305,6 +305,7 @@ type ApplicationProfileContainer struct {
 	Capabilities []string
 	Execs        []ExecCalls
 	Opens        []OpenCalls
+	Syscalls     []string
 }
 
 type ExecCalls struct {


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This PR enhances the `ApplicationProfileContainer` struct by adding a new field `Syscalls`. The `Syscalls` field is an array of strings that represents system calls made by the application. This change allows for more detailed profiling of application behavior.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`pkg/apis/softwarecomposition/types.go`: Added a new field `Syscalls` to the `ApplicationProfileContainer` struct. This field is an array of strings that represents system calls made by the application.
</details>

___
## User Description:
syscalls was under `ApplicationActivitySpec` instead of `ApplicationProfileContainer`. I've added it to `ApplicationProfileContainer` but didn't remove it from `ApplicationActivitySpec` in order to not break anything.
