### PR TITLE
fix generatednetworkpolicy generation

### DIFF
--- a/pkg/apis/softwarecomposition/v1beta1/networkpolicy/networkpolicy.go
+++ b/pkg/apis/softwarecomposition/v1beta1/networkpolicy/networkpolicy.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
-	softwarecomposition "github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
+	"github.com/kubescape/storage/pkg/apis/softwarecomposition"
 	"golang.org/x/exp/maps"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/apis/softwarecomposition/v1beta1/networkpolicy/networkpolicy_test.go
+++ b/pkg/apis/softwarecomposition/v1beta1/networkpolicy/networkpolicy_test.go
@@ -3,7 +3,7 @@ package networkpolicy
 import (
 	"testing"
 
-	softwarecomposition "github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
+	"github.com/kubescape/storage/pkg/apis/softwarecomposition"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/registry/file/generatednetworkpolicy.go
+++ b/pkg/registry/file/generatednetworkpolicy.go
@@ -7,8 +7,9 @@ import (
 
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
-	softwarecomposition "github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
-	networkpolicy "github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1/networkpolicy"
+	"github.com/kubescape/storage/pkg/apis/softwarecomposition"
+	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
+	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1/networkpolicy"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -55,6 +56,14 @@ func (s *GeneratedNetworkPolicyStorage) Delete(ctx context.Context, key string, 
 // Watch is not supported for GeneratedNetworkPolicy objects. Objects are generated on the fly and not stored.
 func (s *GeneratedNetworkPolicyStorage) Watch(ctx context.Context, key string, _ storage.ListOptions) (watch.Interface, error) {
 	return nil, storage.NewInvalidObjError(key, operationNotSupportedMsg)
+}
+
+func (s *GeneratedNetworkPolicyStorage) GetV1beta1(ctx context.Context, key string, opts storage.GetOptions, objPtr *v1beta1.GeneratedNetworkPolicy) error {
+	softwarecompositionObjPtr := &softwarecomposition.GeneratedNetworkPolicy{}
+	if err := s.Get(ctx, key, opts, softwarecompositionObjPtr); err != nil {
+		return err
+	}
+	return v1beta1.Convert_softwarecomposition_GeneratedNetworkPolicy_To_v1beta1_GeneratedNetworkPolicy(softwarecompositionObjPtr, objPtr, nil)
 }
 
 // Get generates and returns a single GeneratedNetworkPolicy object


### PR DESCRIPTION
## **Type**
Bug fix


___

## **Description**
This PR primarily focuses on updating the import paths for `softwarecomposition` and `networkpolicy` across multiple files. The `v1beta1` version specification has been removed from the import paths. Additionally, a new field `PoliciesRef` has been added to the test data in `pkg/registry/file/generatednetworkpolicy_test.go`.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>networkpolicy.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        pkg/apis/softwarecomposition/v1beta1/networkpolicy/networkpolicy.go<br><br>

**The import path for `softwarecomposition` has been updated <br>to remove the `v1beta1` version specification.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/storage/pull/85/files#diff-75cb54bdd2a3a1918c9be4f9c365953380d2b329bb176f3caca9a3d640a99298"> +1/-1</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>networkpolicy_test.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        pkg/apis/softwarecomposition/v1beta1/networkpolicy/networkpolicy_test.go<br><br>

**The import path for `softwarecomposition` has been updated <br>to remove the `v1beta1` version specification.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/storage/pull/85/files#diff-460886b2f266e9d0ca5a73910bd624cd670d91376ab9e50a349a41b04ea1522d"> +1/-1</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>generatednetworkpolicy.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        pkg/registry/file/generatednetworkpolicy.go<br><br>

**The import paths for `softwarecomposition` and <br>`networkpolicy` have been updated to remove the `v1beta1` <br>version specification.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/storage/pull/85/files#diff-cc59b2b4cd6f5550d4bc197bd34324ca62c6ba5ccbe478f30fe3539c96dd98c2"> +2/-2</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>generatednetworkpolicy_test.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        pkg/registry/file/generatednetworkpolicy_test.go<br><br>

**The import path for `softwarecomposition` has been updated <br>to remove the `v1beta1` version specification. Also, a new <br>field `PoliciesRef` has been added to the test data.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/storage/pull/85/files#diff-dbbd2f0b484616879c8f25635b27794728b86aec9252beef361a20e91fc91c06"> +2/-1</a></td>

</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
