### PR TITLE
reject updates on complete app profile, remove omitempty

### DIFF
--- a/pkg/apis/softwarecomposition/v1beta1/types.go
+++ b/pkg/apis/softwarecomposition/v1beta1/types.go
@@ -255,14 +255,14 @@ type ApplicationProfileSpec struct {
 
 type ApplicationProfileContainer struct {
 	Name         string   `json:"name,omitempty"`
-	Capabilities []string `json:"capabilities,omitempty"`
+	Capabilities []string `json:"capabilities"`
 	// +patchMergeKey=path
 	// +patchStrategy=merge
-	Execs []ExecCalls `json:"execs,omitempty" patchStrategy:"merge" patchMergeKey:"path"`
+	Execs []ExecCalls `json:"execs" patchStrategy:"merge" patchMergeKey:"path"`
 	// +patchMergeKey=path
 	// +patchStrategy=merge
-	Opens    []OpenCalls `json:"opens,omitempty" patchStrategy:"merge" patchMergeKey:"path"`
-	Syscalls []string    `json:"syscalls,omitempty"`
+	Opens    []OpenCalls `json:"opens" patchStrategy:"merge" patchMergeKey:"path"`
+	Syscalls []string    `json:"syscalls"`
 }
 
 type ExecCalls struct {

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -617,6 +617,7 @@ func schema_pkg_apis_softwarecomposition_v1beta1_ApplicationProfileContainer(ref
 						},
 					},
 				},
+				Required: []string{"capabilities", "execs", "opens", "syscalls"},
 			},
 		},
 		Dependencies: []string{

--- a/pkg/registry/softwarecomposition/applicationprofile/strategy.go
+++ b/pkg/registry/softwarecomposition/applicationprofile/strategy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	logHelpers "github.com/kubescape/go-logger/helpers"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -12,6 +13,7 @@ import (
 	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/names"
 
+	"github.com/kubescape/go-logger"
 	"github.com/kubescape/k8s-interface/instanceidhandler/v1/helpers"
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition"
 	"github.com/kubescape/storage/pkg/utils"
@@ -62,9 +64,22 @@ func (applicationProfileStrategy) PrepareForUpdate(ctx context.Context, obj, old
 	newAP := obj.(*softwarecomposition.ApplicationProfile)
 	oldAP := old.(*softwarecomposition.ApplicationProfile)
 
+	// if we have an application profile that is marked as complete and completed, we do not allow any updates
+	if oldAP.Annotations[helpers.CompletionMetadataKey] == helpers.Complete && oldAP.Annotations[helpers.StatusMetadataKey] == helpers.Completed {
+		logger.L().Debug("application profile is marked as complete and completed, rejecting update",
+			logHelpers.String("name", oldAP.Name),
+			logHelpers.String("namespace", oldAP.Namespace))
+		*newAP = *oldAP // reset the new object to the old object
+		return
+	}
+
 	// completion status cannot be transitioned from 'complete' -> 'partial'
 	// in such case, we reject status updates
 	if oldAP.Annotations[helpers.CompletionMetadataKey] == helpers.Complete && newAP.Annotations[helpers.CompletionMetadataKey] == helpers.Partial {
+		logger.L().Debug("application profile completion status cannot be transitioned from 'complete' to 'partial', rejecting status updates",
+			logHelpers.String("name", oldAP.Name),
+			logHelpers.String("namespace", oldAP.Namespace))
+
 		newAP.Annotations[helpers.CompletionMetadataKey] = helpers.Complete
 
 		if v, ok := oldAP.Annotations[helpers.StatusMetadataKey]; ok {


### PR DESCRIPTION
## **User description**


___

## **Type**
enhancement, bug_fix


___

## **Description**
- Removed 'omitempty' from several fields in ApplicationProfileContainer to ensure they are always serialized.
- Updated OpenAPI schema to mark 'capabilities', 'execs', 'opens', 'syscalls' as required.
- Added logic to reject updates on ApplicationProfiles that are marked as complete and completed.
- Enhanced test coverage for update scenarios of ApplicationProfiles.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>types.go</strong><dd><code>Ensure Required Fields are Always Serialized</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/apis/softwarecomposition/v1beta1/types.go
<li>Removed 'omitempty' from JSON tags for 'Capabilities', 'Execs', <br>'Opens', and 'Syscalls' in ApplicationProfileContainer.<br> <li> Ensured these fields are always present in the JSON output.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/storage/pull/110/files#diff-c5af80b7e6424e8b4a947dfd8a99a11c5374bc01d4874e3765fb25205fa42158">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>zz_generated.openapi.go</strong><dd><code>Update OpenAPI Schema to Reflect Required Fields</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/generated/openapi/zz_generated.openapi.go
<li>Added 'capabilities', 'execs', 'opens', 'syscalls' to the list of <br>required fields in the OpenAPI schema.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/storage/pull/110/files#diff-9f4c1466e676f9e733cae72d369ffd5ff37f446116c98562807cf3bfb872ae95">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>strategy.go</strong><dd><code>Reject Updates on Completed Application Profiles</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/registry/softwarecomposition/applicationprofile/strategy.go
<li>Added logging and conditions to reject updates to ApplicationProfiles <br>marked as complete and completed.<br> <li> Prevent status transition from 'complete' to 'partial' for <br>ApplicationProfiles.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/storage/pull/110/files#diff-31c3884639bb3a8bb6f8f2968b8573d46eeeb993e9e5579aa8a835c030402a01">+15/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>strategy_test.go</strong><dd><code>Extend Tests for ApplicationProfile Update Logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/registry/softwarecomposition/applicationprofile/strategy_test.go
<li>Expanded tests to cover rejection of updates on completed <br>ApplicationProfiles.<br> <li> Added new test scenarios for handling updates on ApplicationProfiles.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/storage/pull/110/files#diff-50d29e8cedb48c7fb1afb5410d84712023b460583d4154c13415d202b429624d">+177/-1</a>&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

