### PR TITLE
Initialize sbomSet when nil instead of error

### DIFF
--- a/pkg/registry/file/dynamicpathdetector/analyze_opens.go
+++ b/pkg/registry/file/dynamicpathdetector/analyze_opens.go
@@ -1,7 +1,6 @@
 package dynamicpathdetector
 
 import (
-	"errors"
 	"maps"
 	"slices"
 	"strings"
@@ -16,7 +15,7 @@ func AnalyzeOpens(opens []types.OpenCalls, analyzer *PathAnalyzer, sbomSet mapse
 	}
 
 	if sbomSet == nil {
-		return nil, errors.New("sbomSet is nil")
+		sbomSet = mapset.NewThreadUnsafeSet[string]()
 	}
 
 	dynamicOpens := make(map[string]types.OpenCalls)


### PR DESCRIPTION
Fixes #304 
This is safe to do after ensuring https://github.com/kubescape/kubevuln/pull/339

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error resilience by gracefully initializing default values instead of returning errors in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->