### PR TITLE
allowing wildcards in exec args

### DIFF
--- a/pkg/apis/softwarecomposition/types.go
+++ b/pkg/apis/softwarecomposition/types.go
@@ -253,6 +253,13 @@ type ExecCalls struct {
 	Path string
 	Args []string
 	Envs []string
+	// ArgsRequired declares the intent of Args explicitly. When false
+	// (default and the back-compat path) the Args vector is informational
+	// and CompareExecArgs's empty-bypass applies. When true the Args vector
+	// is a strict constraint enforced by MatchExecArgs — an empty Args
+	// means "argv MUST be empty"; a non-empty Args is matched anchored
+	// (wildcard tokens still apply).
+	ArgsRequired bool
 }
 
 const sep = "␟"

--- a/pkg/apis/softwarecomposition/v1beta1/execcalls_protobuf_test.go
+++ b/pkg/apis/softwarecomposition/v1beta1/execcalls_protobuf_test.go
@@ -1,0 +1,114 @@
+package v1beta1
+
+import (
+	"testing"
+)
+
+// TestExecCalls_ArgsRequired_ProtobufRoundtrip pins the wire-contract for
+// the new ArgsRequired field. The codec hand-edits in generated.pb.go
+// (MarshalToSizedBuffer / Size / Unmarshal / String) were not run through
+// go-to-protobuf because the protoc image is x86_64-only and we are on
+// aarch64 (see README §"Changes to the Types"). This test makes sure the
+// hand-edit is wire-compatible by round-tripping all four ArgsRequired/Args
+// combinations through the gogoproto codec.
+func TestExecCalls_ArgsRequired_ProtobufRoundtrip(t *testing.T) {
+	cases := []struct {
+		name string
+		in   ExecCalls
+	}{
+		{
+			name: "ArgsRequired=false (default), Args nil",
+			in:   ExecCalls{Path: "/bin/ls"},
+		},
+		{
+			name: "ArgsRequired=false, Args populated",
+			in:   ExecCalls{Path: "/bin/sh", Args: []string{"-c", "echo"}},
+		},
+		{
+			name: "ArgsRequired=true, Args empty (the new expressible state)",
+			in:   ExecCalls{Path: "/usr/bin/true", Args: []string{}, ArgsRequired: true},
+		},
+		{
+			name: "ArgsRequired=true, Args populated",
+			in:   ExecCalls{Path: "/bin/sh", Args: []string{"-c", "*"}, ArgsRequired: true},
+		},
+		{
+			name: "ArgsRequired=true, Envs populated, Args nil",
+			in:   ExecCalls{Path: "/bin/sh", Envs: []string{"FOO=bar"}, ArgsRequired: true},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			wire, err := tc.in.Marshal()
+			if err != nil {
+				t.Fatalf("Marshal: %v", err)
+			}
+			var out ExecCalls
+			if err := out.Unmarshal(wire); err != nil {
+				t.Fatalf("Unmarshal: %v", err)
+			}
+			if out.Path != tc.in.Path {
+				t.Errorf("Path: got %q, want %q", out.Path, tc.in.Path)
+			}
+			if !stringSlicesEqual(out.Args, tc.in.Args) {
+				t.Errorf("Args: got %v, want %v", out.Args, tc.in.Args)
+			}
+			if !stringSlicesEqual(out.Envs, tc.in.Envs) {
+				t.Errorf("Envs: got %v, want %v", out.Envs, tc.in.Envs)
+			}
+			if out.ArgsRequired != tc.in.ArgsRequired {
+				t.Errorf("ArgsRequired: got %v, want %v (the entire point of this test)", out.ArgsRequired, tc.in.ArgsRequired)
+			}
+
+			// Size must match the actual marshaled length.
+			if got, want := tc.in.Size(), len(wire); got != want {
+				t.Errorf("Size() = %d, but Marshal produced %d bytes", got, want)
+			}
+		})
+	}
+}
+
+// TestExecCalls_ArgsRequired_ProtobufFieldNumber pins the field number
+// chosen for ArgsRequired (field 4, wire-type 0 = varint). The wire tag
+// byte for field=4, wire-type=0 is (4 << 3) | 0 = 0x20. Catching a tag
+// drift here avoids a silent breaking change for downstream protobuf
+// consumers compiling against generated.proto.
+func TestExecCalls_ArgsRequired_ProtobufFieldNumber(t *testing.T) {
+	in := ExecCalls{ArgsRequired: true}
+	wire, err := in.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	// Codec writes field 1 (Path tag 0xa, len 0), then ArgsRequired
+	// (tag 0x20, value 0x01). Find the 0x20 tag and verify the next byte
+	// is the bool value (0x01 for true).
+	found := false
+	for i := 0; i < len(wire)-1; i++ {
+		if wire[i] == 0x20 {
+			if wire[i+1] != 0x01 {
+				t.Errorf("ArgsRequired wire value at offset %d: got 0x%02x, want 0x01 (true)", i+1, wire[i+1])
+			}
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("did not find tag 0x20 (field=4 varint) in wire bytes: %x", wire)
+	}
+}
+
+func stringSlicesEqual(a, b []string) bool {
+	if len(a) == 0 && len(b) == 0 {
+		return true // nil == [] for protobuf-roundtrip purposes
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/apis/softwarecomposition/v1beta1/generated.pb.go
+++ b/pkg/apis/softwarecomposition/v1beta1/generated.pb.go
@@ -1935,6 +1935,14 @@ func (m *ExecCalls) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
+	i--
+	if m.ArgsRequired {
+		dAtA[i] = 1
+	} else {
+		dAtA[i] = 0
+	}
+	i--
+	dAtA[i] = 0x20
 	if len(m.Envs) > 0 {
 		for iNdEx := len(m.Envs) - 1; iNdEx >= 0; iNdEx-- {
 			i -= len(m.Envs[iNdEx])
@@ -9406,6 +9414,7 @@ func (m *ExecCalls) Size() (n int) {
 			n += 1 + l + sovGenerated(uint64(l))
 		}
 	}
+	n += 2
 	return n
 }
 
@@ -12455,6 +12464,7 @@ func (this *ExecCalls) String() string {
 		`Path:` + fmt.Sprintf("%v", this.Path) + `,`,
 		`Args:` + fmt.Sprintf("%v", this.Args) + `,`,
 		`Envs:` + fmt.Sprintf("%v", this.Envs) + `,`,
+		`ArgsRequired:` + fmt.Sprintf("%v", this.ArgsRequired) + `,`,
 		`}`,
 	}, "")
 	return s
@@ -19325,6 +19335,26 @@ func (m *ExecCalls) Unmarshal(dAtA []byte) error {
 			}
 			m.Envs = append(m.Envs, string(dAtA[iNdEx:postIndex]))
 			iNdEx = postIndex
+		case 4:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ArgsRequired", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.ArgsRequired = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := skipGenerated(dAtA[iNdEx:])

--- a/pkg/apis/softwarecomposition/v1beta1/generated.proto
+++ b/pkg/apis/softwarecomposition/v1beta1/generated.proto
@@ -340,6 +340,15 @@ message ExecCalls {
   repeated string args = 2;
 
   repeated string envs = 3;
+
+  // ArgsRequired declares the intent of args explicitly. When false
+  // (default) the args vector is informational and the legacy
+  // CompareExecArgs empty-bypass applies. When true the args vector
+  // is a strict constraint enforced by MatchExecArgs — empty args
+  // means "argv MUST be empty"; non-empty args is matched anchored.
+  // Resolves the args,omitempty / explicit-empty round-trip
+  // ambiguity that CompareExecArgs alone could not express.
+  optional bool argsRequired = 4;
 }
 
 message Executable {

--- a/pkg/apis/softwarecomposition/v1beta1/types.go
+++ b/pkg/apis/softwarecomposition/v1beta1/types.go
@@ -229,6 +229,15 @@ type ExecCalls struct {
 	Path string   `json:"path,omitempty" protobuf:"bytes,1,opt,name=path"`
 	Args []string `json:"args,omitempty" protobuf:"bytes,2,opt,name=args"`
 	Envs []string `json:"envs,omitempty" protobuf:"bytes,3,opt,name=envs"`
+	// ArgsRequired declares the intent of Args explicitly. When false
+	// (default and the back-compat path) the Args vector is informational
+	// and CompareExecArgs's empty-bypass applies. When true the Args
+	// vector is a strict constraint enforced by MatchExecArgs — an empty
+	// Args means "argv MUST be empty"; a non-empty Args is matched
+	// anchored (wildcard tokens still apply). Resolves the
+	// args,omitempty / explicit-empty round-trip ambiguity that
+	// CompareExecArgs alone could not express.
+	ArgsRequired bool `json:"argsRequired,omitempty" protobuf:"varint,4,opt,name=argsRequired"`
 }
 
 type OpenCalls struct {

--- a/pkg/apis/softwarecomposition/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/softwarecomposition/v1beta1/zz_generated.conversion.go
@@ -2468,6 +2468,7 @@ func autoConvert_v1beta1_ExecCalls_To_softwarecomposition_ExecCalls(in *ExecCall
 	out.Path = in.Path
 	out.Args = *(*[]string)(unsafe.Pointer(&in.Args))
 	out.Envs = *(*[]string)(unsafe.Pointer(&in.Envs))
+	out.ArgsRequired = in.ArgsRequired
 	return nil
 }
 
@@ -2480,6 +2481,7 @@ func autoConvert_softwarecomposition_ExecCalls_To_v1beta1_ExecCalls(in *software
 	out.Path = in.Path
 	out.Args = *(*[]string)(unsafe.Pointer(&in.Args))
 	out.Envs = *(*[]string)(unsafe.Pointer(&in.Envs))
+	out.ArgsRequired = in.ArgsRequired
 	return nil
 }
 

--- a/pkg/generated/applyconfiguration/softwarecomposition/v1beta1/execcalls.go
+++ b/pkg/generated/applyconfiguration/softwarecomposition/v1beta1/execcalls.go
@@ -21,9 +21,10 @@ package v1beta1
 // ExecCallsApplyConfiguration represents a declarative configuration of the ExecCalls type for use
 // with apply.
 type ExecCallsApplyConfiguration struct {
-	Path *string  `json:"path,omitempty"`
-	Args []string `json:"args,omitempty"`
-	Envs []string `json:"envs,omitempty"`
+	Path         *string  `json:"path,omitempty"`
+	Args         []string `json:"args,omitempty"`
+	Envs         []string `json:"envs,omitempty"`
+	ArgsRequired *bool    `json:"argsRequired,omitempty"`
 }
 
 // ExecCallsApplyConfiguration constructs a declarative configuration of the ExecCalls type for use with
@@ -57,5 +58,13 @@ func (b *ExecCallsApplyConfiguration) WithEnvs(values ...string) *ExecCallsApply
 	for i := range values {
 		b.Envs = append(b.Envs, values[i])
 	}
+	return b
+}
+
+// WithArgsRequired sets the ArgsRequired field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the ArgsRequired field is set to the value of the last call.
+func (b *ExecCallsApplyConfiguration) WithArgsRequired(value bool) *ExecCallsApplyConfiguration {
+	b.ArgsRequired = &value
 	return b
 }

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -1703,6 +1703,13 @@ func schema_pkg_apis_softwarecomposition_v1beta1_ExecCalls(ref common.ReferenceC
 							},
 						},
 					},
+					"argsRequired": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ArgsRequired declares the intent of Args explicitly. When false (default and the back-compat path) the Args vector is informational and CompareExecArgs's empty-bypass applies. When true the Args vector is a strict constraint enforced by MatchExecArgs — an empty Args means \"argv MUST be empty\"; a non-empty Args is matched anchored (wildcard tokens still apply). Resolves the args,omitempty / explicit-empty round-trip ambiguity that CompareExecArgs alone could not express.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/registry/file/dynamicpathdetector/compare_exec_args.go
+++ b/pkg/registry/file/dynamicpathdetector/compare_exec_args.go
@@ -1,0 +1,95 @@
+package dynamicpathdetector
+
+// CompareExecArgs reports whether a runtime exec argument vector matches a
+// profile argument vector. The profile vector may contain two wildcard
+// tokens:
+//
+//	DynamicIdentifier  ("⋯") — matches exactly one argument position.
+//	WildcardIdentifier ("*") — matches zero or more consecutive arguments.
+//
+// Anything else is a literal-equality match. The match is anchored at both
+// ends: every runtime argument must be consumed by the profile vector,
+// either by a literal, a DynamicIdentifier, or absorbed into a
+// WildcardIdentifier run.
+//
+// Empty profileArgs is treated as "no argv constraint" — i.e. matches any
+// runtime arg vector. This keeps path-only Execs entries (the common case
+// in user-defined ApplicationProfiles, which omit the Args field) from
+// silently triggering R0040 just because the rule started consulting
+// was_executed_with_args. A user that wants to assert "this exec must have
+// no args" can write Args: []string{} in their profile and the empty
+// runtime vector still matches by virtue of the wildcard semantics.
+//
+// Implementation is index-based recursive backtracking with memoisation
+// on (profileIndex, runtimeIndex) state pairs. The naive backtracking
+// form would degrade to exponential time on adversarial inputs like
+// `[*, *, *, …, x]` against a long literal vector — every prefix `*`
+// has multiple split choices and the suffix mismatch only surfaces
+// at the very end, so each path gets re-explored. Memoisation bounds
+// the work at O(len(profile) * len(runtime)) — i.e. quadratic in the
+// vector lengths, the standard wildcard-match complexity. CodeRabbit
+// flagged this as a Major on PR #27.
+func CompareExecArgs(profileArgs, runtimeArgs []string) bool {
+	// Outer-level empty profile = "no argv constraint" — wildcard match.
+	// The inner matcher keeps strict empty-empty semantics so anchoring
+	// during recursion (`profile fully consumed but runtime has more`)
+	// remains a mismatch.
+	if len(profileArgs) == 0 {
+		return true
+	}
+
+	// State key for memoisation: (pi, ri) is the suffix-matching position
+	// in profile and runtime vectors respectively. Because both sides only
+	// shrink (we never re-enter a prefix), there are at most
+	// (len(profile)+1) * (len(runtime)+1) reachable states.
+	type state struct{ pi, ri int }
+	memo := make(map[state]bool, (len(profileArgs)+1)*(len(runtimeArgs)+1))
+	seen := make(map[state]bool, (len(profileArgs)+1)*(len(runtimeArgs)+1))
+
+	var match func(pi, ri int) bool
+	match = func(pi, ri int) bool {
+		s := state{pi: pi, ri: ri}
+		if seen[s] {
+			return memo[s]
+		}
+		seen[s] = true
+
+		// Profile fully consumed → runtime must also be fully consumed
+		// (anchored match).
+		if pi == len(profileArgs) {
+			memo[s] = ri == len(runtimeArgs)
+			return memo[s]
+		}
+
+		head := profileArgs[pi]
+
+		if head == WildcardIdentifier {
+			// Try absorbing 0..(remaining runtime) into this *,
+			// then match the rest. First successful split wins.
+			for k := ri; k <= len(runtimeArgs); k++ {
+				if match(pi+1, k) {
+					memo[s] = true
+					return true
+				}
+			}
+			memo[s] = false
+			return false
+		}
+
+		// Non-wildcard head needs a runtime argument to consume.
+		if ri == len(runtimeArgs) {
+			memo[s] = false
+			return false
+		}
+
+		if head == DynamicIdentifier || head == runtimeArgs[ri] {
+			memo[s] = match(pi+1, ri+1)
+			return memo[s]
+		}
+
+		memo[s] = false
+		return false
+	}
+
+	return match(0, 0)
+}

--- a/pkg/registry/file/dynamicpathdetector/compare_exec_args.go
+++ b/pkg/registry/file/dynamicpathdetector/compare_exec_args.go
@@ -1,5 +1,35 @@
 package dynamicpathdetector
 
+// MatchExecArgs reports whether a runtime exec argument vector satisfies a
+// profile entry's argv contract. argsRequired carries the profile entry's
+// ExecCalls.ArgsRequired flag and disambiguates the two cases that
+// CompareExecArgs alone cannot tell apart:
+//
+//	argsRequired = false → no argv constraint; matches any runtime args.
+//	                       This is the back-compat path for profiles that
+//	                       omit Args (the common case for path-only
+//	                       Execs entries in user-authored profiles).
+//	argsRequired = true  → strict anchored match against profileArgs.
+//	                       An empty profileArgs means "argv MUST be
+//	                       empty"; a non-empty profileArgs is matched
+//	                       anchored with wildcard tokens (see below).
+//
+// This resolves the round-trip ambiguity that v1beta1.ExecCalls.Args
+// (declared `json:",omitempty"`) introduced: an explicit `args: []`
+// round-trips back as nil, so the storage layer alone cannot persist
+// the distinction between "no constraint" and "must have no args".
+// ArgsRequired persists the operator's intent explicitly.
+//
+// The match semantics for argsRequired=true are the anchored-with-
+// wildcards form documented on CompareExecArgs.
+func MatchExecArgs(profileArgs []string, argsRequired bool, runtimeArgs []string) bool {
+	if !argsRequired {
+		// No constraint expressed by the profile entry.
+		return true
+	}
+	return matchExecArgsStrict(profileArgs, runtimeArgs)
+}
+
 // CompareExecArgs reports whether a runtime exec argument vector matches a
 // profile argument vector. The profile vector may contain two wildcard
 // tokens:
@@ -16,9 +46,29 @@ package dynamicpathdetector
 // runtime arg vector. This keeps path-only Execs entries (the common case
 // in user-defined ApplicationProfiles, which omit the Args field) from
 // silently triggering R0040 just because the rule started consulting
-// was_executed_with_args. A user that wants to assert "this exec must have
-// no args" can write Args: []string{} in their profile and the empty
-// runtime vector still matches by virtue of the wildcard semantics.
+// was_executed_with_args.
+//
+// NOTE: callers that need to express "argv MUST be empty" cannot do so
+// through this API alone, because v1beta1.ExecCalls.Args is declared
+// `json:",omitempty"` and an explicit `args: []` round-trips back as
+// nil. Use MatchExecArgs with the profile entry's ArgsRequired flag for
+// that case. CompareExecArgs is preserved for back-compat with callers
+// that have not migrated to the args-required-aware API.
+func CompareExecArgs(profileArgs, runtimeArgs []string) bool {
+	// Outer-level empty profile = "no argv constraint" — wildcard match.
+	// The inner matcher keeps strict empty-empty semantics so anchoring
+	// during recursion (`profile fully consumed but runtime has more`)
+	// remains a mismatch.
+	if len(profileArgs) == 0 {
+		return true
+	}
+	return matchExecArgsStrict(profileArgs, runtimeArgs)
+}
+
+// matchExecArgsStrict is the anchored matcher shared by MatchExecArgs and
+// CompareExecArgs — neither bypass applies; the profile vector is matched
+// position-by-position with wildcard absorption. An empty profileArgs
+// matches only an empty runtimeArgs.
 //
 // Implementation is index-based recursive backtracking with memoisation
 // on (profileIndex, runtimeIndex) state pairs. The naive backtracking
@@ -29,13 +79,10 @@ package dynamicpathdetector
 // the work at O(len(profile) * len(runtime)) — i.e. quadratic in the
 // vector lengths, the standard wildcard-match complexity. CodeRabbit
 // flagged this as a Major on PR #27.
-func CompareExecArgs(profileArgs, runtimeArgs []string) bool {
-	// Outer-level empty profile = "no argv constraint" — wildcard match.
-	// The inner matcher keeps strict empty-empty semantics so anchoring
-	// during recursion (`profile fully consumed but runtime has more`)
-	// remains a mismatch.
+func matchExecArgsStrict(profileArgs, runtimeArgs []string) bool {
+	// Anchored empty-empty case.
 	if len(profileArgs) == 0 {
-		return true
+		return len(runtimeArgs) == 0
 	}
 
 	// State key for memoisation: (pi, ri) is the suffix-matching position

--- a/pkg/registry/file/dynamicpathdetector/tests/compare_exec_args_test.go
+++ b/pkg/registry/file/dynamicpathdetector/tests/compare_exec_args_test.go
@@ -320,3 +320,126 @@ func TestCompareExecArgs_ReDoSResistance(t *testing.T) {
 		t.Errorf("matcher took %v on adversarial input — memoisation regression?", elapsed)
 	}
 }
+
+// TestMatchExecArgs_ContractFourStates pins the four-state contract that
+// ArgsRequired makes expressible (resolves the args,omitempty round-trip
+// ambiguity matthyx blocked on PR #322):
+//
+//   1. ArgsRequired=false, profileArgs=nil  → no constraint (any runtime)
+//   2. ArgsRequired=false, profileArgs=[…]  → no constraint (back-compat)
+//   3. ArgsRequired=true,  profileArgs=[]   → MUST have empty runtime args
+//   4. ArgsRequired=true,  profileArgs=[…]  → strict anchored match
+//
+// State (3) is the case the legacy CompareExecArgs API could not express;
+// MatchExecArgs uses the explicit flag to disambiguate.
+func TestMatchExecArgs_ContractFourStates(t *testing.T) {
+	cases := []struct {
+		name         string
+		profileArgs  []string
+		argsRequired bool
+		runtimeArgs  []string
+		want         bool
+	}{
+		// State 1: ArgsRequired=false, profile nil → no constraint
+		{
+			name: "ArgsRequired=false, profile=nil, runtime=nil → true (no constraint)",
+			argsRequired: false, profileArgs: nil, runtimeArgs: nil, want: true,
+		},
+		{
+			name: "ArgsRequired=false, profile=nil, runtime=non-empty → true (no constraint)",
+			argsRequired: false, profileArgs: nil, runtimeArgs: []string{"foo", "bar"}, want: true,
+		},
+
+		// State 2: ArgsRequired=false, profile populated → no constraint (back-compat)
+		{
+			name: "ArgsRequired=false, profile=[x], runtime=anything → true (back-compat bypass)",
+			argsRequired: false, profileArgs: []string{"x"}, runtimeArgs: []string{"completely", "different"}, want: true,
+		},
+
+		// State 3: ArgsRequired=true, profile=[] → runtime MUST be empty
+		{
+			name: "ArgsRequired=true, profile=[], runtime=[] → true (anchored empty-empty)",
+			argsRequired: true, profileArgs: []string{}, runtimeArgs: []string{}, want: true,
+		},
+		{
+			name: "ArgsRequired=true, profile=[], runtime=nil → true (nil == empty for runtime)",
+			argsRequired: true, profileArgs: []string{}, runtimeArgs: nil, want: true,
+		},
+		{
+			name: "ArgsRequired=true, profile=[], runtime=[x] → false (extra runtime arg)",
+			argsRequired: true, profileArgs: []string{}, runtimeArgs: []string{"x"}, want: false,
+		},
+		{
+			name: "ArgsRequired=true, profile=nil, runtime=[x] → false (anchored, profile vector empty)",
+			argsRequired: true, profileArgs: nil, runtimeArgs: []string{"x"}, want: false,
+		},
+
+		// State 4: ArgsRequired=true, profile populated → strict anchored match
+		{
+			name: "ArgsRequired=true, exact literal match",
+			argsRequired: true, profileArgs: []string{"-c", "echo hi"}, runtimeArgs: []string{"-c", "echo hi"}, want: true,
+		},
+		{
+			name: "ArgsRequired=true, exact literal mismatch",
+			argsRequired: true, profileArgs: []string{"-c", "echo hi"}, runtimeArgs: []string{"-c", "echo bye"}, want: false,
+		},
+		{
+			name: "ArgsRequired=true, trailing wildcard absorbs",
+			argsRequired: true, profileArgs: []string{"-c", "*"}, runtimeArgs: []string{"-c", "echo", "hi"}, want: true,
+		},
+		{
+			name: "ArgsRequired=true, dynamic identifier matches one position",
+			argsRequired: true, profileArgs: []string{"-c", "⋯", "hi"}, runtimeArgs: []string{"-c", "anything", "hi"}, want: true,
+		},
+		{
+			name: "ArgsRequired=true, dynamic identifier requires exactly one — fails on missing",
+			argsRequired: true, profileArgs: []string{"-c", "⋯", "hi"}, runtimeArgs: []string{"-c", "hi"}, want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := dynamicpathdetector.MatchExecArgs(tc.profileArgs, tc.argsRequired, tc.runtimeArgs)
+			if got != tc.want {
+				t.Errorf("MatchExecArgs(%v, argsRequired=%v, %v) = %v, want %v",
+					tc.profileArgs, tc.argsRequired, tc.runtimeArgs, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestMatchExecArgs_BackCompatVsCompareExecArgs proves the back-compat
+// path: MatchExecArgs(args, false, runtime) ≡ CompareExecArgs(args, runtime)
+// for every state where CompareExecArgs has a definite answer. This is
+// the invariant that lets bob (and other callers that haven't migrated
+// to MatchExecArgs) keep using CompareExecArgs without behavioural drift.
+func TestMatchExecArgs_BackCompatVsCompareExecArgs(t *testing.T) {
+	cases := []struct {
+		profile []string
+		runtime []string
+	}{
+		{nil, nil},
+		{nil, []string{"anything"}},
+		{[]string{}, nil},
+		{[]string{"-c", "echo"}, []string{"-c", "echo"}},
+		{[]string{"-c", "echo"}, []string{"-c", "different"}},
+		{[]string{"-c", "*"}, []string{"-c", "a", "b", "c"}},
+		{[]string{"⋯"}, []string{"x"}},
+		{[]string{"⋯"}, []string{}},
+	}
+	for _, c := range cases {
+		oldCompare := dynamicpathdetector.CompareExecArgs(c.profile, c.runtime)
+		// MatchExecArgs with argsRequired=false has the same bypass for empty
+		// profile as CompareExecArgs; for non-empty profile both go via the
+		// shared strict matcher, which gives the same answer too — UNLESS
+		// the profile is non-empty AND the caller passed argsRequired=false
+		// which is "no constraint" → MatchExecArgs returns true. So we test
+		// the CompareExecArgs-equivalent path: argsRequired = (len(profile) > 0).
+		argsRequired := len(c.profile) > 0
+		newMatch := dynamicpathdetector.MatchExecArgs(c.profile, argsRequired, c.runtime)
+		if oldCompare != newMatch {
+			t.Errorf("back-compat mismatch profile=%v runtime=%v: CompareExecArgs=%v, MatchExecArgs(argsRequired=%v)=%v",
+				c.profile, c.runtime, oldCompare, argsRequired, newMatch)
+		}
+	}
+}

--- a/pkg/registry/file/dynamicpathdetector/tests/compare_exec_args_test.go
+++ b/pkg/registry/file/dynamicpathdetector/tests/compare_exec_args_test.go
@@ -1,0 +1,314 @@
+package dynamicpathdetectortests
+
+import (
+	"testing"
+	"time"
+
+	"github.com/kubescape/storage/pkg/registry/file/dynamicpathdetector"
+)
+
+// CompareExecArgs matches a runtime argument vector against a profile
+// argument vector that may contain two wildcard tokens:
+//
+//	"⋯" (DynamicIdentifier)  — matches exactly ONE argument position.
+//	"*" (WildcardIdentifier) — matches ZERO OR MORE consecutive args.
+//
+// Anything else is a literal string match. The match must be exact across
+// the full vectors — extra runtime args after the profile is exhausted (and
+// no trailing wildcard absorbs them) is a non-match.
+
+func TestCompareExecArgs_LiteralMatch(t *testing.T) {
+	cases := []struct {
+		name    string
+		profile []string
+		runtime []string
+		want    bool
+	}{
+		// Empty profileArgs = "no argv constraint" — matches any runtime.
+		// Pinned this way so path-only Execs entries in user-defined
+		// ApplicationProfiles don't silently trigger R0040 when the rule
+		// consults was_executed_with_args. See storage/node-agent issue
+		// where Test_28 (and others using path-only entries) failed because
+		// the strict empty-empty match was firing R0040 on every legit exec.
+		{"both empty", nil, nil, true},
+		{"empty profile, non-empty runtime", nil, []string{"a"}, true},
+		{"empty profile, multi-arg runtime", nil, []string{"a", "b", "c"}, true},
+		{"non-empty profile, empty runtime", []string{"a"}, nil, false},
+		{"single literal match", []string{"--help"}, []string{"--help"}, true},
+		{"single literal mismatch", []string{"--help"}, []string{"--version"}, false},
+		{"profile longer than runtime", []string{"a", "b"}, []string{"a"}, false},
+		{"runtime longer than profile (no wildcard)", []string{"a"}, []string{"a", "b"}, false},
+		{"multi-literal match", []string{"-l", "-a", "/tmp"}, []string{"-l", "-a", "/tmp"}, true},
+		{"multi-literal mismatch in middle", []string{"-l", "-a", "/tmp"}, []string{"-l", "-z", "/tmp"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := dynamicpathdetector.CompareExecArgs(tc.profile, tc.runtime); got != tc.want {
+				t.Errorf("CompareExecArgs(%v, %v) = %v, want %v", tc.profile, tc.runtime, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCompareExecArgs_DynamicIdentifier(t *testing.T) {
+	cases := []struct {
+		name    string
+		profile []string
+		runtime []string
+		want    bool
+	}{
+		{"⋯ matches one arg", []string{"⋯"}, []string{"anything"}, true},
+		{"⋯ does NOT match zero args", []string{"⋯"}, nil, false},
+		{"⋯ does NOT match two args", []string{"⋯"}, []string{"a", "b"}, false},
+		{"⋯ in middle, full vector matches", []string{"--user", "⋯", "--port", "8080"}, []string{"--user", "alice", "--port", "8080"}, true},
+		{"⋯ in middle, surrounding literal mismatch", []string{"--user", "⋯", "--port", "8080"}, []string{"--user", "alice", "--port", "9090"}, false},
+		{"adjacent ⋯⋯ matches exactly two args", []string{"⋯", "⋯"}, []string{"a", "b"}, true},
+		{"adjacent ⋯⋯ rejects one arg", []string{"⋯", "⋯"}, []string{"a"}, false},
+		{"adjacent ⋯⋯ rejects three args", []string{"⋯", "⋯"}, []string{"a", "b", "c"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := dynamicpathdetector.CompareExecArgs(tc.profile, tc.runtime); got != tc.want {
+				t.Errorf("CompareExecArgs(%v, %v) = %v, want %v", tc.profile, tc.runtime, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCompareExecArgs_WildcardIdentifier(t *testing.T) {
+	cases := []struct {
+		name    string
+		profile []string
+		runtime []string
+		want    bool
+	}{
+		{"* matches empty runtime", []string{"*"}, nil, true},
+		{"* matches one arg", []string{"*"}, []string{"a"}, true},
+		{"* matches many args", []string{"*"}, []string{"a", "b", "c", "d"}, true},
+		{"trailing * with prefix match", []string{"-c", "*"}, []string{"-c", "echo hi"}, true},
+		{"trailing * absorbs nothing when runtime exact-prefix length", []string{"-c", "*"}, []string{"-c"}, true},
+		{"trailing * mismatch in literal prefix", []string{"-c", "*"}, []string{"-x", "echo hi"}, false},
+		{"middle * matches and re-anchors on literal", []string{"sh", "*", "exit"}, []string{"sh", "-c", "echo hi", "exit"}, true},
+		{"middle * with literal that does not appear", []string{"sh", "*", "exit"}, []string{"sh", "-c", "echo hi"}, false},
+		{"middle * matches when zero args between anchors", []string{"sh", "*", "exit"}, []string{"sh", "exit"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := dynamicpathdetector.CompareExecArgs(tc.profile, tc.runtime); got != tc.want {
+				t.Errorf("CompareExecArgs(%v, %v) = %v, want %v", tc.profile, tc.runtime, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCompareExecArgs_MixedTokens(t *testing.T) {
+	cases := []struct {
+		name    string
+		profile []string
+		runtime []string
+		want    bool
+	}{
+		{"⋯ then * — needs at least one arg before the *",
+			[]string{"⋯", "*"}, []string{"a"}, true},
+		{"⋯ then * — empty runtime fails (⋯ needs one)",
+			[]string{"⋯", "*"}, nil, false},
+		{"⋯ then * — many args ok",
+			[]string{"⋯", "*"}, []string{"a", "b", "c"}, true},
+		{"* then ⋯ — needs at least one arg for ⋯",
+			[]string{"*", "⋯"}, []string{"x"}, true},
+		{"* then ⋯ — empty runtime fails",
+			[]string{"*", "⋯"}, nil, false},
+		{"literal, ⋯, *  — typical user pattern",
+			[]string{"--user", "⋯", "*"}, []string{"--user", "alice", "--verbose", "--out", "/tmp"}, true},
+		{"literal, ⋯, *  — runtime too short for ⋯",
+			[]string{"--user", "⋯", "*"}, []string{"--user"}, false},
+		{"only ⋯, runtime empty — fails (⋯ requires exactly one)",
+			[]string{"⋯"}, []string{}, false},
+		{"only *, runtime empty — passes",
+			[]string{"*"}, []string{}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := dynamicpathdetector.CompareExecArgs(tc.profile, tc.runtime); got != tc.want {
+				t.Errorf("CompareExecArgs(%v, %v) = %v, want %v", tc.profile, tc.runtime, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCompareExecArgs_RealisticPatterns(t *testing.T) {
+	cases := []struct {
+		name    string
+		profile []string
+		runtime []string
+		want    bool
+	}{
+		{"curl with any URL", []string{"-s", "⋯"}, []string{"-s", "https://example.com"}, true},
+		{"sh -c with any command",
+			[]string{"-c", "*"},
+			[]string{"-c", "while true; do sleep 1; done"},
+			true,
+		},
+		{"echo with any number of words",
+			[]string{"hello", "*"},
+			[]string{"hello", "world", "from", "test"},
+			true,
+		},
+		{"ls -l in arbitrary directory",
+			[]string{"-l", "⋯"},
+			[]string{"-l", "/var/log"},
+			true,
+		},
+		{"ls without args fails wildcard arg pattern",
+			[]string{"-l", "⋯"},
+			[]string{"-l"},
+			false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := dynamicpathdetector.CompareExecArgs(tc.profile, tc.runtime); got != tc.want {
+				t.Errorf("CompareExecArgs(%v, %v) = %v, want %v", tc.profile, tc.runtime, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCompareExecArgs_Argv0BareName pins the convention used by the
+// node-agent recording side: profile.Args includes argv[0] as its
+// first element, and argv[0] is the BARE program name as captured by
+// eBPF (e.g. "sh", not "/bin/sh"). Profile.Path holds the resolved
+// kernel exepath separately ("/bin/sh"), used for ap.was_executed
+// lookup; the matcher never sees Path here.
+//
+// This fixes the contract mismatch that broke
+// Test_32_UnexpectedProcessArguments: tests were authored with
+// Args[0]="/bin/sh" assuming the matcher would normalise argv[0] to
+// the resolved path, but CompareExecArgs does strict positional
+// compare. With Args[0]=bare-name, position 0 matches runtime argv[0]
+// directly and R0040 can be tested in isolation from R0001's path
+// resolution.
+//
+// See also: node-agent/pkg/containerprofilemanager/v1/container_data
+// .go (getExecs slicing exec=[path, ...argv]) and the recording site
+// in event_reporting.go that builds exec=[resolveExecPath(...),
+// ...event.GetArgs()].
+func TestCompareExecArgs_Argv0BareName(t *testing.T) {
+	cases := []struct {
+		name    string
+		profile []string
+		runtime []string
+		want    bool
+	}{
+		// 32a equivalent: sh -c MATCHES.
+		{
+			"sh -c <anything> matches [sh, -c, *]",
+			[]string{"sh", "-c", "*"},
+			[]string{"sh", "-c", "echo hi"},
+			true,
+		},
+		// 32b equivalent: sh -x MISMATCHES at literal anchor "-c".
+		{
+			"sh -x <anything> fails [sh, -c, *] at position 1",
+			[]string{"sh", "-c", "*"},
+			[]string{"sh", "-x", "echo hi"},
+			false,
+		},
+		// 32c equivalent: echo hello MATCHES.
+		{
+			"echo hello <words> matches [echo, hello, *]",
+			[]string{"echo", "hello", "*"},
+			[]string{"echo", "hello", "world", "from", "test"},
+			true,
+		},
+		// 32d equivalent: echo goodbye MISMATCHES at literal anchor "hello".
+		{
+			"echo goodbye <words> fails [echo, hello, *] at position 1",
+			[]string{"echo", "hello", "*"},
+			[]string{"echo", "goodbye", "world"},
+			false,
+		},
+		// argv[0] mismatch — caller wrote profile with FULL PATH at position 0
+		// but runtime captured bare name. This used to silently pass the test
+		// when run with the old Test_32 profile shape but mismatches at the
+		// matcher level — the test that exposed it was Test_32's 32a (which
+		// expected R0040 silent on a sh -c match, but R0040 always fired
+		// because of this position-0 mismatch).
+		{
+			"profile Args[0]=full-path WRONG SHAPE — does not match bare-name argv[0]",
+			[]string{"/bin/sh", "-c", "*"},
+			[]string{"sh", "-c", "echo hi"},
+			false,
+		},
+		// Inverse: profile bare, runtime full path. Equally a non-match.
+		{
+			"profile Args[0]=bare-name does not match full-path argv[0]",
+			[]string{"sh", "-c", "*"},
+			[]string{"/bin/sh", "-c", "echo hi"},
+			false,
+		},
+		// curl -s <one URL> — ⋯ consumes exactly one position.
+		{
+			"curl -s <url> matches [curl, -s, ⋯]",
+			[]string{"curl", "-s", "⋯"},
+			[]string{"curl", "-s", "https://example.com"},
+			true,
+		},
+		// curl -s <url> <extra> — ⋯ refuses the extra position.
+		{
+			"curl -s <url> <extra> fails [curl, -s, ⋯] at one-segment limit",
+			[]string{"curl", "-s", "⋯"},
+			[]string{"curl", "-s", "https://example.com", "--verbose"},
+			false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := dynamicpathdetector.CompareExecArgs(tc.profile, tc.runtime); got != tc.want {
+				t.Errorf("CompareExecArgs(profile=%v, runtime=%v) = %v, want %v", tc.profile, tc.runtime, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCompareExecArgs_ReDoSResistance pins that the matcher handles
+// adversarial wildcard-heavy inputs in bounded time. The classic
+// catastrophic-backtracking case is `[*, *, *, …, "literal"]` vs a
+// long literal-runtime vector that mismatches the trailing literal
+// — every prefix * has multiple split choices and the suffix
+// mismatch only surfaces at the very end, so each path gets
+// re-explored. With memoisation this is O(P*R); without it, naïve
+// recursion would be exponential.
+//
+// CodeRabbit flagged the unmemoised version on PR #27 (Major).
+func TestCompareExecArgs_ReDoSResistance(t *testing.T) {
+	// 20 leading wildcards + a literal that won't match. Without
+	// memoisation, the naïve matcher tries roughly 2^20 path splits
+	// before failing — observable as a many-second test. The
+	// memoised version completes in microseconds.
+	profile := make([]string, 0, 21)
+	for i := 0; i < 20; i++ {
+		profile = append(profile, dynamicpathdetector.WildcardIdentifier)
+	}
+	profile = append(profile, "needle-that-does-not-exist")
+
+	runtime := make([]string, 0, 50)
+	for i := 0; i < 50; i++ {
+		runtime = append(runtime, "a")
+	}
+
+	start := time.Now()
+	got := dynamicpathdetector.CompareExecArgs(profile, runtime)
+	elapsed := time.Since(start)
+
+	if got {
+		t.Errorf("expected mismatch for trailing-literal that isn't in runtime")
+	}
+	// Memoised matcher: 21 * 51 = ~1100 states, each O(R) work for
+	// the wildcard split → total bound ~50K ops. Generous budget of
+	// 100ms catches any regression to the unmemoised form (which
+	// would be measured in seconds, not milliseconds, on this input).
+	if elapsed > 100*time.Millisecond {
+		t.Errorf("matcher took %v on adversarial input — memoisation regression?", elapsed)
+	}
+}

--- a/pkg/registry/file/dynamicpathdetector/tests/compare_exec_args_test.go
+++ b/pkg/registry/file/dynamicpathdetector/tests/compare_exec_args_test.go
@@ -282,6 +282,14 @@ func TestCompareExecArgs_Argv0BareName(t *testing.T) {
 //
 // CodeRabbit flagged the unmemoised version on PR #27 (Major).
 func TestCompareExecArgs_ReDoSResistance(t *testing.T) {
+	// Skip in short mode: this test has a wall-clock budget that is
+	// inherently sensitive to runner CPU contention. The functional
+	// regression intent is preserved — the memoisation correctness is
+	// also covered by the explicit case-table tests above which always
+	// run. CodeRabbit upstream PR #326 finding #5.
+	if testing.Short() {
+		t.Skip("skip timing-sensitive ReDoS regression in short mode")
+	}
 	// 20 leading wildcards + a literal that won't match. Without
 	// memoisation, the naïve matcher tries roughly 2^20 path splits
 	// before failing — observable as a many-second test. The


### PR DESCRIPTION
exec-path: symlink-faithful argv[0] resolution

## ⚠️ Merge order

**This PR depends on `#323` and must be merged AFTER it.**

PR `#323` defines `WildcardIdentifier` (and the broader `CollapseConfig` / `NewPathAnalyzerWithConfigs` surface) in `types.go` and `analyzer.go`. Without it, `compare_exec_args.go` (this PR) fails to compile because `WildcardIdentifier` is undefined.

**Correct merge order:**
1. `#323` — path-wildcards: anchored trailing-`*` + per-endpoint port + R0040 args
2. `#322` (this PR) — allowing wildcards in exec args


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced command-line argument pattern matching: anchored wildcard and single-value dynamic tokens, plus a new "args required" option that changes empty-vs-anchored behavior and is exposed in the API schema.

* **Tests**
  * Expanded coverage for literal, dynamic, wildcard, mixed patterns, realistic argv forms, argv[0] semantics, ReDoS resistance, back-compat checks, and protobuf roundtrip/field-tag tests.

* **Chores**
  * API conversion mappings updated to carry the new flag.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/storage/pull/322?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->