### PR TITLE
added cloudAccountIdentifier and region to host key

### DIFF
--- a/pkg/registry/file/sqlite.go
+++ b/pkg/registry/file/sqlite.go
@@ -73,8 +73,8 @@ func ECSKeysToPath(prefix, root, kind, cluster, cloudAccountIdentifier, region, 
 	return fmt.Sprintf("%s/%s/%s/%s/%s/%s/%s", prefix, root, kind, cluster, cloudAccountIdentifier, region, name)
 }
 
-func HostKeysToPath(prefix, root, kind, hostID, name string) string {
-	return fmt.Sprintf("%s/%s/%s/%s/%s", prefix, root, kind, hostID, name)
+func HostKeysToPath(prefix, root, kind, hostID, cloudAccountIdentifier, region, name string) string {
+	return fmt.Sprintf("%s/%s/%s/%s/%s/%s/%s", prefix, root, kind, hostID, cloudAccountIdentifier, region, name)
 }
 
 func K8sPathToKeys(path string) (string, string, string, string, string, string) {
@@ -103,7 +103,7 @@ func BuildContainerProfileKey(id armotypes.ProfileIdentifier, kind string) strin
 	case armotypes.HostTypeKubernetes, "":
 		return K8sKeysToPath("", softwarecomposition.GroupName, kind, id.Cluster, id.Namespace, id.Name)
 	default:
-		return HostKeysToPath("", softwarecomposition.GroupName, kind, id.HostID, id.Name)
+		return HostKeysToPath("", softwarecomposition.GroupName, kind, id.HostID, id.CloudAccountIdentifier, id.Region, id.Name)
 	}
 }
 
@@ -150,11 +150,13 @@ func ParseContainerProfileKey(key string, hostType armotypes.HostType) (id armot
 			id.HostType = armotypes.HostTypeKubernetes
 		}
 	default:
-		if len(parts) < 5 {
-			return id, prefix, root, kind, fmt.Errorf("invalid Host key format: expected 5 parts, got %d", len(parts))
+		if len(parts) < 7 {
+			return id, prefix, root, kind, fmt.Errorf("invalid Host key format: expected 7 parts, got %d", len(parts))
 		}
 		id.HostID = parts[3]
-		id.Name = parts[4]
+		id.CloudAccountIdentifier = parts[4]
+		id.Region = parts[5]
+		id.Name = parts[6]
 	}
 	return id, prefix, root, kind, nil
 }


### PR DESCRIPTION
Sorry, we do not accept changes directly against this repository. Please see
CONTRIBUTING.md for information on where and how to contribute instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Registry storage keys expanded to include cloud account identifier and region for improved multi-cloud organization.
  * Default host entries now populate and validate the additional cloud account and region fields when reading and writing stored keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->