### PR TITLE
Integration test suite

### DIFF
--- a/.github/workflows/manual-integration-tests.yml
+++ b/.github/workflows/manual-integration-tests.yml
@@ -117,6 +117,19 @@ jobs:
             fi
             echo "| $testname | $status |" >> $GITHUB_STEP_SUMMARY
           done
+      - name: Save Kubescape logs
+        run: |
+          mkdir -p kubescape-logs
+          for pod in $(kubectl get pods -n kubescape -o jsonpath='{.items[*].metadata.name}'); do
+            echo "Saving logs for pod: $pod"
+            kubectl logs -n kubescape $pod --all-containers > "kubescape-logs/$pod.log" || true
+          done
+
+      - name: Upload Kubescape logs
+        uses: actions/upload-artifact@v4
+        with:
+          name: kubescape-logs
+          path: kubescape-logs/
 
       - name: Upload JUnit test results
         uses: actions/upload-artifact@v4

--- a/tests/integration-test-suite/README.md
+++ b/tests/integration-test-suite/README.md
@@ -7,5 +7,5 @@ This directory contains the integration test suite for the Kubescape Storage pro
 To run the tests, use the following command:
 
 ```bash
-go test -v -timeout 30m -run IntegrationTestSuite/TestSimpleProfileStorageFailover -- --update-if-present --extra-helm-set-args "storage.image.repository=quay.io/matthiasb_1/storage,storage.image.tag=containerprofile@sha256:c2c22c18cdeb2479efb5390f5e11df54985737734e125c0d2aeb9c4d26ea0bc8,nodeAge.image.tag=test-4447cfd,capabilities.networkEventsStreaming=disable"c0d2aeb9c4d26ea0bc8,nodeAgent.image.tag=test-4447cfd,capabilities.networkEventsStreaming=disable"
+go test -v -timeout 30m -run IntegrationTestSuite/TestSimpleProfileCreate -- --update-if-present --extra-helm-set-args "storage.image.repository=quay.io/matthiasb_1/storage,storage.image.tag=containerprofile,nodeAgent.image.tag=test-cp-6,capabilities.networkEventsStreaming=disable"
 ```

--- a/tests/integration-test-suite/case_init_container_profile_create_test.go
+++ b/tests/integration-test-suite/case_init_container_profile_create_test.go
@@ -76,7 +76,7 @@ The profile should be complete after the main container's learning period finish
 	// Verify init container is in the profile
 	s.LogWithTimestamp("Verifying init container is in the profile")
 	initContainerFound := false
-	for _, container := range applicationProfile.Spec.Containers {
+	for _, container := range applicationProfile.Spec.InitContainers {
 		if container.Name == "init-sleep" {
 			initContainerFound = true
 			break

--- a/tests/integration-test-suite/case_init_sidecar_profile_create_test.go
+++ b/tests/integration-test-suite/case_init_sidecar_profile_create_test.go
@@ -83,11 +83,13 @@ The profile should be complete after the learning period finishes and include bo
 	// Verify both containers are in the profile
 	s.LogWithTimestamp("Verifying both containers are in the profile")
 	nginxFound := false
-	sidecarFound := false
 	for _, container := range applicationProfile.Spec.Containers {
 		if container.Name == "nginx" {
 			nginxFound = true
 		}
+	}
+	sidecarFound := false
+	for _, container := range applicationProfile.Spec.InitContainers {
 		if container.Name == "sidecar" {
 			sidecarFound = true
 		}


### PR DESCRIPTION
This pull request introduces changes to improve the integration test suite for Kubescape Storage and enhance logging capabilities during manual integration tests. The most important changes include adding functionality to save and upload Kubescape logs, updating the test suite commands and logic, and refining container profile verification.

### Enhancements to logging in manual integration tests:
* [`.github/workflows/manual-integration-tests.yml`](diffhunk://#diff-f491365eb428f46a049821dd3ee2236cb6953c7eedad085278de7a328a5dd552R120-R132): Added steps to save logs for all Kubescape pods and upload them as artifacts for debugging purposes.

### Updates to the integration test suite:
* [`tests/integration-test-suite/README.md`](diffhunk://#diff-d89f1419035673861276794ad300adce1230641afc24c6f373ebc0d31f8c5300L10-R10): Updated the example command to run the integration test suite with a new test case (`TestSimpleProfileCreate`) and modified Helm set arguments for storage and node agent images.
* [`tests/integration-test-suite/case_init_container_profile_create_test.go`](diffhunk://#diff-df40a87f68934b672bee481acccfacac6d34741536efd24cc42c63ebe39a8388L79-R79): Changed the verification logic to check for init containers instead of regular containers in the application profile.
* [`tests/integration-test-suite/case_init_sidecar_profile_create_test.go`](diffhunk://#diff-be2a580f4f0456f72bfd65348bc432c637d86e2ba54b6b5d3ae9bd8da4e4fb15L86-R92): Refactored the verification logic to separately check for containers and init containers, ensuring both are correctly identified in the application profile.