### PR TITLE
fix: restore HostTypeEksEc2 — accidentally removed in #310

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -135,6 +135,7 @@ func LoadConfig(path string) (Config, error) {
 		armotypes.HostTypeDoks,
 		armotypes.HostTypeDroplet,
 		armotypes.HostTypeEc2,
+		armotypes.HostTypeEksEc2,
 		armotypes.HostTypeEksFargate,
 		armotypes.HostTypeGce,
 		armotypes.HostTypeGke,


### PR DESCRIPTION
## Summary
`HostTypeEksEc2` was accidentally removed alongside `HostTypeEcsService`/`HostTypeEcsTask` in #310. Only the latter two were deleted from armoapi-go — `HostTypeEksEc2` still exists and is a valid host type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * EksEc2 host type configuration is now supported. Previously, configurations specifying this host type would fail with an unsupported error; they now process correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->