### PR TITLE
move "get cp object" message to debug in NN storage

### DIFF
--- a/pkg/registry/file/networkneighborhood_storage.go
+++ b/pkg/registry/file/networkneighborhood_storage.go
@@ -57,7 +57,7 @@ func (a NetworkNeighborhoodStorage) Get(ctx context.Context, key string, opts st
 		for cpKey := range nn.Parts {
 			cp := &softwarecomposition.ContainerProfile{}
 			if err := a.realStore.Get(ctx, cpKey, opts, cp); err != nil {
-				logger.L().Warning("NetworkNeighborhoodStorage.Get - get cp object", loggerhelpers.Error(err))
+				logger.L().Debug("NetworkNeighborhoodStorage.Get - get cp object", loggerhelpers.Error(err))
 				return nil
 			}
 			matchLabels = utils.MergeMaps(matchLabels, cp.Spec.MatchLabels)


### PR DESCRIPTION
it was already in debug for AP