### PR TITLE
Remove labels

### DIFF
--- a/pkg/apis/softwarecomposition/networkpolicy/labels.go
+++ b/pkg/apis/softwarecomposition/networkpolicy/labels.go
@@ -1,25 +1,10 @@
 package networkpolicy
 
-import "sync"
-
-type syncMap struct {
-	mut sync.RWMutex
-	m   map[string]bool
-}
-
-var ignoreLabels syncMap
+var ignoreLabels map[string]bool
 
 func init() {
-	ignoreLabels.mut.RLock()
-	if len(ignoreLabels.m) > 0 {
-		ignoreLabels.mut.RUnlock()
-		return
-	}
-	ignoreLabels.mut.RUnlock()
 
-	ignoreLabels.mut.Lock()
-	defer ignoreLabels.mut.Unlock()
-	ignoreLabels.m = map[string]bool{
+	ignoreLabels = map[string]bool{
 		"app.kubernetes.io/name":                      false,
 		"app.kubernetes.io/part-of":                   false,
 		"app.kubernetes.io/component":                 false,
@@ -40,7 +25,5 @@ func init() {
 
 // IsIgnoredLabel returns true if the label is ignored
 func isIgnoredLabel(label string) bool {
-	ignoreLabels.mut.RLock()
-	defer ignoreLabels.mut.RUnlock()
-	return ignoreLabels.m[label]
+	return ignoreLabels[label]
 }

--- a/pkg/apis/softwarecomposition/networkpolicy/labels.go
+++ b/pkg/apis/softwarecomposition/networkpolicy/labels.go
@@ -1,0 +1,46 @@
+package networkpolicy
+
+import "sync"
+
+type syncMap struct {
+	mut sync.RWMutex
+	m   map[string]bool
+}
+
+var ignoreLabels syncMap
+
+func init() {
+	ignoreLabels.mut.RLock()
+	if len(ignoreLabels.m) > 0 {
+		ignoreLabels.mut.RUnlock()
+		return
+	}
+	ignoreLabels.mut.RUnlock()
+
+	ignoreLabels.mut.Lock()
+	defer ignoreLabels.mut.Unlock()
+	ignoreLabels.m = map[string]bool{
+		"app.kubernetes.io/name":                      false,
+		"app.kubernetes.io/part-of":                   false,
+		"app.kubernetes.io/component":                 false,
+		"app.kubernetes.io/instance":                  true,
+		"app.kubernetes.io/version":                   true,
+		"app.kubernetes.io/managed-by":                true,
+		"app.kubernetes.io/created-by":                true,
+		"app.kubernetes.io/owner":                     true,
+		"app.kubernetes.io/revision":                  true,
+		"statefulset.kubernetes.io/pod-name":          true,
+		"scheduler.alpha.kubernetes.io/node-selector": true,
+		"pod-template-hash":                           true,
+		"controller-revision-hash":                    true,
+		"pod-template-generation":                     true,
+		"helm.sh/chart":                               true,
+	}
+}
+
+// IsIgnoredLabel returns true if the label is ignored
+func isIgnoredLabel(label string) bool {
+	ignoreLabels.mut.RLock()
+	defer ignoreLabels.mut.RUnlock()
+	return ignoreLabels.m[label]
+}

--- a/pkg/apis/softwarecomposition/networkpolicy/networkpolicy.go
+++ b/pkg/apis/softwarecomposition/networkpolicy/networkpolicy.go
@@ -258,6 +258,7 @@ func generateEgressRule(neighbor softwarecomposition.NetworkNeighbor, KnownServe
 	policyRefs := []softwarecomposition.PolicyRef{}
 
 	if neighbor.PodSelector != nil {
+		removeLabels(neighbor.PodSelector.MatchLabels)
 		egressRule.To = append(egressRule.To, softwarecomposition.NetworkPolicyPeer{
 			PodSelector: neighbor.PodSelector,
 		})
@@ -348,11 +349,13 @@ func hash(s any) (string, error) {
 	vv := sha256.Sum256(b.Bytes())
 	return hex.EncodeToString(vv[:]), nil
 }
+
 func generateIngressRule(neighbor softwarecomposition.NetworkNeighbor, KnownServer []softwarecomposition.KnownServer) (softwarecomposition.NetworkPolicyIngressRule, []softwarecomposition.PolicyRef) {
 	ingressRule := softwarecomposition.NetworkPolicyIngressRule{}
 	policyRefs := []softwarecomposition.PolicyRef{}
 
 	if neighbor.PodSelector != nil {
+		removeLabels(neighbor.PodSelector.MatchLabels)
 		ingressRule.From = append(ingressRule.From, softwarecomposition.NetworkPolicyPeer{
 			PodSelector: neighbor.PodSelector,
 		})
@@ -436,4 +439,12 @@ func generateIngressRule(neighbor softwarecomposition.NetworkNeighbor, KnownServ
 func getSingleIP(ipAddress string) *softwarecomposition.IPBlock {
 	ipBlock := &softwarecomposition.IPBlock{CIDR: ipAddress + "/32"}
 	return ipBlock
+}
+
+func removeLabels(labels map[string]string) {
+	for key := range labels {
+		if isIgnoredLabel(key) {
+			delete(labels, key)
+		}
+	}
 }

--- a/pkg/apis/softwarecomposition/networkpolicy/networkpolicy_test.go
+++ b/pkg/apis/softwarecomposition/networkpolicy/networkpolicy_test.go
@@ -36,7 +36,9 @@ func TestGenerateNetworkPolicy(t *testing.T) {
 						{
 							PodSelector: &metav1.LabelSelector{
 								MatchLabels: map[string]string{
-									"one": "1",
+									"one":                        "1",
+									"app.kubernetes.io/name":     "nginx",
+									"app.kubernetes.io/revision": "1",
 								},
 							},
 							Ports: []softwarecomposition.NetworkPort{
@@ -50,7 +52,9 @@ func TestGenerateNetworkPolicy(t *testing.T) {
 						{
 							PodSelector: &metav1.LabelSelector{
 								MatchLabels: map[string]string{
-									"two": "2",
+									"two":                        "2",
+									"app.kubernetes.io/name":     "nginx",
+									"app.kubernetes.io/revision": "1",
 								},
 							},
 							Ports: []softwarecomposition.NetworkPort{
@@ -106,7 +110,8 @@ func TestGenerateNetworkPolicy(t *testing.T) {
 									{
 										PodSelector: &metav1.LabelSelector{
 											MatchLabels: map[string]string{
-												"one": "1",
+												"one":                    "1",
+												"app.kubernetes.io/name": "nginx",
 											},
 										},
 									},
@@ -123,7 +128,8 @@ func TestGenerateNetworkPolicy(t *testing.T) {
 									{
 										PodSelector: &metav1.LabelSelector{
 											MatchLabels: map[string]string{
-												"two": "2",
+												"two":                    "2",
+												"app.kubernetes.io/name": "nginx",
 											},
 										},
 									},


### PR DESCRIPTION
## **User description**
Sorry, we do not accept changes directly against this repository. Please see
CONTRIBUTING.md for information on where and how to contribute instead.


___

## **Type**
Enhancement


___

## **Description**
- Added a new file `labels.go` that contains a map of labels that should be ignored and a function to check if a label is in the ignore list.
- Modified the `networkpolicy.go` file to include a call to the `removeLabels` function, which removes ignored labels from the `PodSelector` in both `generateEgressRule` and `generateIngressRule` functions. The `removeLabels` function was also added, which removes labels from a given map if they are in the ignore list.
- Updated the `networkpolicy_test.go` file to include ignored labels in the test cases for the `TestGenerateNetworkPolicy` function.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>labels.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        pkg/apis/softwarecomposition/networkpolicy/labels.go<br><br>

**This file was added to the project. It contains a map of <br>labels that should be ignored and a function <br>`isIgnoredLabel` to check if a label is in the ignore list.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/storage/pull/88/files#diff-734384474602a5f61594d167faddd070ea7f4d5414bf49992981203132bf8ee7"> +29/-0</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>networkpolicy.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        pkg/apis/softwarecomposition/networkpolicy/networkpolicy.go<br><br>

**This file was modified to include a call to the <br>`removeLabels` function, which removes ignored labels from <br>the `PodSelector` in both `generateEgressRule` and <br>`generateIngressRule` functions. The `removeLabels` function <br>was also added, which removes labels from a given map if <br>they are in the ignore list.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/storage/pull/88/files#diff-809c6f4fab5bb1fdc67381838604e585e6606db3b20218e206401890b10d81f2"> +11/-0</a></td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>networkpolicy_test.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        pkg/apis/softwarecomposition/networkpolicy/networkpolicy_test.go<br><br>

**This file was modified to include ignored labels in the test <br>cases for the `TestGenerateNetworkPolicy` function.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/storage/pull/88/files#diff-11d06c13c542ac114b3c0e676d035e563bd6d5c6bb4e4410c11afdd3c467b464"> +10/-4</a></td>

</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
