### PR TITLE
Minor non-functional refactoring/cleanup of storage layer

### DIFF
--- a/pkg/registry/file/configurationscansummarystorage_test.go
+++ b/pkg/registry/file/configurationscansummarystorage_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestConfigurationScanSummaryStorage_Count(t *testing.T) {
 	storageImpl := NewStorageImpl(afero.NewMemMapFs(), "")
-	configScanSummaryStorage := NewConfigurationScanSummaryStorage(&storageImpl)
+	configScanSummaryStorage := NewConfigurationScanSummaryStorage(storageImpl)
 
 	count, err := configScanSummaryStorage.Count("random")
 
@@ -28,7 +28,7 @@ func TestConfigurationScanSummaryStorage_Count(t *testing.T) {
 
 func TestConfigurationScanSummaryStorage_Create(t *testing.T) {
 	storageImpl := NewStorageImpl(afero.NewMemMapFs(), "")
-	configScanSummaryStorage := NewConfigurationScanSummaryStorage(&storageImpl)
+	configScanSummaryStorage := NewConfigurationScanSummaryStorage(storageImpl)
 
 	err := configScanSummaryStorage.Create(context.TODO(), "", nil, nil, 0)
 
@@ -39,7 +39,7 @@ func TestConfigurationScanSummaryStorage_Create(t *testing.T) {
 
 func TestConfigurationScanSummaryStorage_Delete(t *testing.T) {
 	storageImpl := NewStorageImpl(afero.NewMemMapFs(), "")
-	configScanSummaryStorage := NewConfigurationScanSummaryStorage(&storageImpl)
+	configScanSummaryStorage := NewConfigurationScanSummaryStorage(storageImpl)
 
 	err := configScanSummaryStorage.Delete(context.TODO(), "", nil, nil, nil, nil)
 
@@ -50,7 +50,7 @@ func TestConfigurationScanSummaryStorage_Delete(t *testing.T) {
 
 func TestConfigurationScanSummaryStorage_Watch(t *testing.T) {
 	storageImpl := NewStorageImpl(afero.NewMemMapFs(), "")
-	configScanSummaryStorage := NewConfigurationScanSummaryStorage(&storageImpl)
+	configScanSummaryStorage := NewConfigurationScanSummaryStorage(storageImpl)
 
 	_, err := configScanSummaryStorage.Watch(context.TODO(), "", storage.ListOptions{})
 
@@ -61,7 +61,7 @@ func TestConfigurationScanSummaryStorage_Watch(t *testing.T) {
 
 func TestConfigurationScanSummaryStorage_GuaranteedUpdate(t *testing.T) {
 	storageImpl := NewStorageImpl(afero.NewMemMapFs(), "")
-	configScanSummaryStorage := NewConfigurationScanSummaryStorage(&storageImpl)
+	configScanSummaryStorage := NewConfigurationScanSummaryStorage(storageImpl)
 
 	err := configScanSummaryStorage.GuaranteedUpdate(context.TODO(), "", nil, false, nil, nil, nil)
 
@@ -111,7 +111,7 @@ func TestConfigurationScanSummaryStorage_Get(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			configScanSummaryStorage := NewConfigurationScanSummaryStorage(&realStorage)
+			configScanSummaryStorage := NewConfigurationScanSummaryStorage(realStorage)
 
 			if tt.create {
 				wlObj := &softwarecomposition.WorkloadConfigurationScanSummary{}
@@ -177,7 +177,7 @@ func TestConfigurationScanSummaryStorage_GetList(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			configScanSummaryStorage := NewConfigurationScanSummaryStorage(&realStorage)
+			configScanSummaryStorage := NewConfigurationScanSummaryStorage(realStorage)
 
 			if tt.create {
 				wlObj := &softwarecomposition.WorkloadConfigurationScanSummary{}

--- a/pkg/registry/file/generatednetworkpolicy.go
+++ b/pkg/registry/file/generatednetworkpolicy.go
@@ -13,7 +13,6 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/apiserver/pkg/storage"
 )
 
@@ -24,37 +23,14 @@ const (
 
 // GeneratedNetworkPolicyStorage offers a storage solution for GeneratedNetworkPolicy objects, implementing custom business logic for these objects and using the underlying default storage implementation.
 type GeneratedNetworkPolicyStorage struct {
+	immutableStorage
 	realStore StorageQuerier
-	versioner storage.Versioner
 }
 
 var _ storage.Interface = &GeneratedNetworkPolicyStorage{}
 
-func NewGeneratedNetworkPolicyStorage(realStore *StorageQuerier) storage.Interface {
-	return &GeneratedNetworkPolicyStorage{
-		realStore: *realStore,
-		versioner: storage.APIObjectVersioner{},
-	}
-}
-
-// Versioner Returns Versioner associated with this interface.
-func (s *GeneratedNetworkPolicyStorage) Versioner() storage.Versioner {
-	return s.versioner
-}
-
-// Create is not supported for GeneratedNetworkPolicy objects. Objects are generated on the fly and not stored.
-func (s *GeneratedNetworkPolicyStorage) Create(ctx context.Context, key string, obj, out runtime.Object, _ uint64) error {
-	return storage.NewInvalidObjError(key, operationNotSupportedMsg)
-}
-
-// Delete is not supported for GeneratedNetworkPolicy objects. Objects are generated on the fly and not stored.
-func (s *GeneratedNetworkPolicyStorage) Delete(ctx context.Context, key string, out runtime.Object, _ *storage.Preconditions, _ storage.ValidateObjectFunc, _ runtime.Object) error {
-	return storage.NewInvalidObjError(key, operationNotSupportedMsg)
-}
-
-// Watch is not supported for GeneratedNetworkPolicy objects. Objects are generated on the fly and not stored.
-func (s *GeneratedNetworkPolicyStorage) Watch(ctx context.Context, key string, _ storage.ListOptions) (watch.Interface, error) {
-	return nil, storage.NewInvalidObjError(key, operationNotSupportedMsg)
+func NewGeneratedNetworkPolicyStorage(realStore StorageQuerier) storage.Interface {
+	return &GeneratedNetworkPolicyStorage{realStore: realStore}
 }
 
 // Get generates and returns a single GeneratedNetworkPolicy object
@@ -145,24 +121,5 @@ func (s *GeneratedNetworkPolicyStorage) GetList(ctx context.Context, key string,
 		return err
 	}
 
-	return nil
-}
-
-// GuaranteedUpdate is not supported for GeneratedNetworkPolicy objects. Objects are generated on the fly and not stored.
-func (s *GeneratedNetworkPolicyStorage) GuaranteedUpdate(
-	ctx context.Context, key string, destination runtime.Object, ignoreNotFound bool,
-	preconditions *storage.Preconditions, tryUpdate storage.UpdateFunc, cachedExistingObject runtime.Object) error {
-	return storage.NewInvalidObjError(key, operationNotSupportedMsg)
-}
-
-// Count is not supported for GeneratedNetworkPolicy objects. Objects are generated on the fly and not stored.
-func (s *GeneratedNetworkPolicyStorage) Count(key string) (int64, error) {
-	return 0, storage.NewInvalidObjError(key, operationNotSupportedMsg)
-}
-
-// RequestWatchProgress fulfills the storage.Interface
-//
-// It’s function is only relevant to etcd.
-func (s *GeneratedNetworkPolicyStorage) RequestWatchProgress(context.Context) error {
 	return nil
 }

--- a/pkg/registry/file/generatednetworkpolicy_test.go
+++ b/pkg/registry/file/generatednetworkpolicy_test.go
@@ -79,7 +79,7 @@ func TestGeneratedNetworkPolicyStorage_Get(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			realStorage := NewStorageImpl(afero.NewMemMapFs(), "/")
-			generatedNetworkPolicyStorage := NewGeneratedNetworkPolicyStorage(&realStorage)
+			generatedNetworkPolicyStorage := NewGeneratedNetworkPolicyStorage(realStorage)
 
 			if tt.create {
 				wlObj := &softwarecomposition.NetworkNeighbors{
@@ -115,7 +115,7 @@ func TestGeneratedNetworkPolicyStorage_Get(t *testing.T) {
 
 func TestGeneratedNetworkPolicyStorage_Count(t *testing.T) {
 	storageImpl := NewStorageImpl(afero.NewMemMapFs(), "")
-	generatedNetworkPolicyStorage := NewGeneratedNetworkPolicyStorage(&storageImpl)
+	generatedNetworkPolicyStorage := NewGeneratedNetworkPolicyStorage(storageImpl)
 
 	count, err := generatedNetworkPolicyStorage.Count("random")
 
@@ -128,7 +128,7 @@ func TestGeneratedNetworkPolicyStorage_Count(t *testing.T) {
 
 func TestGeneratedNetworkPolicyStorage_Create(t *testing.T) {
 	storageImpl := NewStorageImpl(afero.NewMemMapFs(), "")
-	generatedNetworkPolicyStorage := NewGeneratedNetworkPolicyStorage(&storageImpl)
+	generatedNetworkPolicyStorage := NewGeneratedNetworkPolicyStorage(storageImpl)
 
 	err := generatedNetworkPolicyStorage.Create(context.TODO(), "", nil, nil, 0)
 
@@ -139,7 +139,7 @@ func TestGeneratedNetworkPolicyStorage_Create(t *testing.T) {
 
 func TestGeneratedNetworkPolicyStorage_Delete(t *testing.T) {
 	storageImpl := NewStorageImpl(afero.NewMemMapFs(), "")
-	generatedNetworkPolicyStorage := NewGeneratedNetworkPolicyStorage(&storageImpl)
+	generatedNetworkPolicyStorage := NewGeneratedNetworkPolicyStorage(storageImpl)
 
 	err := generatedNetworkPolicyStorage.Delete(context.TODO(), "", nil, nil, nil, nil)
 
@@ -150,7 +150,7 @@ func TestGeneratedNetworkPolicyStorage_Delete(t *testing.T) {
 
 func TestGeneratedNetworkPolicyStorage_Watch(t *testing.T) {
 	storageImpl := NewStorageImpl(afero.NewMemMapFs(), "")
-	generatedNetworkPolicyStorage := NewGeneratedNetworkPolicyStorage(&storageImpl)
+	generatedNetworkPolicyStorage := NewGeneratedNetworkPolicyStorage(storageImpl)
 
 	_, err := generatedNetworkPolicyStorage.Watch(context.TODO(), "", storage.ListOptions{})
 
@@ -161,7 +161,7 @@ func TestGeneratedNetworkPolicyStorage_Watch(t *testing.T) {
 
 func TestGeneratedNetworkPolicyStorage_GuaranteedUpdate(t *testing.T) {
 	storageImpl := NewStorageImpl(afero.NewMemMapFs(), "")
-	generatedNetworkPolicyStorage := NewGeneratedNetworkPolicyStorage(&storageImpl)
+	generatedNetworkPolicyStorage := NewGeneratedNetworkPolicyStorage(storageImpl)
 
 	err := generatedNetworkPolicyStorage.GuaranteedUpdate(context.TODO(), "", nil, false, nil, nil, nil)
 

--- a/pkg/registry/file/storage.go
+++ b/pkg/registry/file/storage.go
@@ -65,14 +65,7 @@ var _ storage.Interface = &StorageImpl{}
 var _ StorageQuerier = &StorageImpl{}
 
 func NewStorageImpl(appFs afero.Fs, root string) StorageQuerier {
-	return &StorageImpl{
-		appFs:           appFs,
-		locks:           utils.NewMapMutex[string](),
-		processor:       DefaultProcessor{},
-		root:            root,
-		versioner:       storage.APIObjectVersioner{},
-		watchDispatcher: newWatchDispatcher(),
-	}
+	return NewStorageImplWithCollector(appFs, root, DefaultProcessor{})
 }
 
 func NewStorageImplWithCollector(appFs afero.Fs, root string, processor Processor) StorageQuerier {
@@ -740,4 +733,41 @@ func replaceKeyForKind(key string, kind string) string {
 	keySplit[2] = strings.ToLower(kind)
 
 	return strings.Join(keySplit, "/")
+}
+
+type immutableStorage struct{}
+
+// Create is not supported for immutable objects. Objects are generated on the fly and not stored.
+func (immutableStorage) Create(ctx context.Context, key string, obj, out runtime.Object, _ uint64) error {
+	return storage.NewInvalidObjError(key, operationNotSupportedMsg)
+}
+
+// Delete is not supported for immutable objects. Objects are generated on the fly and not stored.
+func (immutableStorage) Delete(ctx context.Context, key string, out runtime.Object, _ *storage.Preconditions, _ storage.ValidateObjectFunc, _ runtime.Object) error {
+	return storage.NewInvalidObjError(key, operationNotSupportedMsg)
+}
+
+// Watch is not supported for immutable objects. Objects are generated on the fly and not stored.
+func (immutableStorage) Watch(ctx context.Context, key string, _ storage.ListOptions) (watch.Interface, error) {
+	return nil, storage.NewInvalidObjError(key, operationNotSupportedMsg)
+}
+
+// GuaranteedUpdate is not supported for immutable objects. Objects are generated on the fly and not stored.
+func (immutableStorage) GuaranteedUpdate(_ context.Context, key string, _ runtime.Object, _ bool, _ *storage.Preconditions, _ storage.UpdateFunc, _ runtime.Object) error {
+	return storage.NewInvalidObjError(key, operationNotSupportedMsg)
+}
+
+// Count is not supported for immutable objects. Objects are generated on the fly and not stored.
+func (immutableStorage) Count(key string) (int64, error) {
+	return 0, storage.NewInvalidObjError(key, operationNotSupportedMsg)
+}
+
+// RequestWatchProgress fulfills the storage.Interface
+//
+// It’s function is only relevant to etcd.
+func (immutableStorage) RequestWatchProgress(context.Context) error { return nil }
+
+// Versioner Returns fixed versioner associated with this interface.
+func (immutableStorage) Versioner() storage.Versioner {
+	return storage.APIObjectVersioner{}
 }

--- a/pkg/registry/file/vulnerabilitysummarystorage.go
+++ b/pkg/registry/file/vulnerabilitysummarystorage.go
@@ -12,7 +12,6 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/apiserver/pkg/storage"
 )
 
@@ -25,35 +24,12 @@ const (
 //
 // It provides vulnerability summaries for scopes like namespace and cluster. To get these summaries, the storage fetches existing stored VulnerabilitySummary objects and aggregates them on the fly.
 type VulnerabilitySummaryStorage struct {
+	immutableStorage
 	realStore StorageQuerier
-	versioner storage.Versioner
 }
 
-func NewVulnerabilitySummaryStorage(realStore *StorageQuerier) storage.Interface {
-	return &VulnerabilitySummaryStorage{
-		realStore: *realStore,
-		versioner: storage.APIObjectVersioner{},
-	}
-}
-
-// Versioner Returns Versioner associated with this interface.
-func (s *VulnerabilitySummaryStorage) Versioner() storage.Versioner {
-	return s.versioner
-}
-
-// Create is not supported for VulnerabilitySummary objects. Objects are generated on the fly and not stored.
-func (s *VulnerabilitySummaryStorage) Create(ctx context.Context, key string, obj, out runtime.Object, _ uint64) error {
-	return storage.NewInvalidObjError(key, operationNotSupportedMsg)
-}
-
-// Delete is not supported for VulnerabilitySummary objects. Objects are generated on the fly and not stored.
-func (s *VulnerabilitySummaryStorage) Delete(ctx context.Context, key string, out runtime.Object, _ *storage.Preconditions, _ storage.ValidateObjectFunc, _ runtime.Object) error {
-	return storage.NewInvalidObjError(key, operationNotSupportedMsg)
-}
-
-// Watch is not supported for VulnerabilitySummary objects. Objects are generated on the fly and not stored.
-func (s *VulnerabilitySummaryStorage) Watch(ctx context.Context, key string, _ storage.ListOptions) (watch.Interface, error) {
-	return nil, storage.NewInvalidObjError(key, operationNotSupportedMsg)
+func NewVulnerabilitySummaryStorage(realStore StorageQuerier) storage.Interface {
+	return &VulnerabilitySummaryStorage{realStore: realStore}
 }
 
 func buildVulnerabilityScanSummary(vulnerabilityManifestSummaryList softwarecomposition.VulnerabilityManifestSummaryList, namespace string) softwarecomposition.VulnerabilitySummary {
@@ -177,24 +153,5 @@ func (s *VulnerabilitySummaryStorage) GetList(ctx context.Context, key string, _
 		return err
 	}
 
-	return nil
-}
-
-// GuaranteedUpdate is not supported for VulnerabilitySummary objects. Objects are generated on the fly and not stored.
-func (s *VulnerabilitySummaryStorage) GuaranteedUpdate(
-	ctx context.Context, key string, destination runtime.Object, ignoreNotFound bool,
-	preconditions *storage.Preconditions, tryUpdate storage.UpdateFunc, cachedExistingObject runtime.Object) error {
-	return storage.NewInvalidObjError(key, operationNotSupportedMsg)
-}
-
-// Count is not supported for VulnerabilitySummary objects. Objects are generated on the fly and not stored.
-func (s *VulnerabilitySummaryStorage) Count(key string) (int64, error) {
-	return 0, storage.NewInvalidObjError(key, operationNotSupportedMsg)
-}
-
-// RequestWatchProgress fulfills the storage.Interface
-//
-// It’s function is only relevant to etcd.
-func (s *VulnerabilitySummaryStorage) RequestWatchProgress(context.Context) error {
 	return nil
 }

--- a/pkg/registry/file/vulnerabilitysummarystorage_test.go
+++ b/pkg/registry/file/vulnerabilitysummarystorage_test.go
@@ -41,7 +41,7 @@ func TestVulnSummaryStorageImpl_Create(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := NewVulnerabilitySummaryStorage(&realStorage)
+			s := NewVulnerabilitySummaryStorage(realStorage)
 			err := s.Create(context.TODO(), tt.args.key, tt.args.obj, tt.args.out, tt.args.in4)
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -77,7 +77,7 @@ func TestVulnSummaryStorageImpl_Delete(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := NewVulnerabilitySummaryStorage(&realStorage)
+			s := NewVulnerabilitySummaryStorage(realStorage)
 			err := s.Delete(context.TODO(), tt.args.key, tt.args.obj, tt.args.precondition, tt.args.validateDeletionFunc, tt.args.cachedObj)
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -109,7 +109,7 @@ func TestVulnSummaryStorageImpl_Watch(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := NewVulnerabilitySummaryStorage(&realStorage)
+			s := NewVulnerabilitySummaryStorage(realStorage)
 			_, err := s.Watch(context.TODO(), tt.args.key, storage.ListOptions{})
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -270,7 +270,7 @@ func TestVulnSummaryStorageImpl_GetList(t *testing.T) {
 					assert.NoError(t, err)
 				}
 			}
-			s := NewVulnerabilitySummaryStorage(&realStorage)
+			s := NewVulnerabilitySummaryStorage(realStorage)
 			o := &softwarecomposition.VulnerabilitySummaryList{}
 			err := s.GetList(context.TODO(), tt.args.keyExpectedObj, storage.ListOptions{}, o)
 			if tt.wantErr {
@@ -315,7 +315,7 @@ func TestVulnSummaryStorageImpl_GuaranteedUpdate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := NewVulnerabilitySummaryStorage(&realStorage)
+			s := NewVulnerabilitySummaryStorage(realStorage)
 			err := s.GuaranteedUpdate(context.TODO(), tt.args.key, tt.args.obj, true, tt.args.preconditions, tt.args.tryUpdate, tt.args.cachedExistingObject)
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -347,7 +347,7 @@ func TestVulnSummaryStorageImpl_Count(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := NewVulnerabilitySummaryStorage(&realStorage)
+			s := NewVulnerabilitySummaryStorage(realStorage)
 			_, err := s.Count(tt.args.key)
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -435,7 +435,7 @@ func TestVulnSummaryStorageImpl_Get(t *testing.T) {
 					assert.NoError(t, err)
 				}
 			}
-			s := NewVulnerabilitySummaryStorage(&realStorage)
+			s := NewVulnerabilitySummaryStorage(realStorage)
 			o := &softwarecomposition.VulnerabilitySummary{}
 			err := s.Get(context.TODO(), tt.args.keyExpectedObj, storage.GetOptions{}, o)
 			if tt.wantErr {


### PR DESCRIPTION
 refactor(file): Simplify storage object creation logic
    
 In particular, this reduces the boilerplate of immutable storage layers (configscansummary, generated network policy and vulnerabilitysummary).
Also,
-  Simplify some list creation logic here and there.
-  Fix the issue that quotes were trimmed twice in some places in parsing side.
-  Don't pass pointers to interfaces (since interfaces are essentially typed pointers).