### PR TITLE
Making service port configurable

### DIFF
--- a/pkg/cmd/server/start.go
+++ b/pkg/cmd/server/start.go
@@ -129,7 +129,19 @@ func NewWardleServerOptions(out, errOut io.Writer, osFs afero.Fs, pool *sqlitemi
 	} else {
 		logger.L().Warning("TLS_SERVER_KEY_FILE not set")
 	}
-	o.RecommendedOptions.SecureServing.BindPort = 8443
+	value, exists = os.LookupEnv("SERVER_BIND_PORT")
+	if exists {
+		port, err := strconv.Atoi(value)
+		if err != nil {
+			logger.L().Error("SERVER_BIND_PORT not a valid integer", helpers.Error(err))
+		} else {
+			logger.L().Info("SERVER_BIND_PORT set to", helpers.Int("port", port))
+			o.RecommendedOptions.SecureServing.BindPort = port
+		}
+	} else {
+		logger.L().Warning("SERVER_BIND_PORT defaulting to 8443")
+		o.RecommendedOptions.SecureServing.BindPort = 8443
+	}
 
 	return o
 }


### PR DESCRIPTION
This pull request introduces a change to the `pkg/cmd/server/start.go` file to enhance server configuration by allowing the `SERVER_BIND_PORT` to be set via an environment variable. If the variable is not set or is invalid, the default port of 8443 is used.

Key change in server configuration:

* Added logic to check for the `SERVER_BIND_PORT` environment variable. If it exists and is a valid integer, the server bind port is set to the specified value. If not, a warning is logged, and the default port (8443) is used. (`[pkg/cmd/server/start.goR132-R144](diffhunk://#diff-100c9b6d0b2b9390b57a2ad09888fc069b32bf2f697b64ca9df6288f621da701R132-R144)`)