### PR TITLE
only return metadata inside watch events

### DIFF
--- a/pkg/registry/file/storage_test.go
+++ b/pkg/registry/file/storage_test.go
@@ -232,7 +232,7 @@ func TestStorageImpl_Delete(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			fs := afero.NewMemMapFs()
 			if tt.create {
-				fpath := getStoredPayloadFilepath(DefaultStorageRoot, tt.args.key)
+				fpath := getStoredMetadataFilepath(DefaultStorageRoot, tt.args.key)
 				_ = afero.WriteFile(fs, fpath, []byte(tt.content), 0644)
 			}
 			s := NewStorageImpl(fs, DefaultStorageRoot)
@@ -519,7 +519,6 @@ func TestStorageImpl_GuaranteedUpdate(t *testing.T) {
 				}
 				return
 			} else {
-				assert.Equal(t, tt.want, destination)
 				onDisk := &v1beta1.SBOMSPDXv2p3{}
 				err = s.Get(context.Background(), tt.args.key, storage.GetOptions{}, onDisk)
 				assert.NoError(t, err)

--- a/pkg/registry/file/watch_test.go
+++ b/pkg/registry/file/watch_test.go
@@ -125,7 +125,8 @@ func TestFilesystemStoragePublishesToMatchingWatch(t *testing.T) {
 						Type: watch.Added,
 						Object: &v1beta1.SBOMSPDXv2p3{
 							ObjectMeta: v1.ObjectMeta{
-								Name: "some-sbom",
+								Name:            "some-sbom",
+								ResourceVersion: "1",
 							},
 						},
 					},
@@ -150,7 +151,8 @@ func TestFilesystemStoragePublishesToMatchingWatch(t *testing.T) {
 						Type: watch.Added,
 						Object: &v1beta1.SBOMSPDXv2p3{
 							ObjectMeta: v1.ObjectMeta{
-								Name: "some-sbom",
+								Name:            "some-sbom",
+								ResourceVersion: "1",
 							},
 						},
 					},
@@ -158,7 +160,8 @@ func TestFilesystemStoragePublishesToMatchingWatch(t *testing.T) {
 						Type: watch.Added,
 						Object: &v1beta1.SBOMSPDXv2p3{
 							ObjectMeta: v1.ObjectMeta{
-								Name: "some-sbom",
+								Name:            "some-sbom",
+								ResourceVersion: "1",
 							},
 						},
 					},
@@ -166,7 +169,8 @@ func TestFilesystemStoragePublishesToMatchingWatch(t *testing.T) {
 						Type: watch.Added,
 						Object: &v1beta1.SBOMSPDXv2p3{
 							ObjectMeta: v1.ObjectMeta{
-								Name: "some-sbom",
+								Name:            "some-sbom",
+								ResourceVersion: "1",
 							},
 						},
 					},
@@ -192,7 +196,8 @@ func TestFilesystemStoragePublishesToMatchingWatch(t *testing.T) {
 						Type: watch.Added,
 						Object: &v1beta1.SBOMSPDXv2p3{
 							ObjectMeta: v1.ObjectMeta{
-								Name: "some-sbom",
+								Name:            "some-sbom",
+								ResourceVersion: "1",
 							},
 						},
 					},
@@ -235,7 +240,7 @@ func TestFilesystemStoragePublishesToMatchingWatch(t *testing.T) {
 			}
 
 			var ttl uint64 = 0
-			var out runtime.Object
+			out := &v1beta1.SBOMSPDXv2p3{}
 			for key, object := range tc.inputObjects {
 				_ = s.Create(ctx, key, object, out, ttl)
 			}
@@ -289,7 +294,8 @@ func TestFilesystemStorageWatchStop(t *testing.T) {
 						Type: watch.Added,
 						Object: &v1beta1.SBOMSPDXv2p3{
 							ObjectMeta: v1.ObjectMeta{
-								Name: "some-sbom",
+								Name:            "some-sbom",
+								ResourceVersion: "1",
 							},
 						},
 					},
@@ -297,7 +303,8 @@ func TestFilesystemStorageWatchStop(t *testing.T) {
 						Type: watch.Added,
 						Object: &v1beta1.SBOMSPDXv2p3{
 							ObjectMeta: v1.ObjectMeta{
-								Name: "some-sbom",
+								Name:            "some-sbom",
+								ResourceVersion: "1",
 							},
 						},
 					},
@@ -331,7 +338,7 @@ func TestFilesystemStorageWatchStop(t *testing.T) {
 
 			// Act out the creation operation
 			var ttl uint64 = 0
-			var out runtime.Object
+			out := &v1beta1.SBOMSPDXv2p3{}
 			for key, object := range tc.inputObjects {
 				_ = s.Create(ctx, key, object, out, ttl)
 			}
@@ -363,14 +370,8 @@ func TestFilesystemStorageWatchStop(t *testing.T) {
 func TestWatchGuaranteedUpdateProducesMatchingEvents(t *testing.T) {
 	toto := &v1beta1.SBOMSPDXv2p3{
 		ObjectMeta: v1.ObjectMeta{
-			Name: "toto",
-		},
-		Spec: v1beta1.SBOMSPDXv2p3Spec{
-			Metadata: v1beta1.SPDXMeta{
-				Tool: v1beta1.ToolMeta{
-					Name: "titi",
-				},
-			},
+			Name:            "toto",
+			ResourceVersion: "1",
 		},
 	}
 


### PR DESCRIPTION
## **Type**
Enhancement


___

## **Description**
This PR introduces changes to the way metadata is handled within the `pkg/registry/file/storage.go` file. The main changes include:
- Replacing the `out` parameter with `metaOut` in several functions to store only metadata instead of the entire object.
- Updating the `watchDispatcher` calls to use `metaOut` instead of `obj` or `out`.
- Modifying the `writeFiles`, `Create`, `Delete`, and `GuaranteedUpdate` functions to accommodate the above changes.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>storage.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        pkg/registry/file/storage.go<br><br>

**The changes in this file are primarily focused on modifying <br>the way metadata is handled within various functions. The <br>`out` parameter, which was previously used to store the <br>output of certain operations, has been replaced with <br>`metaOut`. This new parameter is used to store only <br>metadata, rather than the entire object. This change is <br>reflected in the `writeFiles`, `Create`, `Delete`, and <br>`GuaranteedUpdate` functions. Additionally, the <br>`watchDispatcher` calls have been updated to use `metaOut` <br>instead of `obj` or `out`.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/storage/pull/87/files#diff-c1f824146dbd5c96b0a182e5ff4056cc88592afb5904c19a2b5399f2d94a8812"> +17/-17</a></td>

</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
