### PR TITLE
Taking CA certificate from files directly

### DIFF
--- a/pkg/cmd/server/start.go
+++ b/pkg/cmd/server/start.go
@@ -87,28 +87,10 @@ func NewWardleServerOptions(out, errOut io.Writer, osFs afero.Fs, pool *sqlitemi
 	o.RecommendedOptions.Authorization = nil
 
 	// Set TLS up and bind to 8443
-	// read the client cert filenames from the environment variables
 	value, exists := os.LookupEnv("TLS_CLIENT_CA_FILE")
 	if exists {
-		// This can be /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-		// Read the file and set the value
-		if s, err := os.Stat(value); err != nil {
-			logger.L().Error("TLS_CLIENT_CA_FILE not found", helpers.Error(err))
-		} else {
-			if f, err := os.Open(value); err != nil {
-				logger.L().Error("TLS_CLIENT_CA_FILE not readable", helpers.Error(err))
-			} else {
-				defer f.Close()
-				// Read the contents of the file as string and set the value
-				contents := make([]byte, s.Size())
-				n, err := f.Read(contents)
-				if err != nil {
-					logger.L().Error("TLS_CLIENT_CA_FILE not readable", helpers.Error(err))
-				} else {
-					o.RecommendedOptions.Authentication.ClientCert.ClientCA = string(contents[:n])
-				}
-			}
-		}
+		// Instead of reading the file contents, just set the path
+		o.RecommendedOptions.Authentication.ClientCert.ClientCA = value
 	} else {
 		logger.L().Warning("TLS_CLIENT_CA_FILE not set")
 	}


### PR DESCRIPTION
This pull request corrects the way the TLS client CA file is handled in the server startup code. The most significant change is removing the file reading logic, which is replaced by directly setting the path from an environment variable.

Code simplification:

* [`pkg/cmd/server/start.go`](diffhunk://#diff-100c9b6d0b2b9390b57a2ad09888fc069b32bf2f697b64ca9df6288f621da701L90-R93): Removed the logic for reading the contents of the TLS client CA file and instead directly set the path from the `TLS_CLIENT_CA_FILE` environment variable.