### PR TITLE
fix(cleanup): enhance pod deletion logic and add tests for standalone pods

### DIFF
--- a/pkg/registry/file/cleanup.go
+++ b/pkg/registry/file/cleanup.go
@@ -253,13 +253,17 @@ func deleteByImageId(_, _ string, metadata *metav1.ObjectMeta, resourceMaps Reso
 func deleteByWlid(_, _ string, metadata *metav1.ObjectMeta, resourceMaps ResourceMaps) bool {
 	wlid, ok := metadata.Annotations[helpersv1.WlidMetadataKey]
 	kind := strings.ToLower(wlidPkg.GetKindFromWlid(wlid))
-	if !Workloads.Contains(kind) {
+	if !isCleanableWlidKind(kind) {
 		if kind != "" {
 			logger.L().Debug("skipping unknown kind", helpers.String("kind", kind))
 		}
 		return false
 	}
 	return !ok || !resourceMaps.RunningWlidsToContainerNames.Has(wlidWithoutClusterName(wlid))
+}
+
+func isCleanableWlidKind(kind string) bool {
+	return kind == "pod" || Workloads.Contains(kind)
 }
 
 func deleteByImageIdOrInstanceId(_, _ string, metadata *metav1.ObjectMeta, resourceMaps ResourceMaps) bool {

--- a/pkg/registry/file/cleanup_test.go
+++ b/pkg/registry/file/cleanup_test.go
@@ -16,9 +16,11 @@ import (
 
 	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/goradd/maps"
+	helpersv1 "github.com/kubescape/k8s-interface/instanceidhandler/v1/helpers"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"zombiezen.com/go/sqlite"
 )
 
@@ -78,6 +80,43 @@ func TestCleanupTask(t *testing.T) {
 	slices.Sort(filesDeleted)
 
 	assert.Equal(t, expectedFilesToDelete, filesDeleted)
+}
+
+func TestDeleteByTemplateHashOrWlidStandalonePod(t *testing.T) {
+	t.Run("deletes pod scoped profile when pod is gone", func(t *testing.T) {
+		metadata := &metav1.ObjectMeta{
+			Labels: map[string]string{
+				helpersv1.RelatedKindMetadataKey: "Pod",
+			},
+			Annotations: map[string]string{
+				helpersv1.WlidMetadataKey: "wlid://cluster-kind-kind/namespace-default/pod-airbyte-worker",
+			},
+		}
+		resourceMaps := ResourceMaps{
+			RunningTemplateHash:          mapset.NewSet[string](),
+			RunningWlidsToContainerNames: new(maps.SafeMap[string, mapset.Set[string]]),
+		}
+
+		assert.True(t, deleteByTemplateHashOrWlid("", "", metadata, resourceMaps))
+	})
+
+	t.Run("keeps pod scoped profile while pod is running", func(t *testing.T) {
+		metadata := &metav1.ObjectMeta{
+			Labels: map[string]string{
+				helpersv1.RelatedKindMetadataKey: "Pod",
+			},
+			Annotations: map[string]string{
+				helpersv1.WlidMetadataKey: "wlid://cluster-kind-kind/namespace-default/pod-airbyte-worker",
+			},
+		}
+		resourceMaps := ResourceMaps{
+			RunningTemplateHash:          mapset.NewSet[string](),
+			RunningWlidsToContainerNames: new(maps.SafeMap[string, mapset.Set[string]]),
+		}
+		resourceMaps.RunningWlidsToContainerNames.Set("namespace-default/pod-airbyte-worker", mapset.NewSet[string]("main"))
+
+		assert.False(t, deleteByTemplateHashOrWlid("", "", metadata, resourceMaps))
+	})
 }
 
 type ResourcesFetchMock struct {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup operations to properly handle pod-based workloads as cleanable resource types. Pods are now correctly processed during cleanup cycles, ensuring orphaned pod profiles are appropriately removed.

* **Tests**
  * Added tests validating pod cleanup behavior in standalone scenarios, confirming proper profile removal and retention across different workload configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->