### PR TITLE
add syscalls

### DIFF
--- a/pkg/apis/softwarecomposition/types.go
+++ b/pkg/apis/softwarecomposition/types.go
@@ -305,6 +305,7 @@ type ApplicationProfileContainer struct {
 	Capabilities []string
 	Execs        []ExecCalls
 	Opens        []OpenCalls
+	Syscalls     []string
 }
 
 type ExecCalls struct {

--- a/pkg/apis/softwarecomposition/v1beta1/types.go
+++ b/pkg/apis/softwarecomposition/v1beta1/types.go
@@ -281,6 +281,7 @@ type ApplicationProfileContainer struct {
 	Capabilities []string    `json:"capabilities,omitempty"`
 	Execs        []ExecCalls `json:"execs,omitempty"`
 	Opens        []OpenCalls `json:"opens,omitempty"`
+	Syscalls     []string    `json:"syscalls,omitempty"`
 }
 
 type ExecCalls struct {

--- a/pkg/apis/softwarecomposition/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/softwarecomposition/v1beta1/zz_generated.conversion.go
@@ -1721,6 +1721,7 @@ func autoConvert_v1beta1_ApplicationProfileContainer_To_softwarecomposition_Appl
 	out.Capabilities = *(*[]string)(unsafe.Pointer(&in.Capabilities))
 	out.Execs = *(*[]softwarecomposition.ExecCalls)(unsafe.Pointer(&in.Execs))
 	out.Opens = *(*[]softwarecomposition.OpenCalls)(unsafe.Pointer(&in.Opens))
+	out.Syscalls = *(*[]string)(unsafe.Pointer(&in.Syscalls))
 	return nil
 }
 
@@ -1734,6 +1735,7 @@ func autoConvert_softwarecomposition_ApplicationProfileContainer_To_v1beta1_Appl
 	out.Capabilities = *(*[]string)(unsafe.Pointer(&in.Capabilities))
 	out.Execs = *(*[]ExecCalls)(unsafe.Pointer(&in.Execs))
 	out.Opens = *(*[]OpenCalls)(unsafe.Pointer(&in.Opens))
+	out.Syscalls = *(*[]string)(unsafe.Pointer(&in.Syscalls))
 	return nil
 }
 

--- a/pkg/apis/softwarecomposition/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/softwarecomposition/v1beta1/zz_generated.deepcopy.go
@@ -227,6 +227,11 @@ func (in *ApplicationProfileContainer) DeepCopyInto(out *ApplicationProfileConta
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Syscalls != nil {
+		in, out := &in.Syscalls, &out.Syscalls
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/apis/softwarecomposition/zz_generated.deepcopy.go
+++ b/pkg/apis/softwarecomposition/zz_generated.deepcopy.go
@@ -227,6 +227,11 @@ func (in *ApplicationProfileContainer) DeepCopyInto(out *ApplicationProfileConta
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Syscalls != nil {
+		in, out := &in.Syscalls, &out.Syscalls
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -563,6 +563,20 @@ func schema_pkg_apis_softwarecomposition_v1beta1_ApplicationProfileContainer(ref
 							},
 						},
 					},
+					"syscalls": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This PR introduces the following changes:
- Adds a new field 'Syscalls' to the ApplicationProfileContainer struct in both 'types.go' and 'v1beta1/types.go' files.
- Updates the conversion functions in 'zz_generated.conversion.go' to include the new 'Syscalls' field.
- Updates the deepcopy functions in 'zz_generated.deepcopy.go' to handle the new 'Syscalls' field.
- Updates the schema in 'zz_generated.openapi.go' to reflect the new 'Syscalls' field.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`pkg/apis/softwarecomposition/types.go`: Added 'Syscalls' field to the ApplicationProfileContainer struct.
`pkg/apis/softwarecomposition/v1beta1/types.go`: Added 'Syscalls' field to the ApplicationProfileContainer struct with json annotations.
`pkg/apis/softwarecomposition/v1beta1/zz_generated.conversion.go`: Updated conversion functions to include the new 'Syscalls' field in the ApplicationProfileContainer struct.
`pkg/apis/softwarecomposition/v1beta1/zz_generated.deepcopy.go`: Updated deepcopy functions to handle the new 'Syscalls' field in the ApplicationProfileContainer struct.
`pkg/apis/softwarecomposition/zz_generated.deepcopy.go`: Updated deepcopy functions to handle the new 'Syscalls' field in the ApplicationProfileContainer struct.
`pkg/generated/openapi/zz_generated.openapi.go`: Updated the schema to reflect the new 'Syscalls' field in the ApplicationProfileContainer struct.
</details>
