### PR TITLE
fix cleanup of resources

### DIFF
--- a/main.go
+++ b/main.go
@@ -59,10 +59,16 @@ func main() {
 	if err != nil {
 		panic(err.Error())
 	}
+	interval := os.Getenv("CLEANUP_INTERVAL")
+	intervalDuration, err := time.ParseDuration(interval)
+	if err != nil {
+		intervalDuration = time.Hour * 24
+		logger.L().Info("failed to parse cleanup interval, falling back to default", helpers.Error(err), helpers.String("interval", intervalDuration.String()))
+	}
 	cleanupHandler := cleanup.NewResourcesCleanupHandler(
 		afero.NewOsFs(),
 		file.DefaultStorageRoot,
-		time.Hour*24,
+		intervalDuration,
 		kubernetesAPI)
 	go cleanupHandler.StartCleanupTask()
 

--- a/pkg/cleanup/cleanup.go
+++ b/pkg/cleanup/cleanup.go
@@ -23,8 +23,8 @@ import (
 type TypeCleanupHandlerFunc func(kind, path string, metadata *metav1.ObjectMeta, resourceMaps ResourceMaps) bool
 
 var resourceKindToHandler = map[string]TypeCleanupHandlerFunc{
-	// vulnerabilitysummaries is virtual
 	// configurationscansummaries is virtual
+	// vulnerabilitysummaries is virtual
 	"applicationactivities":               deleteByTemplateHashOrWlid,
 	"applicationprofiles":                 deleteByTemplateHashOrWlid,
 	"applicationprofilesummaries":         deleteByTemplateHashOrWlid,
@@ -65,7 +65,7 @@ func (h *ResourcesCleanupHandler) GetFilesToDelete() []string {
 
 func (h *ResourcesCleanupHandler) StartCleanupTask() {
 	for {
-		logger.L().Info("started cleanup task")
+		logger.L().Info("started cleanup task", helpers.String("interval", h.interval.String()))
 		h.filesToDelete = []string{}
 		var err error
 		h.resources, err = h.fetcher.FetchResources()
@@ -99,7 +99,7 @@ func (h *ResourcesCleanupHandler) StartCleanupTask() {
 
 				toDelete := handler(resourceKind, path, metadata, h.resources)
 				if toDelete {
-					logger.L().Info("deleting", helpers.String("kind", resourceKind), helpers.String("namespace", metadata.Namespace), helpers.String("name", metadata.Name))
+					logger.L().Debug("deleting", helpers.String("kind", resourceKind), helpers.String("namespace", metadata.Namespace), helpers.String("name", metadata.Name))
 					h.filesToDelete = append(h.filesToDelete, path)
 
 					jsonFilePath := path[:len(path)-len(file.MetadataExt)] + file.JsonExt
@@ -135,6 +135,7 @@ func loadMetadataFromPath(appFs afero.Fs, rootPath string) (*metav1.ObjectMeta, 
 	}
 	data := metav1.ObjectMeta{
 		Annotations: map[string]string{},
+		Labels:      map[string]string{},
 	}
 	// ujson parsing
 	var parent string
@@ -155,6 +156,10 @@ func loadMetadataFromPath(appFs afero.Fs, rootPath string) (*metav1.ObjectMeta, 
 			// read annotations
 			if parent == "annotations" {
 				data.Annotations[unquote(key)] = unquote(value)
+			}
+			// read labels
+			if parent == "labels" {
+				data.Labels[unquote(key)] = unquote(value)
 			}
 		}
 		return true
@@ -214,12 +219,10 @@ func deleteByWlidAndContainer(_, _ string, metadata *metav1.ObjectMeta, resource
 }
 
 func deleteByTemplateHashOrWlid(_, _ string, metadata *metav1.ObjectMeta, resourceMaps ResourceMaps) bool {
-	wlReplica, wlReplicaFound := metadata.Annotations[instanceidhandler.TemplateHashKey] // replica
+	wlReplica, wlReplicaFound := metadata.Labels[instanceidhandler.TemplateHashKey] // replica
 	if wlReplicaFound && wlReplica != "" {
 		return !resourceMaps.RunningTemplateHash.Contains(wlReplica)
 	}
-
 	// fallback to wlid
 	return deleteByWlid("", "", metadata, resourceMaps)
-
 }

--- a/pkg/cleanup/cleanup.go
+++ b/pkg/cleanup/cleanup.go
@@ -32,6 +32,8 @@ var resourceKindToHandler = map[string]TypeCleanupHandlerFunc{
 	"openvulnerabilityexchangecontainers": deleteByImageId,
 	"sbomspdxv2p3filtereds":               deleteByInstanceId,
 	"sbomspdxv2p3s":                       deleteByImageId,
+	"sbomsyftfiltereds":                   deleteByInstanceId,
+	"sbomsyfts":                           deleteByImageId,
 	"sbomsummaries":                       deleteByImageId,
 	"vulnerabilitymanifests":              deleteByImageIdOrInstanceId,
 	"vulnerabilitymanifestsummaries":      deleteByWlidAndContainer,


### PR DESCRIPTION
## Type
bug_fix, enhancement


___

## Description
- The cleanup interval for resources is now configurable through an environment variable. If the environment variable is not set or cannot be parsed, a default value of 24 hours is used.
- The cleanup handler's logging has been improved to include the cleanup interval when a cleanup task starts and to log deletions at the debug level.
- The metadata loading function has been updated to also load labels from the metadata file.
- The function to delete resources by template hash or wlid has been updated to look for the template hash in the labels instead of the annotations.
- The list of workloads to cleanup has been reduced to only include cronjob, daemonset, deployment, job, pod, replicaset, and statefulset.


___

## PR changes walkthrough
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>main.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        main.go<br><br>

**The cleanup interval for resources is now configurable <br>through an environment variable. If the environment variable <br>is not set or cannot be parsed, a default value of 24 hours <br>is used. The cleanup handler is updated to use the new <br>configurable interval.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/storage/pull/81/files#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261"> +7/-1</a></td>

</tr>                    
</table></details></td></tr><tr><td><strong>Bug_fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>cleanup.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        pkg/cleanup/cleanup.go<br><br>

**The cleanup handler's logging has been improved to include <br>the cleanup interval when a cleanup task starts and to log <br>deletions at the debug level. The metadata loading function <br>has been updated to also load labels from the metadata file. <br>The function to delete resources by template hash or wlid <br>has been updated to look for the template hash in the labels <br>instead of the annotations. Some unused code has been <br>removed.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/storage/pull/81/files#diff-08b3213f3305de63e9800577122808ae40047fe97028717f5f646ba20a7add9d"> +9/-6</a></td>

</tr>                    
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>discovery.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        pkg/cleanup/discovery.go<br><br>

**The list of workloads to cleanup has been reduced to only <br>include cronjob, daemonset, deployment, job, pod, <br>replicaset, and statefulset. The functions to fetch wlids <br>from running workloads and to fetch instance IDs and image <br>IDs and replicas from running pods have been updated to <br>improve logging and remove unused code.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/storage/pull/81/files#diff-9118a5aa68f59e96c154684eda47af121f71f384fb00b10027c1246b3ecf22b1"> +5/-20</a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table>