### PR TITLE
disable WatchList flag until we support it

### DIFF
--- a/pkg/cmd/server/start.go
+++ b/pkg/cmd/server/start.go
@@ -140,7 +140,8 @@ func NewCommandStartWardleServer(ctx context.Context, defaults *WardleServerOpti
 				return err
 			}
 			flags := cmd.Flags()
-			if err := flags.Set("feature-gates", "ServerSideApply=false"); err != nil {
+			// WatchList not yet implemented in the file-based storage backend, see https://github.com/kubescape/storage/issues/320
+			if err := flags.Set("feature-gates", "ServerSideApply=false,WatchList=false"); err != nil {
 				return err
 			}
 			return nil


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled the WatchList feature in the file-based storage backend to prevent compatibility issues; the server startup now ensures WatchList remains off (ServerSideApply also remains disabled). A comment clarifies WatchList is not yet supported in file-based storage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/storage/pull/321)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->