### PR TITLE
Add known servers

### DIFF
--- a/pkg/registry/file/generatednetworkpolicy.go
+++ b/pkg/registry/file/generatednetworkpolicy.go
@@ -72,8 +72,13 @@ func (s *GeneratedNetworkPolicyStorage) Get(ctx context.Context, key string, opt
 	if err := s.realStore.Get(ctx, key, opts, networkNeighborsObjPtr); err != nil {
 		return err
 	}
-	// TODO(DanielGrunberegerCA): get known servers
-	generatedNetworkPolicy, err := networkpolicy.GenerateNetworkPolicy(*networkNeighborsObjPtr, []softwarecomposition.KnownServer{}, metav1.Now())
+
+	knownServersListObjPtr := &softwarecomposition.KnownServerList{}
+	if err := s.realStore.GetByCluster(ctx, softwarecomposition.GroupName, "knownservers", knownServersListObjPtr); err != nil {
+		return err
+	}
+
+	generatedNetworkPolicy, err := networkpolicy.GenerateNetworkPolicy(*networkNeighborsObjPtr, knownServersListObjPtr.Items, metav1.Now())
 	if err != nil {
 		return fmt.Errorf("error generating network policy: %w", err)
 	}
@@ -109,8 +114,13 @@ func (s *GeneratedNetworkPolicyStorage) GetList(ctx context.Context, key string,
 		return err
 	}
 
+	knownServersListObjPtr := &softwarecomposition.KnownServerList{}
+	if err := s.realStore.GetByCluster(ctx, softwarecomposition.GroupName, "knownservers", knownServersListObjPtr); err != nil {
+		return err
+	}
+
 	for _, networkNeighbors := range networkNeighborsObjListPtr.Items {
-		generatedNetworkPolicy, err := networkpolicy.GenerateNetworkPolicy(networkNeighbors, []softwarecomposition.KnownServer{}, metav1.Now())
+		generatedNetworkPolicy, err := networkpolicy.GenerateNetworkPolicy(networkNeighbors, knownServersListObjPtr.Items, metav1.Now())
 		if err != nil {
 			return fmt.Errorf("error generating network policy: %w", err)
 		}

--- a/pkg/registry/file/generatednetworkpolicy.go
+++ b/pkg/registry/file/generatednetworkpolicy.go
@@ -19,6 +19,7 @@ import (
 
 const (
 	networkNeighborsResource = "networkneighborses"
+	knownServersResource     = "knownservers"
 )
 
 // GeneratedNetworkPolicyStorage offers a storage solution for GeneratedNetworkPolicy objects, implementing custom business logic for these objects and using the underlying default storage implementation.
@@ -74,7 +75,8 @@ func (s *GeneratedNetworkPolicyStorage) Get(ctx context.Context, key string, opt
 	}
 
 	knownServersListObjPtr := &softwarecomposition.KnownServerList{}
-	if err := s.realStore.GetByCluster(ctx, softwarecomposition.GroupName, "knownservers", knownServersListObjPtr); err != nil {
+
+	if err := s.realStore.GetClusterScopedResource(ctx, softwarecomposition.GroupName, knownServersResource, knownServersListObjPtr); err != nil {
 		return err
 	}
 
@@ -115,7 +117,7 @@ func (s *GeneratedNetworkPolicyStorage) GetList(ctx context.Context, key string,
 	}
 
 	knownServersListObjPtr := &softwarecomposition.KnownServerList{}
-	if err := s.realStore.GetByCluster(ctx, softwarecomposition.GroupName, "knownservers", knownServersListObjPtr); err != nil {
+	if err := s.realStore.GetClusterScopedResource(ctx, softwarecomposition.GroupName, knownServersResource, knownServersListObjPtr); err != nil {
 		return err
 	}
 

--- a/pkg/registry/file/storage.go
+++ b/pkg/registry/file/storage.go
@@ -612,7 +612,6 @@ func (s *StorageImpl) GetClusterScopedResource(ctx context.Context, apiVersion, 
 	defer s.lock.RUnlock()
 	spanLock.End()
 
-	// for each namespace, read all json files and append it to list obj
 	_ = afero.Walk(s.appFs, p, func(path string, info os.FileInfo, err error) error {
 		// the first path is the root path
 		if path == p {


### PR DESCRIPTION
## Type
Enhancement

___
## Description
This PR enhances the functionality of the application by implementing the retrieval of known servers from storage. The changes include:
- Addition of a new constant `knownServersResource` in the `generatednetworkpolicy.go` file.
- Modification of the `Get` and `GetList` methods in the `generatednetworkpolicy.go` file to fetch known servers from the real store and use them in generating network policies.
- Addition of a new method `GetClusterScopedResource` in the `storage.go` file to fetch all objects in a given cluster, given their API version and kind.

___
## PR changes walkthrough
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>generatednetworkpolicy.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        pkg/registry/file/generatednetworkpolicy.go<br><br>
        <strong>The `Get` and `GetList` methods were modified to fetch known <br>servers from the real store and use them in generating <br>network policies. A new constant `knownServersResource` was <br>also added.</strong>
      </ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/storage/pull/72/files#diff-cc59b2b4cd6f5550d4bc197bd34324ca62c6ba5ccbe478f30fe3539c96dd98c2"> +15/-3</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>storage.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        pkg/registry/file/storage.go<br><br>
        <strong>A new method `GetClusterScopedResource` was added to fetch <br>all objects in a given cluster, given their API version and <br>kind.</strong>
      </ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/storage/pull/72/files#diff-c1f824146dbd5c96b0a182e5ff4056cc88592afb5904c19a2b5399f2d94a8812"> +48/-0</a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table>
___
## User description
retrieve known servers from real storage
