### PR TITLE
Move NP generate to v1beta1

### DIFF
--- a/pkg/apis/softwarecomposition/v1beta1/network_types.go
+++ b/pkg/apis/softwarecomposition/v1beta1/network_types.go
@@ -85,7 +85,7 @@ type GeneratedNetworkPolicy struct {
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	Spec        NetworkPolicy `json:"spec"`
-	PoliciesRef []PolicyRef   `json:"policyRef"`
+	PoliciesRef []PolicyRef   `json:"policyRef,omitempty"`
 }
 
 type PolicyRef struct {

--- a/pkg/apis/softwarecomposition/v1beta1/networkpolicy/networkpolicy.go
+++ b/pkg/apis/softwarecomposition/v1beta1/networkpolicy/networkpolicy.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
-	"github.com/kubescape/storage/pkg/apis/softwarecomposition"
+	softwarecomposition "github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
 	"golang.org/x/exp/maps"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/apis/softwarecomposition/v1beta1/networkpolicy/networkpolicy_test.go
+++ b/pkg/apis/softwarecomposition/v1beta1/networkpolicy/networkpolicy_test.go
@@ -3,7 +3,7 @@ package networkpolicy
 import (
 	"testing"
 
-	"github.com/kubescape/storage/pkg/apis/softwarecomposition"
+	softwarecomposition "github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/apis/softwarecomposition/v1beta1/types.go
+++ b/pkg/apis/softwarecomposition/v1beta1/types.go
@@ -179,7 +179,7 @@ type VulnerabilityManifestList struct {
 // Intended to store relevant and total vulnerabilities in the future.
 type VulnerabilityCounters struct {
 	All      int `json:"all"`
-	Relevant int `json:"relevant"`
+	Relevant int `json:"relevant,omitempty"`
 }
 
 // SeveritySummary is a summary of all vulnerabilities included in vulnerability manifest
@@ -200,7 +200,7 @@ type VulnerabilitiesObjScope struct {
 
 type VulnerabilitiesComponents struct {
 	ImageVulnerabilitiesObj    VulnerabilitiesObjScope `json:"all"`
-	WorkloadVulnerabilitiesObj VulnerabilitiesObjScope `json:"relevant"`
+	WorkloadVulnerabilitiesObj VulnerabilitiesObjScope `json:"relevant,omitempty"`
 }
 
 type VulnerabilityManifestSummarySpec struct {

--- a/pkg/registry/file/generatednetworkpolicy.go
+++ b/pkg/registry/file/generatednetworkpolicy.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
-	"github.com/kubescape/storage/pkg/apis/softwarecomposition"
-	"github.com/kubescape/storage/pkg/apis/softwarecomposition/networkpolicy"
+	softwarecomposition "github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
+	networkpolicy "github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1/networkpolicy"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/registry/file/generatednetworkpolicy_test.go
+++ b/pkg/registry/file/generatednetworkpolicy_test.go
@@ -4,8 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/kubescape/storage/pkg/apis/softwarecomposition"
-	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
+	softwarecomposition "github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -37,22 +36,29 @@ func TestGeneratedNetworkPolicyStorage_Get(t *testing.T) {
 			name: "existing object is returned",
 			args: args{
 				key:    "/spdx.softwarecomposition.kubescape.io/generatednetworkpolicies/kubescape/toto",
-				objPtr: &v1beta1.GeneratedNetworkPolicy{},
+				objPtr: &softwarecomposition.GeneratedNetworkPolicy{},
 			},
 			expectedError: nil,
 			create:        true,
-			want: &v1beta1.GeneratedNetworkPolicy{
+			want: &softwarecomposition.GeneratedNetworkPolicy{
 				TypeMeta: v1.TypeMeta{
 					Kind:       "GeneratedNetworkPolicy",
 					APIVersion: "spdx.softwarecomposition.kubescape.io/v1beta1",
 				},
-				Spec: v1beta1.NetworkPolicy{
+				ObjectMeta: v1.ObjectMeta{
+					Name:              "toto",
+					Namespace:         "kubescape",
+					CreationTimestamp: v1.Time{},
+				},
+				Spec: softwarecomposition.NetworkPolicy{
 					Kind:       "NetworkPolicy",
 					APIVersion: "networking.k8s.io/v1",
 					ObjectMeta: v1.ObjectMeta{
 						Annotations: map[string]string{
 							"generated-by": "kubescape",
 						},
+						Name:      "toto",
+						Namespace: "kubescape",
 					},
 				},
 			},
@@ -65,7 +71,16 @@ func TestGeneratedNetworkPolicyStorage_Get(t *testing.T) {
 			generatedNetworkPolicyStorage := NewGeneratedNetworkPolicyStorage(&realStorage)
 
 			if tt.create {
-				wlObj := &softwarecomposition.NetworkNeighbors{}
+				wlObj := &softwarecomposition.NetworkNeighbors{
+					TypeMeta: v1.TypeMeta{
+						Kind:       "NetworkNeighbors",
+						APIVersion: "spdx.softwarecomposition.kubescape.io/v1beta1",
+					},
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "toto",
+						Namespace: "kubescape",
+					},
+				}
 				err := realStorage.Create(context.TODO(), "/spdx.softwarecomposition.kubescape.io/networkneighborses/kubescape/toto", wlObj, nil, 0)
 				assert.NoError(t, err)
 			}
@@ -74,6 +89,9 @@ func TestGeneratedNetworkPolicyStorage_Get(t *testing.T) {
 
 			if tt.expectedError != nil {
 				assert.EqualError(t, err, tt.expectedError.Error())
+			}
+			if tt.args.objPtr != nil {
+				tt.args.objPtr.(*softwarecomposition.GeneratedNetworkPolicy).CreationTimestamp = v1.Time{}
 			}
 
 			assert.Equal(t, tt.want, tt.args.objPtr)


### PR DESCRIPTION
## Type
enhancement, tests


___

## Description
This PR focuses on moving the Network Policy generation to the `v1beta1` version. The main changes include:
- Making certain fields optional in various structs by adding `omitempty` to their JSON tags. These fields include `PoliciesRef` in `GeneratedNetworkPolicy`, `Relevant` in `VulnerabilityCounters`, and `WorkloadVulnerabilitiesObj` in `VulnerabilitiesComponents`.
- Updating the import paths for `softwarecomposition` and `networkpolicy` in several files to point to the `v1beta1` version.
- Adjusting the test cases in `networkpolicy_test.go` and `generatednetworkpolicy_test.go` to reflect the updated import paths.


___

## PR changes walkthrough
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>network_types.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        pkg/apis/softwarecomposition/v1beta1/network_types.go<br><br>

**Made the `PoliciesRef` field in the `GeneratedNetworkPolicy` <br>struct optional by adding `omitempty` to its JSON tag.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/storage/pull/83/files#diff-311edac9310cf202a9b743e3027791daf988e9b9276a7fa67a91cab3ec67f176"> +1/-1</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>networkpolicy.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        pkg/apis/softwarecomposition/v1beta1/networkpolicy/networkpolicy.go<br><br>

**Updated the import path for `softwarecomposition` to point <br>to the `v1beta1` version.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/storage/pull/83/files#diff-75cb54bdd2a3a1918c9be4f9c365953380d2b329bb176f3caca9a3d640a99298"> +1/-1</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>types.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        pkg/apis/softwarecomposition/v1beta1/types.go<br><br>

**Made the `Relevant` field in the `VulnerabilityCounters` <br>struct and the `WorkloadVulnerabilitiesObj` field in the <br>`VulnerabilitiesComponents` struct optional by adding <br>`omitempty` to their JSON tags.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/storage/pull/83/files#diff-c5af80b7e6424e8b4a947dfd8a99a11c5374bc01d4874e3765fb25205fa42158"> +2/-2</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>generatednetworkpolicy.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        pkg/registry/file/generatednetworkpolicy.go<br><br>

**Updated the import paths for `softwarecomposition` and <br>`networkpolicy` to point to the `v1beta1` version.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/storage/pull/83/files#diff-cc59b2b4cd6f5550d4bc197bd34324ca62c6ba5ccbe478f30fe3539c96dd98c2"> +2/-2</a></td>

</tr>                    
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>networkpolicy_test.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        pkg/apis/softwarecomposition/v1beta1/networkpolicy/networkpolicy_test.go<br><br>

**Updated the import path for `softwarecomposition` in the <br>test file to point to the `v1beta1` version.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/storage/pull/83/files#diff-460886b2f266e9d0ca5a73910bd624cd670d91376ab9e50a349a41b04ea1522d"> +1/-1</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>generatednetworkpolicy_test.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        pkg/registry/file/generatednetworkpolicy_test.go<br><br>

**Updated the import path for `softwarecomposition` in the <br>test file to point to the `v1beta1` version. Also, made <br>changes in the test cases to reflect the updated import <br>paths.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/storage/pull/83/files#diff-dbbd2f0b484616879c8f25635b27794728b86aec9252beef361a20e91fc91c06"> +24/-6</a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

## User description
Sorry, we do not accept changes directly against this repository. Please see
CONTRIBUTING.md for information on where and how to contribute instead.
