### PR TITLE
warns if cleanup finds files bigger than 30MB

### DIFF
--- a/main.go
+++ b/main.go
@@ -81,7 +81,7 @@ func main() {
 		file.DefaultStorageRoot,
 		intervalDuration,
 		kubernetesAPI)
-	go cleanupHandler.StartCleanupTask()
+	go cleanupHandler.StartCleanupTask(ctx)
 
 	logger.L().Info("APIServer started")
 	code := cli.Run(cmd)

--- a/pkg/cleanup/cleanup_test.go
+++ b/pkg/cleanup/cleanup_test.go
@@ -2,6 +2,7 @@ package cleanup
 
 import (
 	"archive/zip"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -50,7 +51,7 @@ func TestCleanupTask(t *testing.T) {
 		fetcher:    &ResourcesFetchMock{},
 		deleteFunc: deleteFunc,
 	}
-	handler.StartCleanupTask()
+	handler.StartCleanupTask(context.TODO())
 
 	expectedFilesToDelete := []string{
 		"/data/spdx.softwarecomposition.kubescape.io/applicationactivities/gadget/gadget-daemonset-gadget-0d7c-fd3c.g",


### PR DESCRIPTION
it will help us spot AP and NN that were not marked as too big