### PR TITLE
Replace `golang.org/x/exp/maps` with `maps` from stdlib

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,6 @@ require (
 	go.opentelemetry.io/otel v1.30.0
 	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.27.0
-	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
 	golang.org/x/text v0.21.0
 	k8s.io/api v0.29.0
 	k8s.io/apimachinery v0.29.0
@@ -176,6 +175,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.30.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.3.1 // indirect
 	golang.org/x/crypto v0.31.0 // indirect
+	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
 	golang.org/x/mod v0.20.0 // indirect
 	golang.org/x/net v0.33.0 // indirect
 	golang.org/x/oauth2 v0.22.0 // indirect

--- a/pkg/apis/softwarecomposition/networkpolicy/v1/networkpolicy.go
+++ b/pkg/apis/softwarecomposition/networkpolicy/v1/networkpolicy.go
@@ -6,6 +6,7 @@ import (
 	"encoding/gob"
 	"encoding/hex"
 	"fmt"
+	"maps"
 	"net"
 	"sort"
 	"strings"
@@ -14,7 +15,6 @@ import (
 
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition"
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition/networkpolicy"
-	"golang.org/x/exp/maps"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )


### PR DESCRIPTION
The experimental functions in `golang.org/x/exp/maps` are now available in the standard library in Go 1.21.

Reference: https://go.dev/doc/go1.21#maps

Sorry, we do not accept changes directly against this repository. Please see
CONTRIBUTING.md for information on where and how to contribute instead.
