### PR TITLE
Update networkpolicy.go

### DIFF
--- a/pkg/apis/softwarecomposition/networkpolicy/networkpolicy.go
+++ b/pkg/apis/softwarecomposition/networkpolicy/networkpolicy.go
@@ -66,7 +66,7 @@ func GenerateNetworkPolicy(networkNeighbors softwarecomposition.NetworkNeighbors
 	}
 
 	for _, neighborIngress := range networkNeighbors.Spec.Ingress {
-		wg.add(1)
+		wg.Add(1)
 		go func(neighborIngress softwarecomposition.NetworkNeighbor){
 			defer wg.Done()
 			
@@ -79,7 +79,7 @@ func GenerateNetworkPolicy(networkNeighbors softwarecomposition.NetworkNeighbors
 	}
 
 	for _, neighborEgress := range networkNeighbors.Spec.Egress {
-		wg.add(1)
+		wg.Add(1)
 		go func(neighborEgress softwarecomposition.NetworkNeighbor){
 			defer wg.Done()
 			


### PR DESCRIPTION
## Type
Enhancement


___

## Description
This PR introduces concurrency to the `GenerateNetworkPolicy` function in the `networkpolicy.go` file. The main changes include:
- The `sync` package has been imported to manage goroutines using `sync.WaitGroup`.
- The `GenerateNetworkPolicy` function has been modified to generate ingress and egress rules concurrently for each neighbor using goroutines.
- `wg.add(1)` is used to add a count to the WaitGroup before each goroutine is launched, and `wg.Done()` is used to signal the end of a goroutine's execution.
- `wg.wait()` is used to block until all goroutines have completed.


___

## PR changes walkthrough
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Concurrency</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>networkpolicy.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        pkg/apis/softwarecomposition/networkpolicy/networkpolicy.go<br><br>

**The `networkpolicy.go` file has been updated to introduce <br>concurrency in the `GenerateNetworkPolicy` function. The <br>changes include:
- Importing the `sync` package to use <br>`sync.WaitGroup` for managing goroutines.
- Modifying the <br>`GenerateNetworkPolicy` function to generate ingress and <br>egress rules concurrently for each neighbor using <br>goroutines.
- Using `wg.add(1)` to add a count to the <br>WaitGroup before each goroutine is launched, and `wg.Done()` <br>to signal the end of a goroutine's execution.
- Using <br>`wg.wait()` to block until all goroutines have completed.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/storage/pull/79/files#diff-809c6f4fab5bb1fdc67381838604e585e6606db3b20218e206401890b10d81f2"> +22/-12</a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

## User description
## Type
enhancement


___

## Description
This PR introduces concurrency to the `GenerateNetworkPolicy` function in the `networkpolicy.go` file. The changes include:
- Importing the `sync` package to use `sync.WaitGroup` for managing goroutines.
- Modifying the `GenerateNetworkPolicy` function to generate ingress and egress rules concurrently for each neighbor using goroutines.
- Using `wg.add(1)` to add a count to the WaitGroup before each goroutine is launched, and `wg.Done()` to signal the end of a goroutine's execution.
- Using `wg.wait()` to block until all goroutines have completed.


___

## PR changes walkthrough
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Concurrency</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>networkpolicy.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        pkg/apis/softwarecomposition/networkpolicy/networkpolicy.go<br><br>

**The changes in this file include the addition of a <br>`sync.WaitGroup` variable, `wg`, to handle concurrent <br>execution of generating ingress and egress rules. The <br>`GenerateNetworkPolicy` function has been modified to use <br>goroutines for generating ingress and egress rules for each <br>neighbor, thus improving the performance by parallelizing <br>the process. The `wg.wait()` function is used to ensure all <br>goroutines have completed before proceeding.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/storage/pull/79/files#diff-809c6f4fab5bb1fdc67381838604e585e6606db3b20218e206401890b10d81f2"> +22/-12</a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

## User description
Sorry, we do not accept changes directly against this repository. Please see
CONTRIBUTING.md for information on where and how to contribute instead.
