### PR TITLE
Fix MetadataType in artifacts

### DIFF
--- a/pkg/apis/softwarecomposition/syfttypes.go
+++ b/pkg/apis/softwarecomposition/syfttypes.go
@@ -323,6 +323,7 @@ func unpackPkgMetadata(p *SyftPackage, unpacker packageMetadataUnpacker) error {
 			ty = "rust-cargo-audit-entry"
 		}
 	}
+	p.MetadataType = ty
 
 	typ := packagemetadata.ReflectTypeFromJSONName(ty)
 	if typ == nil {

--- a/pkg/apis/softwarecomposition/syfttypes_test.go
+++ b/pkg/apis/softwarecomposition/syfttypes_test.go
@@ -1,0 +1,41 @@
+package softwarecomposition
+
+import (
+	"testing"
+
+	_ "embed"
+
+	"github.com/stretchr/testify/assert"
+)
+
+//go:embed testdata/artifact.json
+var artifact []byte
+
+func TestUpdateSBOMSyft(t *testing.T) {
+	type args struct {
+		id           string
+		metadataType string
+	}
+	tests := []struct {
+		name    string
+		input   []byte
+		args    args
+		wantErr bool
+	}{
+		{
+			name:    "TestUpdateSBOMSyft",
+			input:   artifact,
+			args:    args{id: "8a49897e59f569c2", metadataType: "dpkg-db-entry"},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := SyftPackage{}
+			err := c.UnmarshalJSON(tt.input)
+			assert.NoError(t, err)
+			assert.Equal(t, c.ID, tt.args.id)
+			assert.Equal(t, c.MetadataType, tt.args.metadataType)
+		})
+	}
+}

--- a/pkg/apis/softwarecomposition/v1beta1/syfttypes.go
+++ b/pkg/apis/softwarecomposition/v1beta1/syfttypes.go
@@ -323,6 +323,7 @@ func unpackPkgMetadata(p *SyftPackage, unpacker packageMetadataUnpacker) error {
 			ty = "rust-cargo-audit-entry"
 		}
 	}
+	p.MetadataType = ty
 
 	typ := packagemetadata.ReflectTypeFromJSONName(ty)
 	if typ == nil {


### PR DESCRIPTION
## **User description**
Sorry, we do not accept changes directly against this repository. Please see
CONTRIBUTING.md for information on where and how to contribute instead.


___

## **Type**
bug_fix, tests


___

## **Description**
- Fixed an issue where `MetadataType` was not being set during the unpacking of `SyftPackage`.
- Added tests to ensure `SyftPackage` unmarshalling correctly sets `ID` and `MetadataType`.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>syfttypes.go</strong><dd><code>Set MetadataType in SyftPackage Unpacking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/apis/softwarecomposition/syfttypes.go
- Explicitly set `MetadataType` based on the determined type.



</details>
    

  </td>
  <td><a href="https://github.com/kubescape/storage/pull/108/files#diff-4d4a17b456526172028f75509a8e9a0a2b72d2566873a7c0a83a59261b02de5f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>syfttypes.go</strong><dd><code>Set MetadataType in SyftPackage Unpacking for v1beta1</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/apis/softwarecomposition/v1beta1/syfttypes.go
- Explicitly set `MetadataType` based on the determined type.



</details>
    

  </td>
  <td><a href="https://github.com/kubescape/storage/pull/108/files#diff-007ef636e3e3645c3872a86698fa7c52323e62cae03755761ff27df69bd67722">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>syfttypes_test.go</strong><dd><code>Add Tests for SyftPackage JSON Unmarshalling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/apis/softwarecomposition/syfttypes_test.go
<li>Added new tests for <code>SyftPackage</code> JSON unmarshalling.<br> <li> Validates <code>MetadataType</code> and <code>ID</code> fields after unmarshalling.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/storage/pull/108/files#diff-0de18d26e7883822db933987055aa72aae954c3f39ffab9989afa78979497f80">+41/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

