### PR TITLE
Disable authorization flow

### DIFF
--- a/pkg/cmd/server/start.go
+++ b/pkg/cmd/server/start.go
@@ -83,6 +83,9 @@ func NewWardleServerOptions(out, errOut io.Writer, osFs afero.Fs, pool *sqlitemi
 	}
 	o.RecommendedOptions.Etcd = nil
 
+	// Disable authorization since we are publishing an internal endpoint (that only answers the API server)
+	o.RecommendedOptions.Authorization = nil
+
 	// Set TLS up and bind to 8443
 	// read the client cert filenames from the environment variables
 	value, exists := os.LookupEnv("TLS_CLIENT_CA_FILE")


### PR DESCRIPTION
This pull request includes changing the `pkg/cmd/server/start.go` file to disable authorization for the internal endpoint. Storage is only publishing an endpoint for the Kubernetes API Server (internal endpoint) and there is no point in verifying authorization when it is already done by this stage by the Kubernetes API Server.


* [`pkg/cmd/server/start.go`](diffhunk://#diff-100c9b6d0b2b9390b57a2ad09888fc069b32bf2f697b64ca9df6288f621da701R86-R88): Disabled authorization by setting `o.RecommendedOptions.Authorization` to `nil`, as the endpoint only answers the API server.
