### PR TITLE
fail Create() if object already exists

### DIFF
--- a/pkg/registry/file/storage.go
+++ b/pkg/registry/file/storage.go
@@ -193,7 +193,7 @@ func (s *StorageImpl) writeFiles(key string, obj runtime.Object, metaOut runtime
 	return nil
 }
 
-// Create adds a new object at a key even when it already exists. 'ttl' is time-to-live
+// Create adds a new object at a key unless it already exists. 'ttl' is time-to-live
 // in seconds (and is ignored). If no error is returned and out is not nil, out will be
 // set to the read value from database.
 func (s *StorageImpl) Create(ctx context.Context, key string, obj, metaOut runtime.Object, _ uint64) error {
@@ -204,6 +204,10 @@ func (s *StorageImpl) Create(ctx context.Context, key string, obj, metaOut runti
 	s.locks.Lock(key)
 	defer s.locks.Unlock(key)
 	spanLock.End()
+	// check if object already exists
+	if _, err := s.appFs.Stat(makePayloadPath(filepath.Join(s.root, key))); err == nil {
+		return storage.NewKeyExistsError(key, 0)
+	}
 	// resourceVersion should not be set on create
 	if version, err := s.versioner.ObjectResourceVersion(obj); err == nil && version != 0 {
 		msg := "resourceVersion should not be set on objects to be created"

--- a/pkg/registry/file/vulnerabilitysummarystorage_test.go
+++ b/pkg/registry/file/vulnerabilitysummarystorage_test.go
@@ -443,9 +443,9 @@ func TestVulnSummaryStorageImpl_Get(t *testing.T) {
 	}(pool)
 	sch := scheme.Scheme
 	require.NoError(t, softwarecomposition.AddToScheme(sch))
-	realStorage := NewStorageImpl(afero.NewMemMapFs(), "/", pool, sch)
 
 	for _, tt := range tests {
+		realStorage := NewStorageImpl(afero.NewMemMapFs(), "/", pool, sch)
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.createObj {
 				for i := range tt.args.keyCreatedObj {


### PR DESCRIPTION
while this aligns with regular api-server behavior, we should test all our components in case we don't expect Create() to fail