### PR TITLE
Implement queue management system with configurable parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ vendor/*
 # Ignore the binaries built in the example directory
 artifacts/simple-image/storage-apiserver
 artifacts/simple-image/kube-sample-apiserver
+logs-*/*
+tmp/*

--- a/build/Dockerfile.debug
+++ b/build/Dockerfile.debug
@@ -1,0 +1,20 @@
+FROM --platform=$BUILDPLATFORM golang:1.23-bookworm AS builder
+
+ENV GO111MODULE=on CGO_ENABLED=0
+WORKDIR /work
+ARG TARGETOS TARGETARCH
+RUN go install github.com/go-delve/delve/cmd/dlv@latest
+RUN --mount=target=. \
+    --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg \
+    GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /out/storage .
+
+FROM gcr.io/distroless/static-debian12:debug
+
+COPY --from=builder /go/bin/dlv /usr/bin/dlv
+COPY --from=builder /out/storage /usr/bin/storage
+
+ARG image_version
+ENV RELEASE=$image_version
+
+ENTRYPOINT ["/usr/bin/dlv", "--listen=:40000", "--headless=true","--accept-multiclient", "--continue", "--api-version=2", "--log", "exec", "/usr/bin/storage"]

--- a/configuration/queue-configuration.json
+++ b/configuration/queue-configuration.json
@@ -1,0 +1,37 @@
+{
+    "defaultQueueLength": 100,
+    "defaultWorkerCount": 2,
+    "defaultMaxObjectSize": 20000,
+    "kindQueues": {
+      "applicationprofiles": {
+        "queueLength": 50,
+        "workerCount": 2,
+        "maxObjectSize": 20000000
+      },
+      "networkneighborhoods": {
+        "queueLength": 50,
+        "workerCount": 2,
+        "maxObjectSize": 10000000
+      },
+      "openvulnerabilityexchangecontainers": {
+        "queueLength": 50,
+        "workerCount": 2,
+        "maxObjectSize": 500000
+      },
+      "sbomsyftfiltereds": {
+        "queueLength": 50,
+        "workerCount": 2,
+        "maxObjectSize": 20000000
+      },
+      "sbomsyfts": {
+        "queueLength": 50,
+        "workerCount": 1,
+        "maxObjectSize": 100000000
+      },
+      "vulnerabilitymanifests": {
+        "queueLength": 50,
+        "workerCount": 2,
+        "maxObjectSize": 10000000
+      }
+    }
+  }

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/kubescape/k8s-interface v0.0.195
 	github.com/ncw/directio v1.0.5
 	github.com/olvrng/ujson v1.1.0
+	github.com/panjf2000/ants/v2 v2.11.3
 	github.com/puzpuzpuz/xsync/v2 v2.4.1
 	github.com/spf13/afero v1.11.0
 	github.com/spf13/cobra v1.9.1

--- a/go.sum
+++ b/go.sum
@@ -564,6 +564,8 @@ github.com/opencontainers/runtime-spec v1.2.1/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/
 github.com/opencontainers/runtime-tools v0.9.1-0.20250303011046-260e151b8552 h1:CkXngT0nixZqQUPDVfwVs3GiuhfTqCMk0V+OoHpxIvA=
 github.com/opencontainers/runtime-tools v0.9.1-0.20250303011046-260e151b8552/go.mod h1:T487Kf80NeF2i0OyVXHiylg217e0buz8pQsa0T791RA=
 github.com/openzipkin/zipkin-go v0.1.1/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=
+github.com/panjf2000/ants/v2 v2.11.3 h1:AfI0ngBoXJmYOpDh9m516vjqoUu2sLrIVgppI9TZVpg=
+github.com/panjf2000/ants/v2 v2.11.3/go.mod h1:8u92CYMUc6gyvTIw8Ru7Mt7+/ESnJahz5EVtqfrilek=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/indent v1.2.1 h1:lFiviAbISHv3Rf0jcuh489bi06hj98JsVMtIDZQb9yM=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -6,6 +6,12 @@ import (
 	"github.com/spf13/viper"
 )
 
+type KindQueueConfig struct {
+	QueueLength   int `mapstructure:"queueLength"`
+	WorkerCount   int `mapstructure:"workerCount"`
+	MaxObjectSize int `mapstructure:"maxObjectSize"`
+}
+
 type Config struct {
 	CleanupInterval            time.Duration `mapstructure:"cleanupInterval"`
 	DefaultNamespace           string        `mapstructure:"defaultNamespace"`
@@ -19,6 +25,17 @@ type Config struct {
 	TlsClientCaFile            string        `mapstructure:"tlsClientCaFile"`
 	TlsServerCertFile          string        `mapstructure:"tlsServerCertFile"`
 	TlsServerKeyFile           string        `mapstructure:"tlsServerKeyFile"`
+
+	// New fields for per-kind queue/worker/object size config
+	KindQueues           map[string]KindQueueConfig `mapstructure:"kindQueues"`
+	DefaultQueueLength   int                        `mapstructure:"defaultQueueLength"`
+	DefaultWorkerCount   int                        `mapstructure:"defaultWorkerCount"`
+	DefaultMaxObjectSize int                        `mapstructure:"defaultMaxObjectSize"`
+
+	// Debugging
+	QueueTimeoutPrint         bool `mapstructure:"queueTimeoutPrint"`
+	QueueTimeout              int  `mapstructure:"queueTimeout"`
+	QueueProcessingStatsPrint bool `mapstructure:"queueProcessingStatsPrint"`
 }
 
 // LoadConfig reads configuration from file or environment variables.
@@ -33,6 +50,44 @@ func LoadConfig(path string) (Config, error) {
 	viper.SetDefault("maxNetworkNeighborhoodSize", 40000)
 	viper.SetDefault("rateLimitTotal", 10)
 	viper.SetDefault("serverBindPort", 8443)
+	viper.SetDefault("defaultQueueLength", 100)
+	viper.SetDefault("defaultWorkerCount", 2)
+	viper.SetDefault("defaultMaxObjectSize", 400000)
+	viper.SetDefault("queueTimeoutPrint", false)
+	viper.SetDefault("queueTimeout", 60)
+	viper.SetDefault("queueProcessingStatsPrint", false)
+	viper.SetDefault("kindQueues", map[string]KindQueueConfig{
+		"applicationprofiles": {
+			QueueLength:   50,
+			WorkerCount:   1,
+			MaxObjectSize: 20000000,
+		},
+		"networkneighborhoods": {
+			QueueLength:   50,
+			WorkerCount:   1,
+			MaxObjectSize: 10000000,
+		},
+		"openvulnerabilityexchangecontainers": {
+			QueueLength:   50,
+			WorkerCount:   1,
+			MaxObjectSize: 500000,
+		},
+		"sbomsyftfiltereds": {
+			QueueLength:   50,
+			WorkerCount:   1,
+			MaxObjectSize: 20000000,
+		},
+		"sbomsyfts": {
+			QueueLength:   50,
+			WorkerCount:   1,
+			MaxObjectSize: 100000000,
+		},
+		"vulnerabilitymanifests": {
+			QueueLength:   50,
+			WorkerCount:   1,
+			MaxObjectSize: 10000000,
+		},
+	})
 
 	err := viper.ReadInConfig()
 	if err != nil {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -25,6 +25,42 @@ func TestLoadConfig(t *testing.T) {
 				MaxNetworkNeighborhoodSize: 40000,
 				RateLimitTotal:             10,
 				ServerBindPort:             8443,
+				KindQueues: map[string]KindQueueConfig{
+					"applicationprofiles": {
+						QueueLength:   50,
+						WorkerCount:   1,
+						MaxObjectSize: 20000000,
+					},
+					"networkneighborhoods": {
+						QueueLength:   50,
+						WorkerCount:   1,
+						MaxObjectSize: 10000000,
+					},
+					"openvulnerabilityexchangecontainers": {
+						QueueLength:   50,
+						WorkerCount:   1,
+						MaxObjectSize: 500000,
+					},
+					"sbomsyftfiltereds": {
+						QueueLength:   50,
+						WorkerCount:   1,
+						MaxObjectSize: 20000000,
+					},
+					"sbomsyfts": {
+						QueueLength:   50,
+						WorkerCount:   1,
+						MaxObjectSize: 100000000,
+					},
+					"vulnerabilitymanifests": {
+						QueueLength:   50,
+						WorkerCount:   1,
+						MaxObjectSize: 10000000,
+					},
+				},
+				DefaultQueueLength:   100,
+				DefaultWorkerCount:   2,
+				DefaultMaxObjectSize: 400000,
+				QueueTimeout:         60,
 			},
 			wantErr: false,
 		},

--- a/pkg/queuemanager/manager.go
+++ b/pkg/queuemanager/manager.go
@@ -1,0 +1,199 @@
+package queuemanager
+
+import (
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/kubescape/go-logger"
+	"github.com/kubescape/go-logger/helpers"
+	"github.com/kubescape/storage/pkg/config"
+	"github.com/panjf2000/ants/v2"
+	"k8s.io/apiserver/pkg/endpoints/request"
+)
+
+type queuedRequest struct {
+	w    http.ResponseWriter
+	r    *http.Request
+	next http.Handler
+	done chan struct{}
+}
+
+type kindQueue struct {
+	queue         chan *queuedRequest
+	pool          *ants.Pool
+	maxObjectSize int
+}
+
+type QueueManager struct {
+	queues           map[string]*kindQueue
+	lastQueueFullLog map[string]time.Time
+	mu               sync.Mutex
+	cfg              *config.Config
+}
+
+func NewQueueManager(cfg *config.Config) *QueueManager {
+	return &QueueManager{
+		queues:           make(map[string]*kindQueue),
+		cfg:              cfg,
+		lastQueueFullLog: make(map[string]time.Time),
+	}
+}
+
+func (qm *QueueManager) getOrCreateQueue(kind string) *kindQueue {
+	qm.mu.Lock()
+	defer qm.mu.Unlock()
+	q, exists := qm.queues[kind]
+	if !exists {
+		// Get per-kind config or use defaults
+		kcfg, ok := qm.cfg.KindQueues[kind]
+		queueLen := qm.cfg.DefaultQueueLength
+		workerCount := qm.cfg.DefaultWorkerCount
+		maxObjectSize := qm.cfg.DefaultMaxObjectSize
+		if ok {
+			if kcfg.QueueLength > 0 {
+				queueLen = kcfg.QueueLength
+			}
+			if kcfg.WorkerCount > 0 {
+				workerCount = kcfg.WorkerCount
+			}
+			if kcfg.MaxObjectSize > 0 {
+				maxObjectSize = kcfg.MaxObjectSize
+			}
+		}
+		queue := make(chan *queuedRequest, queueLen)
+		pool, _ := ants.NewPool(workerCount)
+		q = &kindQueue{
+			queue:         queue,
+			pool:          pool,
+			maxObjectSize: maxObjectSize,
+		}
+		logger.L().Info("queue configuration", helpers.String("kind", kind), helpers.Int("queueLength", queueLen), helpers.Int("workerCount", workerCount), helpers.Int("maxObjectSize", maxObjectSize))
+		// Start a dispatcher goroutine for this kind
+		go func(q *kindQueue) {
+			for req := range q.queue {
+				reqLocal := req // capture loop variable
+				err := q.pool.Submit(func() {
+					select {
+					case <-reqLocal.r.Context().Done():
+						// Client has gone away, do not process
+						close(reqLocal.done)
+						return
+					default:
+						// Still active, process
+						reqLocal.next.ServeHTTP(reqLocal.w, reqLocal.r)
+						close(reqLocal.done)
+						return
+					}
+				})
+				if err != nil {
+					logger.L().Error("failed to submit to worker pool", helpers.Error(err), helpers.String("path", reqLocal.r.URL.Path), helpers.String("kind", kind), helpers.String("verb", reqLocal.r.Method), helpers.String("kind", kind))
+					close(reqLocal.done)
+				}
+			}
+		}(q)
+		qm.queues[kind] = q
+	}
+	return q
+}
+
+func extractKindAndVerb(r *http.Request) (kind, verb string) {
+	reqInfo, ok := request.RequestInfoFrom(r.Context())
+	if ok {
+		return reqInfo.Resource, reqInfo.Verb
+	}
+	// fallback:
+	return extractKindAndVerbFromPath(r)
+}
+
+func extractKindAndVerbFromPath(r *http.Request) (kind, verb string) {
+	// Example: /apis/spdx.softwarecomposition.kubescape.io/v1beta1/namespaces/foo/configurationscansummaries
+	//          /apis/spdx.softwarecomposition.kubescape.io/v1beta1/namespaces/default/applicationprofiles
+	path := r.URL.Path
+	if strings.HasPrefix(path, "/apis/spdx.softwarecomposition.kubescape.io/v1beta1/") {
+		parts := strings.Split(path[1:], "/")
+		// Look for "namespaces" in the path
+		for i, part := range parts {
+			if part == "namespaces" && i+2 < len(parts) {
+				// The kind is after the namespace name
+				return parts[i+2], r.Method
+			}
+		}
+		// If "namespaces" is not present, fallback to the current logic
+		if len(parts) >= 4 && parts[3] != "" {
+			return parts[3], r.Method
+		}
+	}
+	return "unknown", r.Method
+}
+
+func (qm *QueueManager) QueueHandler(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		kind, verb := extractKindAndVerb(r)
+		if kind == "unknown" || r.URL.Query().Get("watch") == "true" || r.URL.Query().Get("list") == "true" || r.URL.Query().Get("follow") == "true" ||
+			strings.HasSuffix(r.URL.Path, "/portforward") || strings.HasSuffix(r.URL.Path, "/exec") {
+			// Skip queue for watch, list, follow, portforward, exec, or unknown kind
+			// These requests should not take up queue workers - they are not designed to be memory intensive (taking only metadata)
+			// Unknown cannot be assigned to a queue
+			next.ServeHTTP(w, r)
+			return
+		}
+		q := qm.getOrCreateQueue(kind)
+		// Enforce max object size if applicable (Content-Length header)
+		if q.maxObjectSize > 0 && r.ContentLength > int64(q.maxObjectSize) {
+			http.Error(w, "Request entity too large", http.StatusRequestEntityTooLarge)
+			return
+		}
+		req := &queuedRequest{
+			w:    w,
+			r:    r,
+			next: next,
+			done: make(chan struct{}),
+		}
+		select {
+		case q.queue <- req:
+			<-req.done
+		default:
+			qm.logQueueFullThrottled(kind, verb)
+			http.Error(w, "Too Many Requests (queue full)", http.StatusTooManyRequests)
+		}
+	})
+}
+
+func (qm *QueueManager) logQueueFullThrottled(kind, verb string) {
+	qm.mu.Lock()
+	lastLog, ok := qm.lastQueueFullLog[kind]
+	qm.mu.Unlock()
+	if !ok || time.Since(lastLog) > 1*time.Minute {
+		logger.L().Warning("queue full for resource", helpers.String("kind", kind), helpers.String("verb", verb), helpers.String("queue", "default"))
+		qm.mu.Lock()
+		qm.lastQueueFullLog[kind] = time.Now()
+		qm.mu.Unlock()
+	}
+}
+
+// TimeoutLoggerMiddleware logs a warning if a request takes longer than timeoutSeconds seconds to finish.
+func TimeoutLoggerMiddleware(next http.Handler, timeoutSeconds int) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("watch") == "true" || r.URL.Query().Get("list") == "true" || r.URL.Query().Get("follow") == "true" ||
+			strings.HasSuffix(r.URL.Path, "/portforward") || strings.HasSuffix(r.URL.Path, "/exec") {
+			next.ServeHTTP(w, r)
+			return
+		}
+		done := make(chan struct{})
+		go func() {
+			select {
+			case <-done:
+				// Request finished in time
+			case <-time.After(time.Duration(timeoutSeconds) * time.Second):
+				logger.L().Warning("Request took longer than timeout", helpers.String("path", r.URL.Path), helpers.String("method", r.Method), helpers.String("query", r.URL.RawQuery), helpers.String("remote", r.RemoteAddr))
+			}
+		}()
+		next.ServeHTTP(w, r)
+		close(done)
+	})
+}
+
+// Example usage (wrap your main handler or router):
+// http.Handle("/", TimeoutLoggerMiddleware(qm.QueueHandler(yourHandler)))

--- a/pkg/queuemanager/manager_test.go
+++ b/pkg/queuemanager/manager_test.go
@@ -1,0 +1,70 @@
+package queuemanager
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractKindAndVerbFromPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		url      string
+		method   string
+		wantKind string
+		wantVerb string
+	}{
+		{
+			name:     "With namespaces in path",
+			url:      "/apis/spdx.softwarecomposition.kubescape.io/v1beta1/namespaces/foo/configurationscansummaries",
+			method:   "GET",
+			wantKind: "configurationscansummaries",
+			wantVerb: "GET",
+		},
+		{
+			name:     "With namespaces and different kind",
+			url:      "/apis/spdx.softwarecomposition.kubescape.io/v1beta1/namespaces/default/applicationprofiles",
+			method:   "POST",
+			wantKind: "applicationprofiles",
+			wantVerb: "POST",
+		},
+		{
+			name:     "Without namespaces, fallback to 4th part",
+			url:      "/apis/spdx.softwarecomposition.kubescape.io/v1beta1/sbomsyfts",
+			method:   "PUT",
+			wantKind: "sbomsyfts",
+			wantVerb: "PUT",
+		},
+		{
+			name:     "Short path, fallback to unknown",
+			url:      "/foo/bar",
+			method:   "PATCH",
+			wantKind: "unknown",
+			wantVerb: "PATCH",
+		},
+		{
+			name:     "Path with only prefix",
+			url:      "/apis/spdx.softwarecomposition.kubescape.io/v1beta1/",
+			method:   "DELETE",
+			wantKind: "unknown",
+			wantVerb: "DELETE",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(tt.method, tt.url, nil)
+			kind, verb := extractKindAndVerbFromPath(req)
+			assert.Equal(t, tt.wantKind, kind)
+			assert.Equal(t, tt.wantVerb, verb)
+		})
+	}
+}
+
+func TestExtractKindAndVerb_Fallback(t *testing.T) {
+	req := httptest.NewRequest("GET", "/foo/bar", nil)
+	kind, verb := extractKindAndVerb(req)
+	assert.Equal(t, "unknown", kind)
+	assert.Equal(t, "GET", verb)
+}

--- a/pkg/statscollector/collector.go
+++ b/pkg/statscollector/collector.go
@@ -1,0 +1,110 @@
+package statscollector
+
+import (
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"k8s.io/apiserver/pkg/endpoints/request"
+)
+
+type Stats struct {
+	Min   time.Duration
+	Max   time.Duration
+	Sum   time.Duration
+	Count int64
+}
+
+type key struct {
+	Kind string
+	Verb string
+}
+
+type StatsCollector struct {
+	mu    sync.RWMutex
+	stats map[key]*Stats
+}
+
+func NewStatsCollector() *StatsCollector {
+	return &StatsCollector{
+		stats: make(map[key]*Stats),
+	}
+}
+
+// GetStats returns a snapshot of the current statistics. If reset is true, statistics are cleared after reading.
+func (sc *StatsCollector) GetStats(reset bool) map[string]map[string]Stats {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+	result := make(map[string]map[string]Stats)
+	for k, v := range sc.stats {
+		if _, ok := result[k.Kind]; !ok {
+			result[k.Kind] = make(map[string]Stats)
+		}
+		// Copy the struct to avoid race
+		result[k.Kind][k.Verb] = *v
+	}
+	if reset {
+		sc.stats = make(map[key]*Stats)
+	}
+	return result
+}
+
+// Handler returns a middleware that collects timing statistics for the downstream handler chain.
+// It should be attached as close as possible to the actual API logic in the handler chain
+// to measure only the core API logic execution time (excluding upstream middleware).
+func (sc *StatsCollector) Handler(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		kind, verb := extractKindAndVerb(r)
+		start := time.Now()
+		next.ServeHTTP(w, r)
+		elapsed := time.Since(start)
+
+		k := key{Kind: kind, Verb: verb}
+		sc.mu.Lock()
+		s, ok := sc.stats[k]
+		if !ok {
+			s = &Stats{Min: elapsed, Max: elapsed, Sum: elapsed, Count: 1}
+			sc.stats[k] = s
+		} else {
+			if elapsed < s.Min {
+				s.Min = elapsed
+			}
+			if elapsed > s.Max {
+				s.Max = elapsed
+			}
+			s.Sum += elapsed
+			s.Count++
+		}
+		sc.mu.Unlock()
+	})
+}
+
+func extractKindAndVerb(r *http.Request) (kind, verb string) {
+	reqInfo, ok := request.RequestInfoFrom(r.Context())
+	if ok {
+		return reqInfo.Resource, reqInfo.Verb
+	}
+	// fallback:
+	return extractKindAndVerbFromPath(r)
+}
+
+func extractKindAndVerbFromPath(r *http.Request) (kind, verb string) {
+	// Example: /apis/spdx.softwarecomposition.kubescape.io/v1beta1/namespaces/foo/configurationscansummaries
+	path := r.URL.Path
+	if strings.HasPrefix(path, "/apis/spdx.softwarecomposition.kubescape.io/v1beta1/") {
+		parts := strings.Split(path[1:], "/")
+		// Look for "namespaces" in the path
+		for i, part := range parts {
+			if part == "namespaces" && i+2 < len(parts) {
+				// The kind is after the namespace name
+				return parts[i+2], r.Method
+			}
+		}
+		// If "namespaces" is not present, fallback to the current logic
+		if len(parts) >= 4 {
+			return parts[3], r.Method
+		}
+	}
+	return "unknown", r.Method
+}


### PR DESCRIPTION
This pull request introduces a queue management system for handling API requests with configurable queue lengths, worker counts, and maximum object sizes. It includes significant changes across multiple files to implement the new `QueueManager` and integrate it into the server configuration. The key changes are grouped below by theme:

### Queue Management Implementation:
* Added a new `QueueManager` in `pkg/queuemanager/manager.go` to manage per-kind request queues with configurable parameters like queue length, worker count, and maximum object size. It includes logic for request handling, queue creation, and throttling when queues are full.

### Configuration Updates:
* Updated `pkg/config/config.go` to include new configuration fields (`KindQueues`, `DefaultQueueLength`, `DefaultWorkerCount`, `DefaultMaxObjectSize`) and their corresponding default values. Added a new `KindQueueConfig` struct to represent per-kind configurations. [[1]](diffhunk://#diff-a3d824da3c42420cd5cbb0a4a2c0e7b5bfddd819652788a0596d195dc6e31fa5R9-R14) [[2]](diffhunk://#diff-a3d824da3c42420cd5cbb0a4a2c0e7b5bfddd819652788a0596d195dc6e31fa5R28-R33) [[3]](diffhunk://#diff-a3d824da3c42420cd5cbb0a4a2c0e7b5bfddd819652788a0596d195dc6e31fa5R48-R50)
* Added a new `queue-configuration.json` file to define default and per-kind queue configurations.

### Integration with Server:
* Modified `pkg/cmd/server/start.go` to integrate the `QueueManager` into the server's request handling chain by setting `BuildHandlerChainFunc` in the server configuration.
* Added the `queuemanager` package to the imports in `pkg/cmd/server/start.go`.

### Dependency Addition:
* Added the `github.com/panjf2000/ants/v2` library to `go.mod` for managing worker pools in the `QueueManager`.