### PR TITLE
support ephemeral containers

### DIFF
--- a/pkg/apis/softwarecomposition/types.go
+++ b/pkg/apis/softwarecomposition/types.go
@@ -268,8 +268,9 @@ type ApplicationProfile struct {
 }
 
 type ApplicationProfileSpec struct {
-	Containers     []ApplicationProfileContainer
-	InitContainers []ApplicationProfileContainer
+	Containers          []ApplicationProfileContainer
+	InitContainers      []ApplicationProfileContainer
+	EphemeralContainers []ApplicationProfileContainer
 }
 
 type ApplicationProfileContainer struct {

--- a/pkg/apis/softwarecomposition/v1beta1/types.go
+++ b/pkg/apis/softwarecomposition/v1beta1/types.go
@@ -248,6 +248,9 @@ type ApplicationProfileSpec struct {
 	// +patchMergeKey=name
 	// +patchStrategy=merge
 	InitContainers []ApplicationProfileContainer `json:"initContainers,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
+	// +patchMergeKey=name
+	// +patchStrategy=merge
+	EphemeralContainers []ApplicationProfileContainer `json:"ephemeralContainers,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 }
 
 type ApplicationProfileContainer struct {

--- a/pkg/apis/softwarecomposition/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/softwarecomposition/v1beta1/zz_generated.conversion.go
@@ -1989,6 +1989,7 @@ func Convert_softwarecomposition_ApplicationProfileList_To_v1beta1_ApplicationPr
 func autoConvert_v1beta1_ApplicationProfileSpec_To_softwarecomposition_ApplicationProfileSpec(in *ApplicationProfileSpec, out *softwarecomposition.ApplicationProfileSpec, s conversion.Scope) error {
 	out.Containers = *(*[]softwarecomposition.ApplicationProfileContainer)(unsafe.Pointer(&in.Containers))
 	out.InitContainers = *(*[]softwarecomposition.ApplicationProfileContainer)(unsafe.Pointer(&in.InitContainers))
+	out.EphemeralContainers = *(*[]softwarecomposition.ApplicationProfileContainer)(unsafe.Pointer(&in.EphemeralContainers))
 	return nil
 }
 
@@ -2000,6 +2001,7 @@ func Convert_v1beta1_ApplicationProfileSpec_To_softwarecomposition_ApplicationPr
 func autoConvert_softwarecomposition_ApplicationProfileSpec_To_v1beta1_ApplicationProfileSpec(in *softwarecomposition.ApplicationProfileSpec, out *ApplicationProfileSpec, s conversion.Scope) error {
 	out.Containers = *(*[]ApplicationProfileContainer)(unsafe.Pointer(&in.Containers))
 	out.InitContainers = *(*[]ApplicationProfileContainer)(unsafe.Pointer(&in.InitContainers))
+	out.EphemeralContainers = *(*[]ApplicationProfileContainer)(unsafe.Pointer(&in.EphemeralContainers))
 	return nil
 }
 

--- a/pkg/apis/softwarecomposition/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/softwarecomposition/v1beta1/zz_generated.deepcopy.go
@@ -295,6 +295,13 @@ func (in *ApplicationProfileSpec) DeepCopyInto(out *ApplicationProfileSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.EphemeralContainers != nil {
+		in, out := &in.EphemeralContainers, &out.EphemeralContainers
+		*out = make([]ApplicationProfileContainer, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 

--- a/pkg/apis/softwarecomposition/zz_generated.deepcopy.go
+++ b/pkg/apis/softwarecomposition/zz_generated.deepcopy.go
@@ -295,6 +295,13 @@ func (in *ApplicationProfileSpec) DeepCopyInto(out *ApplicationProfileSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.EphemeralContainers != nil {
+		in, out := &in.EphemeralContainers, &out.EphemeralContainers
+		*out = make([]ApplicationProfileContainer, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -712,6 +712,25 @@ func schema_pkg_apis_softwarecomposition_v1beta1_ApplicationProfileSpec(ref comm
 							},
 						},
 					},
+					"ephemeralContainers": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: map[string]interface{}{},
+										Ref:     ref("github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1.ApplicationProfileContainer"),
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 		},

--- a/pkg/registry/file/processor.go
+++ b/pkg/registry/file/processor.go
@@ -2,11 +2,12 @@ package file
 
 import (
 	"fmt"
+	"strconv"
+
 	sets "github.com/deckarep/golang-set/v2"
 	"github.com/kubescape/k8s-interface/instanceidhandler/v1/helpers"
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition"
 	"k8s.io/apimachinery/pkg/runtime"
-	"strconv"
 )
 
 type Processor interface {
@@ -46,7 +47,8 @@ func (a ApplicationProfileProcessor) PreSave(object runtime.Object) error {
 		return containers
 	}
 
-	// Use the function for both InitContainers and Containers
+	// Use the function for InitContainers, EphemeralContainers and Containers
+	profile.Spec.EphemeralContainers = processContainers(profile.Spec.EphemeralContainers)
 	profile.Spec.InitContainers = processContainers(profile.Spec.InitContainers)
 	profile.Spec.Containers = processContainers(profile.Spec.Containers)
 

--- a/pkg/registry/file/processor_test.go
+++ b/pkg/registry/file/processor_test.go
@@ -2,12 +2,13 @@ package file
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/kubescape/k8s-interface/instanceidhandler/v1/helpers"
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"testing"
 )
 
 func TestApplicationProfileProcessor_PreSave(t *testing.T) {
@@ -18,12 +19,20 @@ func TestApplicationProfileProcessor_PreSave(t *testing.T) {
 		wantErr assert.ErrorAssertionFunc
 	}{
 		{
-			name: "ApplicationProfile with initContainers",
+			name: "ApplicationProfile with initContainers and ephemeralContainers",
 			object: &softwarecomposition.ApplicationProfile{
 				ObjectMeta: v1.ObjectMeta{
 					Annotations: map[string]string{},
 				},
 				Spec: softwarecomposition.ApplicationProfileSpec{
+					EphemeralContainers: []softwarecomposition.ApplicationProfileContainer{
+						{
+							Name: "ephemeralContainer",
+							Execs: []softwarecomposition.ExecCalls{
+								{Path: "/bin/bash", Args: []string{"-c", "echo abc"}},
+							},
+						},
+					},
 					InitContainers: []softwarecomposition.ApplicationProfileContainer{
 						{
 							Name: "initContainer",
@@ -56,10 +65,20 @@ func TestApplicationProfileProcessor_PreSave(t *testing.T) {
 			want: &softwarecomposition.ApplicationProfile{
 				ObjectMeta: v1.ObjectMeta{
 					Annotations: map[string]string{
-						helpers.ResourceSizeMetadataKey: "5",
+						helpers.ResourceSizeMetadataKey: "6",
 					},
 				},
 				Spec: softwarecomposition.ApplicationProfileSpec{
+					EphemeralContainers: []softwarecomposition.ApplicationProfileContainer{
+						{
+							Name:         "ephemeralContainer",
+							Capabilities: []string{},
+							Execs: []softwarecomposition.ExecCalls{
+								{Path: "/bin/bash", Args: []string{"-c", "echo abc"}},
+							},
+							Syscalls: []string{},
+						},
+					},
 					InitContainers: []softwarecomposition.ApplicationProfileContainer{
 						{
 							Name:         "initContainer",


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Added support for ephemeral containers in `ApplicationProfileSpec`, including JSON tags, deep copy, conversion, and OpenAPI schema definitions.
- Updated discovery logic to include ephemeral containers in workload identification and image ID collection.
- Extended `ApplicationProfileProcessor` to process ephemeral containers, ensuring they are included in pre-save operations.
- Added unit tests to validate the processing of ephemeral containers.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>types.go</strong><dd><code>Support for Ephemeral Containers in ApplicationProfileSpec</code></dd></summary>
<hr>

pkg/apis/softwarecomposition/types.go
<li>Added <code>EphemeralContainers</code> field to <code>ApplicationProfileSpec</code> struct.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/storage/pull/106/files#diff-738b6d3a0462272940289f302f6b07d66e4991404bda26edafcbf58399824e55">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>types.go</strong><dd><code>Add EphemeralContainers Field to ApplicationProfileSpec with JSON Tags</code></dd></summary>
<hr>

pkg/apis/softwarecomposition/v1beta1/types.go
<li>Added <code>EphemeralContainers</code> field with JSON tags and patch strategies to <br><code>ApplicationProfileSpec</code> struct.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/storage/pull/106/files#diff-c5af80b7e6424e8b4a947dfd8a99a11c5374bc01d4874e3765fb25205fa42158">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>zz_generated.conversion.go</strong><dd><code>Autogenerated Conversion for EphemeralContainers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/apis/softwarecomposition/v1beta1/zz_generated.conversion.go
<li>Added conversion logic for <code>EphemeralContainers</code> between internal and <br>v1beta1 versions.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/storage/pull/106/files#diff-2bc1d43253045f615835b4dd60a6a23470291fd031ef91c6d79e1b489922eaeb">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>zz_generated.deepcopy.go</strong><dd><code>Autogenerated DeepCopy for EphemeralContainers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/apis/softwarecomposition/v1beta1/zz_generated.deepcopy.go
- Implemented deep copy logic for `EphemeralContainers`.



</details>
    

  </td>
  <td><a href="https://github.com/kubescape/storage/pull/106/files#diff-57aff44c0b160536aa2f03929847b600bf00fd7db89f5090f1963efd245a9d24">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>zz_generated.deepcopy.go</strong><dd><code>Support DeepCopy for EphemeralContainers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/apis/softwarecomposition/zz_generated.deepcopy.go
<li>Added deep copy logic for <code>EphemeralContainers</code> in <br>ApplicationProfileSpec.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/storage/pull/106/files#diff-f265718cc4c961dbd3e21569119334fdf38a5758851ea6a4a14837bba4a908f7">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>discovery.go</strong><dd><code>Discover Ephemeral Containers in Workloads</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/cleanup/discovery.go
<li>Added logic to fetch workload identifiers from running ephemeral <br>containers.<br> <li> Included ephemeral container image IDs in the discovery process.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/storage/pull/106/files#diff-9118a5aa68f59e96c154684eda47af121f71f384fb00b10027c1246b3ecf22b1">+29/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>zz_generated.openapi.go</strong><dd><code>OpenAPI Schema for EphemeralContainers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/generated/openapi/zz_generated.openapi.go
- Added OpenAPI schema properties for `EphemeralContainers`.



</details>
    

  </td>
  <td><a href="https://github.com/kubescape/storage/pull/106/files#diff-9f4c1466e676f9e733cae72d369ffd5ff37f446116c98562807cf3bfb872ae95">+19/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>processor.go</strong><dd><code>Process EphemeralContainers in ApplicationProfile PreSave</code></dd></summary>
<hr>

pkg/registry/file/processor.go
- Extended `PreSave` logic to process `EphemeralContainers`.



</details>
    

  </td>
  <td><a href="https://github.com/kubescape/storage/pull/106/files#diff-44434353040b2d3b43adbf08b09aac6916051e2a2c8c0eaacdeb94c50dfa5813">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr><tr><td><strong>Tests
</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>processor_test.go</strong><dd><code>Test Processing of EphemeralContainers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/registry/file/processor_test.go
- Added test cases for processing `EphemeralContainers`.



</details>
    

  </td>
  <td><a href="https://github.com/kubescape/storage/pull/106/files#diff-ef893a71cf16451eda3486cac7c1a568d70a55a87c145631672ba08e1e877a34">+22/-3</a>&nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

