### PR TITLE
path-wildcards: anchored trailing-* + per-endpoint port + R0040 args

### DIFF
--- a/pkg/registry/file/dynamicpathdetector/analyze_endpoints.go
+++ b/pkg/registry/file/dynamicpathdetector/analyze_endpoints.go
@@ -7,28 +7,41 @@ import (
 	"strings"
 
 	mapset "github.com/deckarep/golang-set/v2"
+	"github.com/kubescape/go-logger"
+	loggerhelpers "github.com/kubescape/go-logger/helpers"
 	types "github.com/kubescape/storage/pkg/apis/softwarecomposition"
 )
+
+func isWildcardPort(port string) bool {
+	return port == "0"
+}
 
 func AnalyzeEndpoints(endpoints *[]types.HTTPEndpoint, analyzer *PathAnalyzer) []types.HTTPEndpoint {
 	if len(*endpoints) == 0 {
 		return nil
 	}
 
-	var newEndpoints []*types.HTTPEndpoint
+	// First pass: build the analyzer trie from each endpoint's true (port,
+	// path) tuple. Each port keys a separate sub-tree, so :0/foo and
+	// :443/foo are analyzed independently — :443/foo is NOT rewritten to
+	// :0/foo just because some unrelated endpoint also uses :0.
 	for _, endpoint := range *endpoints {
 		_, _ = AnalyzeURL(endpoint.Endpoint, analyzer)
 	}
 
+	// Second pass: process endpoints with their original ports.
+	var newEndpoints []*types.HTTPEndpoint
 	for _, endpoint := range *endpoints {
-		processedEndpoint, err := ProcessEndpoint(&endpoint, analyzer, newEndpoints)
+		ep := endpoint
+		processedEndpoint, err := ProcessEndpoint(&ep, analyzer, newEndpoints)
 		if processedEndpoint == nil && err == nil || err != nil {
 			continue
-		} else {
-			newEndpoints = append(newEndpoints, processedEndpoint)
 		}
+		newEndpoints = append(newEndpoints, processedEndpoint)
 	}
 
+	// Cross-port folding happens here: only same-(path, direction) siblings
+	// of an explicit :0 wildcard get absorbed into it.
 	newEndpoints = MergeDuplicateEndpoints(newEndpoints)
 
 	return convertPointerToValueSlice(newEndpoints)
@@ -88,6 +101,50 @@ func AnalyzeURL(urlString string, analyzer *PathAnalyzer) (string, error) {
 	return ":" + port + path, nil
 }
 
+// splitEndpointPortAndPath splits the canonical `:<port><path>` form
+// produced by AnalyzeURL into its (port, path) parts.
+//
+// Defensive contract: AnalyzeURL guarantees a leading `:` and a port
+// segment, but callers and tests sometimes pass bare paths (e.g.
+// "/health") for ad-hoc lookups. To keep merge keys deterministic,
+// this helper returns empty port + leading-slash-normalised path for
+// any input that does not start with `:`. The empty string returns
+// ("", "/") to match the original fall-through behavior.
+func splitEndpointPortAndPath(endpoint string) (string, string) {
+	if !strings.HasPrefix(endpoint, ":") {
+		if endpoint == "" {
+			return "", "/"
+		}
+		if !strings.HasPrefix(endpoint, "/") {
+			endpoint = "/" + endpoint
+		}
+		return "", endpoint
+	}
+	s := endpoint[1:]
+	idx := strings.Index(s, "/")
+	if idx == -1 {
+		return s, "/"
+	}
+	return s[:idx], s[idx:]
+}
+
+// MergeDuplicateEndpoints folds duplicates and merges same-path specific-port
+// endpoints into a wildcard-port (:0) sibling. Folding is symmetric and is
+// keyed on the same triple HTTPEndpoint.Equal compares — (Endpoint,
+// Direction, Internal). An Internal=false endpoint will therefore NOT merge
+// with an Internal=true sibling even if their path and direction match.
+//
+//   - If a specific-port endpoint is encountered AFTER its :0 sibling, the
+//     specific-port methods/headers are merged INTO the wildcard entry.
+//   - If a specific-port endpoint is encountered BEFORE its :0 sibling, it
+//     is initially recorded; when the wildcard arrives we sweep `seen` for
+//     same-(path, direction, Internal) specific-port siblings, fold them
+//     into the wildcard, and remove them from the output.
+//
+// This contract was tightened on the back of upstream review on
+// kubescape/storage#316 — a single :0 entry must NOT cause unrelated
+// concrete-port endpoints to be wildcarded; only same-path same-Internal
+// siblings fold.
 func MergeDuplicateEndpoints(endpoints []*types.HTTPEndpoint) []*types.HTTPEndpoint {
 	seen := make(map[string]*types.HTTPEndpoint)
 	var newEndpoints []*types.HTTPEndpoint
@@ -97,21 +154,71 @@ func MergeDuplicateEndpoints(endpoints []*types.HTTPEndpoint) []*types.HTTPEndpo
 		if existing, found := seen[key]; found {
 			existing.Methods = MergeStrings(existing.Methods, endpoint.Methods)
 			mergeHeaders(existing, endpoint)
-		} else {
+			continue
+		}
+
+		port, pathPart := splitEndpointPortAndPath(endpoint.Endpoint)
+
+		if isWildcardPort(port) {
+			// Wildcard arriving after specific-port siblings — sweep `seen`
+			// for any same-(path, direction, Internal) specific-port entries
+			// already recorded, fold them into the wildcard, then drop them
+			// from the output slice.
+			for k, e := range seen {
+				ePort, ePath := splitEndpointPortAndPath(e.Endpoint)
+				if isWildcardPort(ePort) || ePath != pathPart ||
+					e.Direction != endpoint.Direction || e.Internal != endpoint.Internal {
+					continue
+				}
+				endpoint.Methods = MergeStrings(endpoint.Methods, e.Methods)
+				mergeHeaders(endpoint, e)
+				delete(seen, k)
+				newEndpoints = removeEndpoint(newEndpoints, e)
+			}
 			seen[key] = endpoint
 			newEndpoints = append(newEndpoints, endpoint)
+			continue
 		}
+
+		// Specific port: if a wildcard sibling for the same
+		// (path, direction, Internal) is already in `seen`, fold this entry
+		// into it. The wildcardKey shape MUST match getEndpointKey exactly so
+		// the lookup hits the same map slot the wildcard was inserted under.
+		wildcardKey := fmt.Sprintf(":0%s|%s|%t", pathPart, endpoint.Direction, endpoint.Internal)
+		if existing, found := seen[wildcardKey]; found {
+			existing.Methods = MergeStrings(existing.Methods, endpoint.Methods)
+			mergeHeaders(existing, endpoint)
+			continue
+		}
+
+		seen[key] = endpoint
+		newEndpoints = append(newEndpoints, endpoint)
 	}
 
 	return newEndpoints
 }
 
+// removeEndpoint returns a new slice with the first occurrence of target
+// removed (compared by pointer). Used by MergeDuplicateEndpoints when a
+// previously-recorded specific-port entry is absorbed into a later wildcard.
+func removeEndpoint(s []*types.HTTPEndpoint, target *types.HTTPEndpoint) []*types.HTTPEndpoint {
+	for i, e := range s {
+		if e == target {
+			return append(s[:i], s[i+1:]...)
+		}
+	}
+	return s
+}
+
+// getEndpointKey returns a key that uniquely identifies an HTTPEndpoint by
+// the same fields HTTPEndpoint.Equal compares: Endpoint, Direction, Internal.
+// Keep this in sync with the wildcardKey shape constructed in
+// MergeDuplicateEndpoints — the two MUST hash identical entries identically.
 func getEndpointKey(endpoint *types.HTTPEndpoint) string {
-	return fmt.Sprintf("%s|%s", endpoint.Endpoint, endpoint.Direction)
+	return fmt.Sprintf("%s|%s|%t", endpoint.Endpoint, endpoint.Direction, endpoint.Internal)
 }
 
 func mergeHeaders(existing, new *types.HTTPEndpoint) {
-	// TODO: Find a better way to unmashal the headers
 	existingHeaders, err := existing.GetHeaders()
 	if err != nil {
 		return
@@ -133,7 +240,12 @@ func mergeHeaders(existing, new *types.HTTPEndpoint) {
 
 	rawJSON, err := json.Marshal(existingHeaders)
 	if err != nil {
-		fmt.Println("Error marshaling JSON:", err)
+		// Don't pollute stdout from a library function. The caller has
+		// no signal-back path here (mergeHeaders is a void helper) so
+		// log at Debug and bail — leaving Headers untouched is the
+		// safer choice than corrupting them with a partial marshal.
+		logger.L().Debug("mergeHeaders: failed to marshal merged headers, leaving existing untouched",
+			loggerhelpers.Error(err))
 		return
 	}
 

--- a/pkg/registry/file/dynamicpathdetector/analyze_endpoints.go
+++ b/pkg/registry/file/dynamicpathdetector/analyze_endpoints.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kubescape/go-logger"
 	loggerhelpers "github.com/kubescape/go-logger/helpers"
 	types "github.com/kubescape/storage/pkg/apis/softwarecomposition"
+	"github.com/kubescape/storage/pkg/apis/softwarecomposition/consts"
 )
 
 func isWildcardPort(port string) bool {
@@ -184,7 +185,9 @@ func MergeDuplicateEndpoints(endpoints []*types.HTTPEndpoint) []*types.HTTPEndpo
 		// (path, direction, Internal) is already in `seen`, fold this entry
 		// into it. The wildcardKey shape MUST match getEndpointKey exactly so
 		// the lookup hits the same map slot the wildcard was inserted under.
-		wildcardKey := fmt.Sprintf(":0%s|%s|%t", pathPart, endpoint.Direction, endpoint.Internal)
+		// CodeRabbit upstream PR #323 finding #5: the two formats are
+		// derived from the same helper to remove the duplication risk.
+		wildcardKey := buildEndpointKey(":0"+pathPart, endpoint.Direction, endpoint.Internal)
 		if existing, found := seen[wildcardKey]; found {
 			existing.Methods = MergeStrings(existing.Methods, endpoint.Methods)
 			mergeHeaders(existing, endpoint)
@@ -201,6 +204,14 @@ func MergeDuplicateEndpoints(endpoints []*types.HTTPEndpoint) []*types.HTTPEndpo
 // removeEndpoint returns a new slice with the first occurrence of target
 // removed (compared by pointer). Used by MergeDuplicateEndpoints when a
 // previously-recorded specific-port entry is absorbed into a later wildcard.
+//
+// NOTE — in-place backing-array mutation: the `append(s[:i], s[i+1:]...)`
+// pattern shifts elements left within the original backing array, leaving
+// a stale pointer at s[len-1] outside the returned slice. The sole caller
+// immediately replaces `newEndpoints` with the return value, so there is
+// no live alias today. If a future refactor stores intermediate slice
+// references, swap to a copy-based removal to avoid action-at-a-distance.
+// CodeRabbit upstream PR #323 finding #9.
 func removeEndpoint(s []*types.HTTPEndpoint, target *types.HTTPEndpoint) []*types.HTTPEndpoint {
 	for i, e := range s {
 		if e == target {
@@ -212,10 +223,20 @@ func removeEndpoint(s []*types.HTTPEndpoint, target *types.HTTPEndpoint) []*type
 
 // getEndpointKey returns a key that uniquely identifies an HTTPEndpoint by
 // the same fields HTTPEndpoint.Equal compares: Endpoint, Direction, Internal.
-// Keep this in sync with the wildcardKey shape constructed in
-// MergeDuplicateEndpoints — the two MUST hash identical entries identically.
+// CodeRabbit upstream PR #323 finding #5: both this function and the
+// wildcard-key construction in MergeDuplicateEndpoints route through
+// buildEndpointKey so the format can't drift between the two callsites.
 func getEndpointKey(endpoint *types.HTTPEndpoint) string {
-	return fmt.Sprintf("%s|%s|%t", endpoint.Endpoint, endpoint.Direction, endpoint.Internal)
+	return buildEndpointKey(endpoint.Endpoint, endpoint.Direction, endpoint.Internal)
+}
+
+// buildEndpointKey is the single source of truth for the endpoint-lookup
+// key shape used by MergeDuplicateEndpoints. Inlining the fmt.Sprintf at
+// two callsites is what allowed the two formats to drift in the past
+// (e.g. one with %s|%s|%t and another with %s|%s|%v). Keep this helper
+// the only producer of the key.
+func buildEndpointKey(endpoint string, direction consts.NetworkDirection, internal bool) string {
+	return fmt.Sprintf("%s|%s|%t", endpoint, direction, internal)
 }
 
 func mergeHeaders(existing, new *types.HTTPEndpoint) {

--- a/pkg/registry/file/dynamicpathdetector/analyze_endpoints_internal_test.go
+++ b/pkg/registry/file/dynamicpathdetector/analyze_endpoints_internal_test.go
@@ -1,0 +1,55 @@
+package dynamicpathdetector
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestSplitEndpointPortAndPath_DefensiveContract pins the inputs that
+// AnalyzeURL is supposed to produce (`:<port><path>`) AND the defensive
+// behavior for bare-path / empty / no-leading-slash inputs that may
+// arrive via ad-hoc lookups or tests. Without the guard, "foo" was
+// returned as ("foo", "/") — silently treating an opaque token as a
+// port number. Flagged on upstream PR #316 by CodeRabbit (C7).
+func TestSplitEndpointPortAndPath_DefensiveContract(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantPort string
+		wantPath string
+	}{
+		// Canonical AnalyzeURL output.
+		{"empty", "", "", "/"},
+		{"port_only", ":80", "80", "/"},
+		{"port_with_root_path", ":80/", "80", "/"},
+		{"port_with_path", ":80/health", "80", "/health"},
+		{"wildcard_port", ":0", "0", "/"},
+		{"wildcard_port_with_path", ":0/api/users", "0", "/api/users"},
+		{"port_with_deep_path", ":443/v1/items/42", "443", "/v1/items/42"},
+
+		// Defensive — bare paths arriving without the `:` prefix.
+		{"bare_path", "/health", "", "/health"},
+		{"bare_root", "/", "", "/"},
+		{"bare_deep_path", "/v1/items/42", "", "/v1/items/42"},
+
+		// Defensive — opaque token without a leading slash. Previous
+		// behavior silently returned ("foo", "/") which would be
+		// indistinguishable from port="foo". The guard normalises this
+		// to ("", "/foo").
+		{"opaque_token", "foo", "", "/foo"},
+		{"opaque_with_dot", "host.example.com", "", "/host.example.com"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotPort, gotPath := splitEndpointPortAndPath(tt.input)
+			assert.Equal(t, tt.wantPort, gotPort,
+				"splitEndpointPortAndPath(%q) port = %q, want %q",
+				tt.input, gotPort, tt.wantPort)
+			assert.Equal(t, tt.wantPath, gotPath,
+				"splitEndpointPortAndPath(%q) path = %q, want %q",
+				tt.input, gotPath, tt.wantPath)
+		})
+	}
+}

--- a/pkg/registry/file/dynamicpathdetector/analyze_opens.go
+++ b/pkg/registry/file/dynamicpathdetector/analyze_opens.go
@@ -48,9 +48,91 @@ func AnalyzeOpens(opens []types.OpenCalls, analyzer *PathAnalyzer, sbomSet mapse
 		}
 	}
 
-	return slices.SortedFunc(maps.Values(dynamicOpens), func(a, b types.OpenCalls) int {
+	result := slices.SortedFunc(maps.Values(dynamicOpens), func(a, b types.OpenCalls) int {
 		return strings.Compare(a.Path, b.Path)
-	}), nil
+	})
+
+	return consolidateOpens(result, sbomSet), nil
+}
+
+// consolidateOpens drops any literal Open whose path is already covered
+// by a wildcard / dynamic-identifier sibling in the same result set, and
+// merges the dropped entry's Flags into that sibling. This is a
+// post-trie cleanup pass: AnalyzeOpens may emit both a collapsed pattern
+// (e.g. /etc/⋯) AND the original literals (/etc/passwd) when only some
+// children at that node hit threshold. Without this pass, downstream
+// matchers see both forms and the literal acts as redundant noise.
+//
+// Two invariants:
+//
+//  1. Patterns are always preserved — if a path contains either
+//     WildcardIdentifier or DynamicIdentifier it counts as a pattern
+//     and is never absorbed.
+//  2. SBOM-listed paths are always preserved — they are part of the
+//     image's manifest and must remain identifiable on their own,
+//     even if a wildcard pattern would otherwise cover them.
+//
+// Subsumption check uses the same CompareDynamic the runtime matcher
+// (CEL `ap.was_opened`) uses, so both sides agree on what "covered"
+// means at every depth.
+func consolidateOpens(opens []types.OpenCalls, sbomSet mapset.Set[string]) []types.OpenCalls {
+	if len(opens) <= 1 {
+		return opens
+	}
+
+	isPattern := make([]bool, len(opens))
+	// Sorted slice of pattern indices, longest-path-first. Order matters:
+	// when two patterns both cover the same literal, the more specific
+	// (longer) one wins so folded Flags land deterministically. With ties,
+	// the input's existing sort (alphabetical by Path) breaks them.
+	patternOrder := make([]int, 0, len(opens))
+	for i, o := range opens {
+		if strings.Contains(o.Path, WildcardIdentifier) || strings.Contains(o.Path, DynamicIdentifier) {
+			isPattern[i] = true
+			patternOrder = append(patternOrder, i)
+		}
+	}
+	if len(patternOrder) == 0 {
+		return opens
+	}
+	slices.SortFunc(patternOrder, func(a, b int) int {
+		if d := len(opens[b].Path) - len(opens[a].Path); d != 0 {
+			return d
+		}
+		return strings.Compare(opens[a].Path, opens[b].Path)
+	})
+
+	keep := make([]bool, len(opens))
+	for i := range opens {
+		keep[i] = true
+	}
+
+	for i, o := range opens {
+		if isPattern[i] {
+			continue // patterns always survive
+		}
+		if sbomSet != nil && sbomSet.ContainsOne(o.Path) {
+			continue // SBOM paths always survive
+		}
+		for _, pi := range patternOrder {
+			if CompareDynamic(opens[pi].Path, o.Path) {
+				// `o` is subsumed by the pattern at pi — fold its Flags
+				// into the pattern entry so all observed access modes
+				// remain represented.
+				opens[pi].Flags = mapset.Sorted(mapset.NewThreadUnsafeSet(slices.Concat(opens[pi].Flags, o.Flags)...))
+				keep[i] = false
+				break
+			}
+		}
+	}
+
+	out := make([]types.OpenCalls, 0, len(opens))
+	for i, o := range opens {
+		if keep[i] {
+			out = append(out, o)
+		}
+	}
+	return out
 }
 
 func AnalyzeOpen(path string, analyzer *PathAnalyzer) (string, error) {

--- a/pkg/registry/file/dynamicpathdetector/analyze_opens.go
+++ b/pkg/registry/file/dynamicpathdetector/analyze_opens.go
@@ -75,6 +75,14 @@ func AnalyzeOpens(opens []types.OpenCalls, analyzer *PathAnalyzer, sbomSet mapse
 // Subsumption check uses the same CompareDynamic the runtime matcher
 // (CEL `ap.was_opened`) uses, so both sides agree on what "covered"
 // means at every depth.
+//
+// Complexity: O(n²) over the input slice — each literal walks the full
+// pattern set to test coverage. For the profile sizes seen in practice
+// (≤ a few thousand entries per container even on chatty workloads) the
+// constant factor dominates and the quadratic shape is acceptable. If
+// profiles ever balloon beyond ~10k entries, swap the inner scan to a
+// precomputed prefix-trie lookup. CodeRabbit upstream PR #323 finding
+// #6 (acknowledged, not yet optimised).
 func consolidateOpens(opens []types.OpenCalls, sbomSet mapset.Set[string]) []types.OpenCalls {
 	if len(opens) <= 1 {
 		return opens

--- a/pkg/registry/file/dynamicpathdetector/analyzer.go
+++ b/pkg/registry/file/dynamicpathdetector/analyzer.go
@@ -3,13 +3,94 @@ package dynamicpathdetector
 import (
 	"path"
 	"strings"
+	"sync"
 )
 
+// bufPool reuses byte-slice capacity across AnalyzePath calls. strings.Builder
+// was tempting but its Reset() discards the buffer, defeating the pool; a raw
+// []byte with len=0/cap-preserved survives reuse. Steady-state per-call cost
+// is one string allocation (the final string conversion) and nothing else.
+// Thread-safe by virtue of sync.Pool.
+const defaultBuildBufCap = 128
+
+var bufPool = sync.Pool{
+	New: func() any {
+		b := make([]byte, 0, defaultBuildBufCap)
+		return &b
+	},
+}
+
+// NewPathAnalyzer builds an analyzer with a single global collapse threshold
+// and no per-prefix overrides — equivalent behaviour to the pre-CollapseConfig
+// world. Retained so existing callers don't need to change.
 func NewPathAnalyzer(threshold int) *PathAnalyzer {
+	return NewPathAnalyzerWithConfigs(threshold, nil)
+}
+
+// NewPathAnalyzerWithConfigs builds an analyzer whose collapse threshold can
+// vary per path prefix. defaultThreshold applies when no CollapseConfig in
+// configs matches; configs are checked longest-prefix-wins at walk time.
+//
+// configs is copied so the caller can reuse or mutate the slice without
+// affecting the analyzer.
+func NewPathAnalyzerWithConfigs(defaultThreshold int, configs []CollapseConfig) *PathAnalyzer {
+	copied := make([]CollapseConfig, len(configs))
+	copy(copied, configs)
 	return &PathAnalyzer{
-		RootNodes: make(map[string]*SegmentNode),
-		threshold: threshold,
+		RootNodes:  make(map[string]*SegmentNode),
+		threshold:  defaultThreshold,
+		configs:    copied,
+		defaultCfg: CollapseConfig{Prefix: "/", Threshold: defaultThreshold},
 	}
+}
+
+// effectiveThreshold returns the collapse threshold applicable to the given
+// path prefix, picking the longest matching CollapseConfig or falling back
+// to the analyzer's default. Loop is O(len(configs)) and configs is small
+// (five entries in practice); no allocations.
+//
+// Tiebreak on equal-length prefixes: FIRST entry wins (strict `>`). This
+// must mirror FindConfigForPath so callers using FindConfigForPath to
+// introspect the active config see the same result the analyzer actually
+// uses at walk time. Mismatched comparators (`>=` vs `>`) on duplicate
+// prefixes are a silent footgun for anyone who doesn't dedupe configs.
+func (ua *PathAnalyzer) effectiveThreshold(pathPrefix string) int {
+	bestLen := -1
+	best := ua.threshold
+	for i := range ua.configs {
+		c := &ua.configs[i]
+		if len(c.Prefix) > bestLen && hasPrefixAtBoundary(pathPrefix, c.Prefix) {
+			bestLen = len(c.Prefix)
+			best = c.Threshold
+		}
+	}
+	return best
+}
+
+// hasPrefixAtBoundary is like strings.HasPrefix but only matches if the
+// prefix ends at a path boundary (either pathPrefix == prefix, or the next
+// rune in pathPrefix is '/'). Prevents "/etc" matching "/etcd".
+//
+// Special case: prefix == "/" — the trailing '/' already implies a boundary,
+// and any absolute path begins with '/'. Without this case, a user-supplied
+// `{Prefix:"/", Threshold:X}` config would silently never match for any
+// path past the root (e.g. "/foo" since pathPrefix[1] == 'f', not '/'),
+// which means an explicit catch-all override could not actually override
+// the analyzer's default threshold.
+func hasPrefixAtBoundary(pathPrefix, prefix string) bool {
+	if len(pathPrefix) < len(prefix) {
+		return false
+	}
+	if pathPrefix[:len(prefix)] != prefix {
+		return false
+	}
+	if len(pathPrefix) == len(prefix) {
+		return true
+	}
+	if prefix == "/" {
+		return true
+	}
+	return pathPrefix[len(prefix)] == '/'
 }
 
 func (ua *PathAnalyzer) AnalyzePath(p, identifier string) (string, error) {
@@ -27,7 +108,14 @@ func (ua *PathAnalyzer) AnalyzePath(p, identifier string) (string, error) {
 }
 
 func (ua *PathAnalyzer) processSegments(node *SegmentNode, p string) string {
-	var result strings.Builder
+	// Acquire a pooled byte-slice. len=0, cap preserved from previous reuse.
+	bufPtr := bufPool.Get().(*[]byte)
+	buf := (*bufPtr)[:0]
+	if cap(buf) < len(p) {
+		// Pooled capacity is too small for this input; grow once.
+		buf = make([]byte, 0, len(p)+16)
+	}
+
 	currentNode := node
 	i := 0
 	for {
@@ -36,33 +124,119 @@ func (ua *PathAnalyzer) processSegments(node *SegmentNode, p string) string {
 			i++
 		}
 		segment := p[start:i]
-		currentNode = ua.processSegment(currentNode, segment)
-		ua.updateNodeStats(currentNode)
-		result.WriteString(currentNode.SegmentName)
+		// Two thresholds at two scopes — necessary because processSegment
+		// and updateNodeStats ask different questions about different nodes:
+		//
+		// insertThreshold is for the PARENT node's config (path prefix up
+		// to, but not including, the current segment). It answers: "if
+		// we need to add `segment` under the parent, should we wildcard
+		// the parent's children instead (threshold == 1)?". Using p[:i]
+		// here would incorrectly apply the current segment's own config,
+		// causing a {Prefix: "/instant", Threshold: 1} rule to wildcard
+		// the "instant" segment itself and produce "/*/*/*" rather than
+		// "/instant/*".
+		//
+		// collapseThreshold is for the CURRENT node's config (path prefix
+		// INCLUDING the current segment, i.e. the node we just descended
+		// to). It answers: "do this node's direct children exceed the
+		// collapse threshold configured for this node's path?". Here we
+		// do want p[:i] — updateNodeStats then collapses the current
+		// node's children to ⋯ when Count > threshold.
+		insertThreshold := ua.effectiveThreshold(p[:start])
+		collapseThreshold := ua.effectiveThreshold(p[:i])
+		currentNode = ua.processSegment(currentNode, segment, insertThreshold)
+		ua.updateNodeStats(currentNode, collapseThreshold)
+		buf = append(buf, currentNode.SegmentName...)
+		// Wildcard absorbs the rest of the path: once a segment has been
+		// emitted as `*`, walking deeper would just append more "/*"
+		// suffixes, producing "/a/*/*/*" where the correct output is
+		// "/a/*". Terminate emission here.
+		if currentNode.SegmentName == WildcardIdentifier {
+			break
+		}
 		i++
 		if len(p) < i {
 			break
 		}
-		result.WriteByte('/')
+		buf = append(buf, '/')
 	}
-	return result.String()
+
+	// Post-process: collapse runs of adjacent DynamicIdentifier segments
+	// (e.g. "/a/⋯/⋯/b") into a single WildcardIdentifier ("/a/*/b"). Done
+	// in place by shrinking buf — zero allocation because the output is
+	// always shorter than the input.
+	buf = collapseAdjacentDynamic(buf)
+
+	// string(buf) always copies, so it is safe to return the pool capacity
+	// immediately afterwards — the returned string does not alias buf.
+	out := string(buf)
+	*bufPtr = buf
+	bufPool.Put(bufPtr)
+	return out
 }
 
-func (ua *PathAnalyzer) processSegment(node *SegmentNode, segment string) *SegmentNode {
+// collapseAdjacentDynamic compacts buf in place: any run of
+// "⋯/⋯[/⋯…]" becomes a single "*". Returns a buf[:n] slice where n is
+// the compacted length. Does not allocate; suitable for the hot path.
+func collapseAdjacentDynamic(buf []byte) []byte {
+	// DynamicIdentifier is U+22EF, three UTF-8 bytes: 0xE2 0x8B 0xAF.
+	const d0, d1, d2 = 0xE2, 0x8B, 0xAF
+	const dynLen = 3
+	isDyn := func(i int) bool {
+		return i+dynLen <= len(buf) && buf[i] == d0 && buf[i+1] == d1 && buf[i+2] == d2
+	}
+
+	out := 0
+	i := 0
+	for i < len(buf) {
+		// Need at least "⋯/⋯" (7 bytes) to trigger a collapse.
+		if isDyn(i) && i+dynLen+1+dynLen <= len(buf) && buf[i+dynLen] == '/' && isDyn(i+dynLen+1) {
+			buf[out] = '*'
+			out++
+			// Consume "⋯/⋯" plus any further "/⋯" in the run.
+			i += dynLen + 1 + dynLen
+			for i+1+dynLen <= len(buf) && buf[i] == '/' && isDyn(i+1) {
+				i += 1 + dynLen
+			}
+			continue
+		}
+		buf[out] = buf[i]
+		out++
+		i++
+	}
+	return buf[:out]
+}
+
+func (ua *PathAnalyzer) processSegment(node *SegmentNode, segment string, threshold int) *SegmentNode {
 	if segment == DynamicIdentifier {
 		return ua.handleDynamicSegment(node)
-	} else if node.IsNextDynamic() {
+	}
+	// Wildcard short-circuit: once a node has a * child, all paths through
+	// it go there. This is the glob-style "collapse everything below here"
+	// behaviour; set up either by threshold=1 (see below) or by a caller
+	// explicitly feeding a WildcardIdentifier segment.
+	if wildcardChild, exists := node.Children[WildcardIdentifier]; exists {
+		return wildcardChild
+	}
+	if node.IsNextDynamic() {
 		if len(node.Children) > 1 {
 			temp := node.Children[DynamicIdentifier]
 			node.Children = map[string]*SegmentNode{}
 			node.Children[DynamicIdentifier] = temp
 		}
 		return node.Children[DynamicIdentifier]
-	} else if child, exists := node.Children[segment]; exists {
-		return child
-	} else {
-		return ua.handleNewSegment(node, segment)
 	}
+	if child, exists := node.Children[segment]; exists {
+		return child
+	}
+	// Threshold-1 short-circuit: a prefix explicitly configured to accept
+	// one unique child (CollapseConfig Threshold == 1) collapses to * on
+	// the first *new* segment rather than going through the ⋯ path. This
+	// matches the caller's intent of "anything under /app is noise".
+	if threshold == 1 {
+		return ua.createWildcardNode(node)
+	}
+	return ua.handleNewSegment(node, segment)
 }
 
 func (ua *PathAnalyzer) handleNewSegment(node *SegmentNode, segment string) *SegmentNode {
@@ -82,6 +256,32 @@ func (ua *PathAnalyzer) handleDynamicSegment(node *SegmentNode) *SegmentNode {
 	} else {
 		return ua.createDynamicNode(node)
 	}
+}
+
+// createWildcardNode replaces all of node's existing children with a single
+// WildcardIdentifier (*) child, absorbing any existing subtree counts into it.
+// Used for the threshold-1 short-circuit: a CollapseConfig with Threshold == 1
+// means "any new child segment under this prefix is noise", so the FIRST new
+// segment immediately wildcards (there are typically no children to absorb on
+// the first call; if the analyzer has previously seen children there, they
+// get folded into the wildcard subtree at this point). The semantics are
+// pinned by TestAnalyzeOpensThreshold1ImmediateWildcard /
+// "single path - no collapse yet" which expects /instant/only-child/data
+// to collapse to /instant/* after a single insert.
+func (ua *PathAnalyzer) createWildcardNode(node *SegmentNode) *SegmentNode {
+	wildcard := &SegmentNode{
+		SegmentName: WildcardIdentifier,
+		Count:       0,
+		Children:    make(map[string]*SegmentNode),
+	}
+	// Absorb any previously-accumulated children. Mirrors createDynamicNode.
+	for _, child := range node.Children {
+		shallowChildrenCopy(child, wildcard)
+	}
+	node.Children = map[string]*SegmentNode{
+		WildcardIdentifier: wildcard,
+	}
+	return wildcard
 }
 
 func (ua *PathAnalyzer) createDynamicNode(node *SegmentNode) *SegmentNode {
@@ -104,8 +304,12 @@ func (ua *PathAnalyzer) createDynamicNode(node *SegmentNode) *SegmentNode {
 	return dynamicNode
 }
 
-func (ua *PathAnalyzer) updateNodeStats(node *SegmentNode) {
-	if node.Count > ua.threshold && !node.IsNextDynamic() {
+// updateNodeStats collapses node's children into a single ⋯ (DynamicIdentifier)
+// child once the number of distinct children exceeds the provided threshold.
+// Threshold is passed in by the caller so per-prefix overrides (via
+// CollapseConfig) can take effect without this function knowing about them.
+func (ua *PathAnalyzer) updateNodeStats(node *SegmentNode, threshold int) {
+	if node.Count > threshold && !node.IsNextDynamic() {
 		dynamicChild := &SegmentNode{
 			SegmentName: DynamicIdentifier,
 			Count:       0,
@@ -116,6 +320,15 @@ func (ua *PathAnalyzer) updateNodeStats(node *SegmentNode) {
 		for _, child := range node.Children {
 			shallowChildrenCopy(child, dynamicChild)
 		}
+
+		// The absorbed children become dynamicChild's own children —
+		// update dynamicChild.Count so subsequent updateNodeStats calls
+		// on this node can correctly detect that the grandchild level
+		// also exceeds its threshold and trigger the next collapse.
+		// Without this, multi-level grids like /a/{many}/{many}/leaf
+		// only collapse the first level and leave the grandchild
+		// literals intact in the output.
+		dynamicChild.Count = len(dynamicChild.Children)
 
 		node.Children = map[string]*SegmentNode{
 			DynamicIdentifier: dynamicChild,
@@ -134,33 +347,123 @@ func shallowChildrenCopy(src, dst *SegmentNode) {
 	}
 }
 
+// CompareDynamic checks whether `regularPath` is matched by `dynamicPath`.
+// The dynamic path may contain DynamicIdentifier (⋯, exactly-one-segment
+// wildcard) or WildcardIdentifier (*, zero-or-more-segment mid-path /
+// one-or-more-segment trailing wildcard). The node-agent R0002 rule
+// (Files Access Anomalies) uses this at every file-open to decide whether
+// the access is in-profile.
+//
+// Anchoring contract:
+//   - Anchored patterns (start with `/`): `/etc/*` matches files UNDER
+//     /etc but NOT the bare `/etc` directory itself, mirroring shell
+//     glob semantics. This avoids R0002 silently allowing access to a
+//     profiled directory's parent.
+//   - Unanchored `*` (no leading slash): explicit catch-all that also
+//     matches the root path `/`. The only way to whitelist `/` itself
+//     is an explicit unanchored `*`.
+//
+// Trailing-slash insensitivity: `/etc/` is treated as `/etc`, and
+// `/etc/passwd/` as `/etc/passwd`. Trailing empty path components from
+// `strings.Split` are trimmed so `len(regular) > 0` correctly reflects
+// the presence of a real path tail when matching trailing `*`.
+//
+// The empty regular path (`""`) is treated as "no path" and matches
+// nothing — distinct from the root path `/`, which matches unanchored
+// `*` per the contract above.
 func CompareDynamic(dynamicPath, regularPath string) bool {
-	dynamicIndex, regularIndex := 0, 0
-	dynamicLen, regularLen := len(dynamicPath), len(regularPath)
-
-	for dynamicIndex < dynamicLen && regularIndex < regularLen {
-		// Find the next segment in dynamicPath
-		dynamicSegmentStart := dynamicIndex
-		for dynamicIndex < dynamicLen && dynamicPath[dynamicIndex] != '/' {
-			dynamicIndex++
-		}
-		dynamicSegment := dynamicPath[dynamicSegmentStart:dynamicIndex]
-
-		// Find the next segment in regularPath
-		regularSegmentStart := regularIndex
-		for regularIndex < regularLen && regularPath[regularIndex] != '/' {
-			regularIndex++
-		}
-		regularSegment := regularPath[regularSegmentStart:regularIndex]
-
-		if dynamicSegment != DynamicIdentifier && dynamicSegment != regularSegment {
-			return false
-		}
-
-		// Move to the next segment
-		dynamicIndex++
-		regularIndex++
+	// Empty inputs match nothing. Note that splitPath("") and splitPath("/")
+	// both yield [""] after trim, so without this guard an empty profile
+	// entry would silently match the root path.
+	if dynamicPath == "" || regularPath == "" {
+		return false
 	}
+	return compareSegments(splitPath(dynamicPath), splitPath(regularPath))
+}
 
-	return dynamicIndex >= dynamicLen && regularIndex >= regularLen
+// splitPath splits a path on `/` and trims trailing empty segments
+// produced by trailing slashes (e.g. `/etc/` -> ["", "etc"] not
+// ["", "etc", ""]). The leading empty segment from a leading slash is
+// preserved as the anchor marker. Single-element results are not
+// trimmed so the root path `/` retains its `[""]` shape.
+func splitPath(p string) []string {
+	s := strings.Split(p, "/")
+	for len(s) > 1 && s[len(s)-1] == "" {
+		s = s[:len(s)-1]
+	}
+	return s
+}
+
+func compareSegments(dynamic, regular []string) bool {
+	if len(dynamic) == 0 {
+		return len(regular) == 0
+	}
+	if dynamic[0] == WildcardIdentifier {
+		// Trailing `*` matches one OR MORE remaining segments — never
+		// zero. This is what makes `/etc/*` not match the bare `/etc`
+		// directory, while still matching `/etc/passwd` and any deeper
+		// path. The unanchored-`*` case (regular path is `/`, regular
+		// slice is [""]) returns true because len(regular) == 1.
+		if len(dynamic) == 1 {
+			return len(regular) > 0
+		}
+		// Mid-path `*`: zero-or-more semantics. Try every offset
+		// including i == 0 (wildcard consumed zero segments). No
+		// optimistic peek at dynamic[1]: that optimization used to
+		// require regular[i] to literally equal dynamic[1], which is
+		// wrong whenever dynamic[1] is itself another `*` (consecutive
+		// wildcards like `/*/*` would never recurse and thus never
+		// match — user-authored profiles can contain literal /*/*
+		// patterns even though analyzer-generated ones are squashed by
+		// collapseAdjacentDynamicIdentifiers).
+		for i := 0; i <= len(regular); i++ {
+			if compareSegments(dynamic[1:], regular[i:]) {
+				return true
+			}
+		}
+		return false
+	}
+	if len(regular) == 0 {
+		return false
+	}
+	if dynamic[0] == DynamicIdentifier || dynamic[0] == regular[0] {
+		return compareSegments(dynamic[1:], regular[1:])
+	}
+	return false
+}
+
+// FindConfigForPath returns a value copy of the CollapseConfig whose
+// Prefix matches `path` with the longest match. Falls back to the
+// analyzer's default config (Prefix:"/") when no per-prefix override
+// applies, so the result is always meaningful — there is no "no match"
+// signal.
+//
+// Returning by value keeps the analyzer's internal state immutable
+// from callers. NewPathAnalyzerWithConfigs already makes a defensive
+// inbound copy of `configs`; this is its outbound twin. Without it,
+// `cfg := analyzer.FindConfigForPath(p); cfg.Threshold = 1` would
+// silently mutate the analyzer's threshold map for every future call.
+func (ua *PathAnalyzer) FindConfigForPath(path string) CollapseConfig {
+	bestIdx := -1
+	bestLen := -1
+	for i := range ua.configs {
+		cfg := &ua.configs[i]
+		if hasPrefixAtBoundary(path, cfg.Prefix) && len(cfg.Prefix) > bestLen {
+			bestIdx = i
+			bestLen = len(cfg.Prefix)
+		}
+	}
+	if bestIdx == -1 {
+		return ua.defaultCfg
+	}
+	return ua.configs[bestIdx]
+}
+
+// CollapseAdjacentDynamicIdentifiers replaces runs of adjacent
+// DynamicIdentifier segments (e.g. "/a/⋯/⋯/b") with a single
+// WildcardIdentifier ("/a/*/b"). Static segments between dynamic
+// identifiers prevent collapsing. String wrapper over the internal
+// byte-level collapseAdjacentDynamic, intended for test coverage.
+func CollapseAdjacentDynamicIdentifiers(p string) string {
+	return string(collapseAdjacentDynamic([]byte(p)))
 }

--- a/pkg/registry/file/dynamicpathdetector/analyzer.go
+++ b/pkg/registry/file/dynamicpathdetector/analyzer.go
@@ -88,6 +88,19 @@ func hasPrefixAtBoundary(pathPrefix, prefix string) bool {
 	if prefix == "" {
 		return true
 	}
+	// Normalise operator-supplied trailing slashes. A CollapseConfig with
+	// `Prefix:"/etc/"` semantically means the same as `Prefix:"/etc"` —
+	// the slash is the implicit segment boundary. Without this, an
+	// operator authoring `/etc/` via CollapseConfiguration CR would
+	// silently never match (the byte-equality check rejects `/etc/foo`
+	// because `/etc/foo[:5]` = `/etc/` only when prefix is `/etc/`, which
+	// then forces the next char to be at offset 5 — but offset 5 IS the
+	// boundary slash itself; the boundary check expects another `/`
+	// AFTER that, which is `f`, not `/` → false). Matthias upstream
+	// PR #323 follow-up.
+	for len(prefix) > 1 && prefix[len(prefix)-1] == '/' {
+		prefix = prefix[:len(prefix)-1]
+	}
 	if len(pathPrefix) < len(prefix) {
 		return false
 	}
@@ -388,36 +401,214 @@ func CompareDynamic(dynamicPath, regularPath string) bool {
 	if dynamicPath == "" || regularPath == "" {
 		return false
 	}
-	dynamic := splitPath(dynamicPath)
-	regular := splitPath(regularPath)
-	// Fast path: the recursive form is already O(n) for dynamic patterns
-	// with at most one `*`. Memoisation only earns its keep when the
-	// pattern has TWO OR MORE `*` segments — that's the multi-wildcard
-	// shape that triggers 2^n / n!-style re-entry. For the common
-	// single-`*` / no-`*` shapes the memo-map allocation is pure
-	// overhead, so we keep them on the lean recursive path.
-	// Upstream PR #326 rabbit finding #4 + the adversarial coverage in
-	// compare_dynamic_memoise_test.go drive this split.
-	if multipleWildcards(dynamic) {
-		memo := make(map[[2]int]bool, len(dynamic)*len(regular))
-		return compareSegmentsMemo(dynamic, regular, 0, 0, memo)
+	// Dispatch by `*` count:
+	//
+	//   0 or 1 `*`  → zero-alloc index-based segment walk (compareSegmentsIndex).
+	//                 This is the hot R0002 / file-open path; on `main` it
+	//                 measured ~16 ns/op, 0 allocs/op. The previous splitPath +
+	//                 slice-based descent moved it to ~85 ns/op, 128 B/op,
+	//                 2 allocs/op — reverted here.
+	//   2+ `*`      → splitPath + DP-memoised core. The memo absorbs the
+	//                 exponential re-entry of multi-`*` patterns, which the
+	//                 index-based walk would still hit. Allocation cost is
+	//                 acceptable because multi-`*` patterns are rare and
+	//                 author-supplied, not on the per-event hot path.
+	//
+	// Matthias's upstream PR #323 perf review drove this split.
+	if countStarSegments(dynamicPath) >= 2 {
+		// Multiple `*` segments: try collapsing consecutive runs first.
+		// Spec §5.1 makes adjacent `*`s redundant (mid `*` is 0+
+		// idempotent; trailing `*` is preserved by the run's last
+		// element). After collapse, a 2+-`*` pattern like `/a/*/*/b`
+		// reduces to a single-`*` `/a/*/b` and falls into the
+		// zero-allocation linear path. Only TRULY non-adjacent
+		// multi-`*` patterns (e.g. `/a/*/b/*/c`) still take the memo
+		// path. The collapse is only invoked on the slow path; the
+		// 0/1-`*` hot path pays no overhead.
+		dynamicPath = collapseConsecutiveStars(dynamicPath)
+		if countStarSegments(dynamicPath) >= 2 {
+			dynamic := splitPath(dynamicPath)
+			regular := splitPath(regularPath)
+			memo := make(map[[2]int]bool, len(dynamic)*len(regular))
+			return compareSegmentsMemo(dynamic, regular, 0, 0, memo)
+		}
 	}
-	return compareSegments(dynamic, regular)
+	return compareSegmentsIndex(dynamicPath, 0, regularPath, 0)
 }
 
-// multipleWildcards reports whether the dynamic-segment slice contains
-// more than one `*` segment. Single-`*` patterns can't backtrack
-// re-entrantly (the only `*` consumes monotonically from the same
-// starting point), so they're safe to keep on the non-memoised path.
-func multipleWildcards(dynamic []string) bool {
+// collapseConsecutiveStars replaces runs of consecutive `*` segments
+// with a single `*`. `/a/*/*/b` → `/a/*/b`, `/*/*/*/x` → `/*/x`, etc.
+//
+// Semantic equivalence under v0.0.1 spec §5.1:
+//
+//   - Mid `*` matches 0+ segments; collapsing N consecutive mid `*`s
+//     into one preserves the 0+ arity.
+//   - Trailing `*` matches 1+ segments. A run of consecutive `*`s
+//     ending in a trailing position still requires 1+ from the run's
+//     last element; the upstream mid `*`s each contribute 0+. Net: 1+.
+//   - Therefore `/x/*/*/* ` (trailing run) ≡ `/x/*` (single trailing `*`)
+//     and `/x/*/*/y` (mid run) ≡ `/x/*/y` (single mid `*`).
+//
+// Two-pass implementation:
+//
+//  1. Zero-allocation scan for `/*/*` with a segment-boundary check on
+//     the trailing `*`. If absent (the common case), return p as-is.
+//  2. Build the collapsed string via strings.Builder (one allocation).
+//
+// The hot path — patterns with no adjacent `*` — pays only Pass 1's
+// scan cost (~few ns) and no allocation.
+//
+// Producers' linter SHOULD flag adjacent `*` and have authors collapse
+// in source. This matcher-side collapse is the safety net for legacy
+// or hand-authored profiles.
+func collapseConsecutiveStars(p string) string {
+	// Pass 1: detect any "/*/*" with the second `*` actually a `*` segment.
+	needsCollapse := false
+	for i := 0; i+3 < len(p); i++ {
+		if p[i] != '/' || p[i+1] != '*' || p[i+2] != '/' || p[i+3] != '*' {
+			continue
+		}
+		// p[i+3] is `*`. It's a `*` SEGMENT iff p[i+4] is `/` or string-end.
+		if i+4 == len(p) || p[i+4] == '/' {
+			needsCollapse = true
+			break
+		}
+	}
+	if !needsCollapse {
+		return p
+	}
+
+	// Pass 2: build collapsed string. We walk segments and drop any `*`
+	// segment whose immediate predecessor was also `*`.
+	var b strings.Builder
+	b.Grow(len(p))
+	// Track whether we just emitted a `*` segment, so we know to drop
+	// subsequent `*` segments AND their preceding separator slash.
+	prevSegWasStar := false
+	// Track the position we're about to write a `/` from (so we can
+	// drop it if the next segment turns out to be a collapsed `*`).
+	pendingSlash := false
+	i := 0
+	for i < len(p) {
+		// Emit any pending separator if the next byte starts a segment.
+		// We DON'T emit a `/` if we're about to drop a `*` segment.
+		if p[i] == '/' {
+			pendingSlash = true
+			i++
+			continue
+		}
+		segStart := i
+		for i < len(p) && p[i] != '/' {
+			i++
+		}
+		seg := p[segStart:i]
+		isStar := seg == "*"
+		if isStar && prevSegWasStar {
+			// Skip this `*` AND its leading slash (pendingSlash) —
+			// they're absorbed by the previous `*`.
+			pendingSlash = false
+			continue
+		}
+		if pendingSlash {
+			b.WriteByte('/')
+			pendingSlash = false
+		}
+		b.WriteString(seg)
+		prevSegWasStar = isStar
+	}
+	// Trailing slash, if any (the path ended in `/`).
+	if pendingSlash {
+		b.WriteByte('/')
+	}
+	return b.String()
+}
+
+// countStarSegments counts the number of standalone `*` segments in a
+// path. A `*` segment is a single `*` byte bounded by `/` or string-edge
+// — distinct from literal `*` characters embedded inside other tokens
+// (which v0.0.1 does not currently distinguish but may via `\*` escaping
+// in v0.0.2 per spec §5.1).
+//
+// Zero-allocation: scans the string in place.
+func countStarSegments(p string) int {
 	count := 0
-	for _, s := range dynamic {
-		if s == WildcardIdentifier {
+	for i := 0; i < len(p); i++ {
+		if p[i] != '*' {
+			continue
+		}
+		leftOK := i == 0 || p[i-1] == '/'
+		rightOK := i+1 == len(p) || p[i+1] == '/'
+		if leftOK && rightOK {
 			count++
-			if count > 1 {
+		}
+	}
+	return count
+}
+
+// segAt returns the segment of `s` starting at byte offset `pos`,
+// together with the byte index immediately after the segment's trailing
+// `/` (or len(s) if the segment is the last one).
+//
+// Zero-allocation: returns a slice into the source string.
+func segAt(s string, pos int) (seg string, nextPos int) {
+	start := pos
+	for pos < len(s) && s[pos] != '/' {
+		pos++
+	}
+	seg = s[start:pos]
+	if pos < len(s) {
+		// skip trailing `/`
+		return seg, pos + 1
+	}
+	return seg, pos
+}
+
+// compareSegmentsIndex is the zero-allocation core. It implements the
+// same recursive-descent contract as the slice-based compareSegments
+// but walks the source strings via byte indices, never splitting.
+//
+// di / ri are byte offsets into dynamicPath / regularPath respectively.
+//
+// Per the precondition in CompareDynamic, the dynamic path contains
+// AT MOST one `*` segment. The function therefore never re-enters with
+// a stale `*` position — backtracking depth is bounded by the number
+// of segments in the regular path on the unique mid-`*` shape.
+func compareSegmentsIndex(dynamicPath string, di int, regularPath string, ri int) bool {
+	dl, rl := len(dynamicPath), len(regularPath)
+	if di >= dl {
+		return ri >= rl
+	}
+	dSeg, dNext := segAt(dynamicPath, di)
+	if dSeg == WildcardIdentifier {
+		// Trailing `*` matches one OR MORE remaining segments — never
+		// zero. This is what makes `/etc/*` not match the bare `/etc`
+		// directory, while still matching `/etc/passwd` and deeper.
+		if dNext >= dl {
+			return ri < rl
+		}
+		// Mid-path `*`: zero-or-more semantics. Try every offset
+		// including ri itself (wildcard consumed zero segments).
+		for rTry := ri; rTry <= rl; {
+			if compareSegmentsIndex(dynamicPath, dNext, regularPath, rTry) {
 				return true
 			}
+			// Advance rTry past one segment + its trailing `/`.
+			for rTry < rl && regularPath[rTry] != '/' {
+				rTry++
+			}
+			if rTry >= rl {
+				return false
+			}
+			rTry++ // skip `/`
 		}
+		return false
+	}
+	if ri >= rl {
+		return false
+	}
+	rSeg, rNext := segAt(regularPath, ri)
+	if dSeg == DynamicIdentifier || dSeg == rSeg {
+		return compareSegmentsIndex(dynamicPath, dNext, regularPath, rNext)
 	}
 	return false
 }
@@ -425,7 +616,8 @@ func multipleWildcards(dynamic []string) bool {
 // compareSegmentsMemo is the DP-memoised core, reached only when the
 // dynamic pattern has two or more `*` segments. It walks (di, ri) cursor
 // pairs over the dynamic and regular slices. The semantics are identical
-// to compareSegments: only the redundant re-entry is eliminated.
+// to the index-based compareSegmentsIndex: only the redundant re-entry
+// is eliminated.
 //
 // Per-state outcomes are cached in memo. On a cache hit the prior
 // boolean is returned directly; on a miss the recursive expansion runs
@@ -478,44 +670,6 @@ func splitPath(p string) []string {
 		s = s[:len(s)-1]
 	}
 	return s
-}
-
-func compareSegments(dynamic, regular []string) bool {
-	if len(dynamic) == 0 {
-		return len(regular) == 0
-	}
-	if dynamic[0] == WildcardIdentifier {
-		// Trailing `*` matches one OR MORE remaining segments — never
-		// zero. This is what makes `/etc/*` not match the bare `/etc`
-		// directory, while still matching `/etc/passwd` and any deeper
-		// path. The unanchored-`*` case (regular path is `/`, regular
-		// slice is [""]) returns true because len(regular) == 1.
-		if len(dynamic) == 1 {
-			return len(regular) > 0
-		}
-		// Mid-path `*`: zero-or-more semantics. Try every offset
-		// including i == 0 (wildcard consumed zero segments). No
-		// optimistic peek at dynamic[1]: that optimization used to
-		// require regular[i] to literally equal dynamic[1], which is
-		// wrong whenever dynamic[1] is itself another `*` (consecutive
-		// wildcards like `/*/*` would never recurse and thus never
-		// match — user-authored profiles can contain literal /*/*
-		// patterns even though analyzer-generated ones are squashed by
-		// collapseAdjacentDynamicIdentifiers).
-		for i := 0; i <= len(regular); i++ {
-			if compareSegments(dynamic[1:], regular[i:]) {
-				return true
-			}
-		}
-		return false
-	}
-	if len(regular) == 0 {
-		return false
-	}
-	if dynamic[0] == DynamicIdentifier || dynamic[0] == regular[0] {
-		return compareSegments(dynamic[1:], regular[1:])
-	}
-	return false
 }
 
 // FindConfigForPath returns a value copy of the CollapseConfig whose

--- a/pkg/registry/file/dynamicpathdetector/analyzer.go
+++ b/pkg/registry/file/dynamicpathdetector/analyzer.go
@@ -78,6 +78,16 @@ func (ua *PathAnalyzer) effectiveThreshold(pathPrefix string) int {
 // which means an explicit catch-all override could not actually override
 // the analyzer's default threshold.
 func hasPrefixAtBoundary(pathPrefix, prefix string) bool {
+	// Empty-prefix guard. CodeRabbit upstream PR #323 finding #10:
+	// without this, hasPrefixAtBoundary("/foo", "") falls through to
+	// pathPrefix[0] == '/', which is true for any absolute path —
+	// effectively treating `""` as a root-matching prefix. None of the
+	// shipped configs use an empty prefix, but operators could supply
+	// one via CollapseConfiguration CR, and an explicit guard makes
+	// the invariant load-bearing rather than incidental.
+	if prefix == "" {
+		return true
+	}
 	if len(pathPrefix) < len(prefix) {
 		return false
 	}
@@ -378,7 +388,83 @@ func CompareDynamic(dynamicPath, regularPath string) bool {
 	if dynamicPath == "" || regularPath == "" {
 		return false
 	}
-	return compareSegments(splitPath(dynamicPath), splitPath(regularPath))
+	dynamic := splitPath(dynamicPath)
+	regular := splitPath(regularPath)
+	// Fast path: the recursive form is already O(n) for dynamic patterns
+	// with at most one `*`. Memoisation only earns its keep when the
+	// pattern has TWO OR MORE `*` segments — that's the multi-wildcard
+	// shape that triggers 2^n / n!-style re-entry. For the common
+	// single-`*` / no-`*` shapes the memo-map allocation is pure
+	// overhead, so we keep them on the lean recursive path.
+	// Upstream PR #326 rabbit finding #4 + the adversarial coverage in
+	// compare_dynamic_memoise_test.go drive this split.
+	if multipleWildcards(dynamic) {
+		memo := make(map[[2]int]bool, len(dynamic)*len(regular))
+		return compareSegmentsMemo(dynamic, regular, 0, 0, memo)
+	}
+	return compareSegments(dynamic, regular)
+}
+
+// multipleWildcards reports whether the dynamic-segment slice contains
+// more than one `*` segment. Single-`*` patterns can't backtrack
+// re-entrantly (the only `*` consumes monotonically from the same
+// starting point), so they're safe to keep on the non-memoised path.
+func multipleWildcards(dynamic []string) bool {
+	count := 0
+	for _, s := range dynamic {
+		if s == WildcardIdentifier {
+			count++
+			if count > 1 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// compareSegmentsMemo is the DP-memoised core, reached only when the
+// dynamic pattern has two or more `*` segments. It walks (di, ri) cursor
+// pairs over the dynamic and regular slices. The semantics are identical
+// to compareSegments: only the redundant re-entry is eliminated.
+//
+// Per-state outcomes are cached in memo. On a cache hit the prior
+// boolean is returned directly; on a miss the recursive expansion runs
+// and the result is stored before return.
+func compareSegmentsMemo(dynamic, regular []string, di, ri int, memo map[[2]int]bool) bool {
+	if di == len(dynamic) {
+		return ri == len(regular)
+	}
+	key := [2]int{di, ri}
+	if v, ok := memo[key]; ok {
+		return v
+	}
+
+	var result bool
+	if dynamic[di] == WildcardIdentifier {
+		// Trailing `*` matches one OR MORE remaining segments — never
+		// zero. Identical semantics to the un-memoised form.
+		if di == len(dynamic)-1 {
+			result = ri < len(regular)
+		} else {
+			// Mid-path `*`: zero-or-more semantics. Try every offset
+			// including i == 0 (wildcard consumed zero segments). The
+			// memoisation cache absorbs the repeated work this loop
+			// would otherwise inflict on re-entrant states.
+			for i := ri; i <= len(regular); i++ {
+				if compareSegmentsMemo(dynamic, regular, di+1, i, memo) {
+					result = true
+					break
+				}
+			}
+		}
+	} else if ri == len(regular) {
+		result = false
+	} else if dynamic[di] == DynamicIdentifier || dynamic[di] == regular[ri] {
+		result = compareSegmentsMemo(dynamic, regular, di+1, ri+1, memo)
+	}
+
+	memo[key] = result
+	return result
 }
 
 // splitPath splits a path on `/` and trims trailing empty segments

--- a/pkg/registry/file/dynamicpathdetector/tests/analyze_endpoints_test.go
+++ b/pkg/registry/file/dynamicpathdetector/tests/analyze_endpoints_test.go
@@ -12,8 +12,6 @@ import (
 )
 
 func TestAnalyzeEndpoints(t *testing.T) {
-	analyzer := dynamicpathdetector.NewPathAnalyzer(100)
-
 	tests := []struct {
 		name     string
 		input    []types.HTTPEndpoint
@@ -69,6 +67,43 @@ func TestAnalyzeEndpoints(t *testing.T) {
 				{
 					Endpoint: ":80/users/\u22ef/posts/\u22ef",
 					Methods:  []string{"GET", "POST"},
+				},
+			},
+		},
+		{
+			// A single :0 (wildcard-port) entry MUST NOT contaminate
+			// unrelated concrete-port endpoints. Only same-(path, direction)
+			// siblings of an explicit :0 entry are folded into it; here the
+			// :80 and :8770 paths are distinct from the :0 path, so each
+			// endpoint stays on its own port. Regression test for the bug
+			// flagged in upstream review on kubescape/storage#316.
+			name: "Test with 0 port",
+			input: []types.HTTPEndpoint{
+				{
+					Endpoint: ":0/users/123/posts/\u22ef",
+					Methods:  []string{"GET"},
+				},
+				{
+					Endpoint: ":80/users/\u22ef/posts/101",
+					Methods:  []string{"POST"},
+				},
+				{
+					Endpoint: ":8770/users/blub/posts/101",
+					Methods:  []string{"POST"},
+				},
+			},
+			expected: []types.HTTPEndpoint{
+				{
+					Endpoint: ":0/users/123/posts/\u22ef",
+					Methods:  []string{"GET"},
+				},
+				{
+					Endpoint: ":80/users/\u22ef/posts/101",
+					Methods:  []string{"POST"},
+				},
+				{
+					Endpoint: ":8770/users/blub/posts/101",
+					Methods:  []string{"POST"},
 				},
 			},
 		},
@@ -133,6 +168,7 @@ func TestAnalyzeEndpoints(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(dynamicpathdetector.EndpointDynamicThreshold, nil)
 			result := dynamicpathdetector.AnalyzeEndpoints(&tt.input, analyzer)
 			ja := jsonassert.New(t)
 			for i := range result {
@@ -145,10 +181,11 @@ func TestAnalyzeEndpoints(t *testing.T) {
 }
 
 func TestAnalyzeEndpointsWithThreshold(t *testing.T) {
-	analyzer := dynamicpathdetector.NewPathAnalyzer(100)
+	threshold := dynamicpathdetector.EndpointDynamicThreshold
+	analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(threshold, nil)
 
 	var input []types.HTTPEndpoint
-	for i := 0; i < 101; i++ {
+	for i := 0; i < threshold+1; i++ {
 		input = append(input, types.HTTPEndpoint{
 			Endpoint: fmt.Sprintf(":80/users/%d", i),
 			Methods:  []string{"GET"},
@@ -167,10 +204,11 @@ func TestAnalyzeEndpointsWithThreshold(t *testing.T) {
 }
 
 func TestAnalyzeEndpointsWithExactThreshold(t *testing.T) {
-	analyzer := dynamicpathdetector.NewPathAnalyzer(100)
+	threshold := dynamicpathdetector.EndpointDynamicThreshold
+	analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(threshold, nil)
 
 	var input []types.HTTPEndpoint
-	for i := 0; i < 100; i++ {
+	for i := 0; i < threshold; i++ {
 		input = append(input, types.HTTPEndpoint{
 			Endpoint: fmt.Sprintf(":80/users/%d", i),
 			Methods:  []string{"GET"},
@@ -179,18 +217,17 @@ func TestAnalyzeEndpointsWithExactThreshold(t *testing.T) {
 
 	result := dynamicpathdetector.AnalyzeEndpoints(&input, analyzer)
 
-	// Check that all 100 endpoints are still individual
-	assert.Equal(t, 100, len(result))
+	// At exact threshold: all endpoints should remain individual
+	assert.Equal(t, threshold, len(result))
 
 	// Now add one more endpoint to trigger the dynamic behavior
 	input = append(input, types.HTTPEndpoint{
-		Endpoint: ":80/users/100",
+		Endpoint: fmt.Sprintf(":80/users/%d", threshold),
 		Methods:  []string{"GET"},
 	})
 
 	result = dynamicpathdetector.AnalyzeEndpoints(&input, analyzer)
 
-	// Check that all endpoints are now merged into one dynamic endpoint
 	expected := []types.HTTPEndpoint{
 		{
 			Endpoint: ":80/users/\u22ef",
@@ -201,7 +238,7 @@ func TestAnalyzeEndpointsWithExactThreshold(t *testing.T) {
 }
 
 func TestAnalyzeEndpointsWithInvalidURL(t *testing.T) {
-	analyzer := dynamicpathdetector.NewPathAnalyzer(100)
+	analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(dynamicpathdetector.EndpointDynamicThreshold, nil)
 
 	input := []types.HTTPEndpoint{
 		{
@@ -212,4 +249,319 @@ func TestAnalyzeEndpointsWithInvalidURL(t *testing.T) {
 
 	result := dynamicpathdetector.AnalyzeEndpoints(&input, analyzer)
 	assert.Equal(t, 0, len(result))
+}
+
+// TestAnalyzeEndpoints_WildcardDoesNotContaminateUnrelatedPaths pins the bug
+// flagged by upstream review on kubescape/storage#316: a single wildcard-port
+// endpoint must NOT cause unrelated specific-port endpoints (different path)
+// to be rewritten to :0. Only same-path siblings should fold into the wildcard.
+func TestAnalyzeEndpoints_WildcardDoesNotContaminateUnrelatedPaths(t *testing.T) {
+	analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(dynamicpathdetector.EndpointDynamicThreshold, nil)
+
+	input := []types.HTTPEndpoint{
+		{
+			Endpoint:  ":0/health",
+			Methods:   []string{"GET"},
+			Direction: "outbound",
+		},
+		{
+			Endpoint:  ":443/login",
+			Methods:   []string{"POST"},
+			Direction: "outbound",
+		},
+	}
+
+	result := dynamicpathdetector.AnalyzeEndpoints(&input, analyzer)
+
+	endpoints := make(map[string]bool, len(result))
+	for _, ep := range result {
+		endpoints[ep.Endpoint] = true
+	}
+	assert.Equal(t, 2, len(result), "unrelated paths must not be merged: got %v", endpoints)
+	assert.True(t, endpoints[":0/health"], "wildcard endpoint :0/health must be preserved")
+	assert.True(t, endpoints[":443/login"], "specific-port endpoint :443/login must keep its port (no wildcard sibling on the same path)")
+}
+
+// TestAnalyzeEndpoints_SamePathSpecificFirstThenWildcard exercises the
+// reverse-order case: the specific-port endpoint comes first in the slice,
+// then a wildcard sibling on the SAME path. The two must merge into the
+// wildcard. Without symmetric merging in MergeDuplicateEndpoints, the
+// specific endpoint sticks around alongside the wildcard.
+func TestAnalyzeEndpoints_SamePathSpecificFirstThenWildcard(t *testing.T) {
+	analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(dynamicpathdetector.EndpointDynamicThreshold, nil)
+
+	input := []types.HTTPEndpoint{
+		{
+			Endpoint:  ":443/login",
+			Methods:   []string{"POST"},
+			Direction: "outbound",
+		},
+		{
+			Endpoint:  ":0/login",
+			Methods:   []string{"GET"},
+			Direction: "outbound",
+		},
+	}
+
+	result := dynamicpathdetector.AnalyzeEndpoints(&input, analyzer)
+
+	assert.Equal(t, 1, len(result), "specific-port sibling must fold into the wildcard regardless of order")
+	assert.Equal(t, ":0/login", result[0].Endpoint)
+	assert.ElementsMatch(t, []string{"GET", "POST"}, result[0].Methods, "methods from both ports must be merged")
+}
+
+// TestAnalyzeEndpoints_NoWildcardKeepsSpecificPort asserts that without ANY
+// wildcard sibling, specific-port endpoints stay specific. A regression here
+// would mean the analyzer is wildcarding too aggressively.
+func TestAnalyzeEndpoints_NoWildcardKeepsSpecificPort(t *testing.T) {
+	analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(dynamicpathdetector.EndpointDynamicThreshold, nil)
+
+	input := []types.HTTPEndpoint{
+		{
+			Endpoint:  ":443/login",
+			Methods:   []string{"POST"},
+			Direction: "outbound",
+		},
+	}
+
+	result := dynamicpathdetector.AnalyzeEndpoints(&input, analyzer)
+
+	assert.Equal(t, 1, len(result))
+	assert.Equal(t, ":443/login", result[0].Endpoint, "no wildcard sibling => port must be preserved")
+}
+
+// TestAnalyzeEndpoints_OnlyMatchingPathsFoldIntoWildcard combines the
+// wildcard-contamination case with the same-path-merge case to verify both
+// invariants hold simultaneously. :0/api absorbs :80/api (same path); but
+// :443/admin (different path, no wildcard sibling) keeps its port.
+func TestAnalyzeEndpoints_OnlyMatchingPathsFoldIntoWildcard(t *testing.T) {
+	analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(dynamicpathdetector.EndpointDynamicThreshold, nil)
+
+	input := []types.HTTPEndpoint{
+		{
+			Endpoint:  ":0/api",
+			Methods:   []string{"GET"},
+			Direction: "outbound",
+		},
+		{
+			Endpoint:  ":80/api",
+			Methods:   []string{"POST"},
+			Direction: "outbound",
+		},
+		{
+			Endpoint:  ":443/admin",
+			Methods:   []string{"DELETE"},
+			Direction: "outbound",
+		},
+	}
+
+	result := dynamicpathdetector.AnalyzeEndpoints(&input, analyzer)
+
+	endpoints := make(map[string][]string, len(result))
+	for _, ep := range result {
+		endpoints[ep.Endpoint] = ep.Methods
+	}
+
+	assert.Equal(t, 2, len(result), "expected :0/api and :443/admin, got %v", endpoints)
+	assert.ElementsMatch(t, []string{"GET", "POST"}, endpoints[":0/api"], "/api siblings must merge into wildcard")
+	assert.ElementsMatch(t, []string{"DELETE"}, endpoints[":443/admin"], ":443/admin must NOT be wildcarded — no wildcard sibling on /admin")
+}
+
+func TestAnalyzeEndpointsMultiplePortsMergeIntoWildcard(t *testing.T) {
+	analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(dynamicpathdetector.EndpointDynamicThreshold, nil)
+
+	input := []types.HTTPEndpoint{
+		{
+			Endpoint:  ":0/api/data",
+			Methods:   []string{"GET"},
+			Direction: "outbound",
+		},
+		{
+			Endpoint:  ":80/api/data",
+			Methods:   []string{"POST"},
+			Direction: "outbound",
+		},
+		{
+			Endpoint:  ":81/api/data",
+			Methods:   []string{"PUT"},
+			Direction: "outbound",
+		},
+	}
+
+	result := dynamicpathdetector.AnalyzeEndpoints(&input, analyzer)
+
+	assert.Equal(t, 1, len(result))
+	assert.Equal(t, ":0/api/data", result[0].Endpoint)
+	assert.Equal(t, []string{"GET", "POST", "PUT"}, result[0].Methods)
+}
+
+func TestMergeDuplicateEndpointsWildcardPort(t *testing.T) {
+	wildcardEP := &types.HTTPEndpoint{
+		Endpoint:  ":0/api/data",
+		Methods:   []string{"GET"},
+		Direction: "outbound",
+	}
+	specificEP := &types.HTTPEndpoint{
+		Endpoint:  ":80/api/data",
+		Methods:   []string{"POST"},
+		Direction: "outbound",
+	}
+
+	result := dynamicpathdetector.MergeDuplicateEndpoints([]*types.HTTPEndpoint{wildcardEP, specificEP})
+
+	assert.Equal(t, 1, len(result))
+	assert.Equal(t, ":0/api/data", result[0].Endpoint)
+	assert.Equal(t, []string{"GET", "POST"}, result[0].Methods)
+}
+
+// TestMergeDuplicateEndpoints_SpecificFirstThenWildcard pins the reverse
+// order — specific-port endpoint encountered first, wildcard sibling second.
+// Without symmetric merging in MergeDuplicateEndpoints both entries survive,
+// which CodeRabbit flagged on PR #316. Locking the contract here.
+func TestMergeDuplicateEndpoints_SpecificFirstThenWildcard(t *testing.T) {
+	specificEP := &types.HTTPEndpoint{
+		Endpoint:  ":80/api/data",
+		Methods:   []string{"POST"},
+		Direction: "outbound",
+	}
+	wildcardEP := &types.HTTPEndpoint{
+		Endpoint:  ":0/api/data",
+		Methods:   []string{"GET"},
+		Direction: "outbound",
+	}
+
+	result := dynamicpathdetector.MergeDuplicateEndpoints([]*types.HTTPEndpoint{specificEP, wildcardEP})
+
+	assert.Equal(t, 1, len(result), "wildcard sibling must absorb the earlier specific-port entry")
+	assert.Equal(t, ":0/api/data", result[0].Endpoint)
+	assert.ElementsMatch(t, []string{"GET", "POST"}, result[0].Methods)
+}
+
+// TestMergeDuplicateEndpoints_NoWildcardKeepsAllSpecificPorts asserts that
+// without a wildcard sibling, distinct (port,path) pairs all survive.
+// A regression here would mean the merge is collapsing too aggressively.
+func TestMergeDuplicateEndpoints_NoWildcardKeepsAllSpecificPorts(t *testing.T) {
+	a := &types.HTTPEndpoint{Endpoint: ":80/api/data", Methods: []string{"GET"}, Direction: "outbound"}
+	b := &types.HTTPEndpoint{Endpoint: ":443/api/data", Methods: []string{"POST"}, Direction: "outbound"}
+	c := &types.HTTPEndpoint{Endpoint: ":8080/api/data", Methods: []string{"PUT"}, Direction: "outbound"}
+
+	result := dynamicpathdetector.MergeDuplicateEndpoints([]*types.HTTPEndpoint{a, b, c})
+
+	assert.Equal(t, 3, len(result), "no wildcard sibling => all specific-port endpoints must be kept")
+}
+
+// ---------------------------------------------------------------------------
+// Internal-field isolation tests.
+//
+// `HTTPEndpoint.Equal` distinguishes endpoints by (Endpoint, Direction,
+// Internal). The merge key in `MergeDuplicateEndpoints` and the wildcard
+// sweep must therefore also distinguish Internal — otherwise an
+// internally-originating endpoint can absorb an externally-originating one
+// (or vice versa) just because they share path + direction.
+//
+// Flagged by upstream review on kubescape/storage#316 (matthyx).
+// ---------------------------------------------------------------------------
+
+// TestMergeDuplicateEndpoints_InternalFieldDistinguishesDuplicates asserts
+// that two endpoints differing ONLY in Internal are NOT collapsed by the
+// duplicate-key check at the top of the merge loop.
+func TestMergeDuplicateEndpoints_InternalFieldDistinguishesDuplicates(t *testing.T) {
+	external := &types.HTTPEndpoint{
+		Endpoint:  ":443/login",
+		Methods:   []string{"POST"},
+		Direction: "outbound",
+		Internal:  false,
+	}
+	internal := &types.HTTPEndpoint{
+		Endpoint:  ":443/login",
+		Methods:   []string{"GET"},
+		Direction: "outbound",
+		Internal:  true,
+	}
+
+	result := dynamicpathdetector.MergeDuplicateEndpoints([]*types.HTTPEndpoint{external, internal})
+
+	assert.Equal(t, 2, len(result),
+		"endpoints with different Internal must NOT merge (HTTPEndpoint.Equal distinguishes Internal)")
+	// Each output must keep its own Internal value and methods.
+	for _, ep := range result {
+		switch ep.Internal {
+		case false:
+			assert.Equal(t, []string{"POST"}, ep.Methods, "external endpoint methods must not be polluted")
+		case true:
+			assert.Equal(t, []string{"GET"}, ep.Methods, "internal endpoint methods must not be polluted")
+		}
+	}
+}
+
+// TestMergeDuplicateEndpoints_InternalFieldGuardsWildcardAbsorbingPrior
+// pins the wildcard-after-specific path: an Internal=false :0 wildcard must
+// NOT sweep up a previously-recorded Internal=true specific-port sibling.
+func TestMergeDuplicateEndpoints_InternalFieldGuardsWildcardAbsorbingPrior(t *testing.T) {
+	specificInternal := &types.HTTPEndpoint{
+		Endpoint:  ":443/login",
+		Methods:   []string{"POST"},
+		Direction: "outbound",
+		Internal:  true,
+	}
+	wildcardExternal := &types.HTTPEndpoint{
+		Endpoint:  ":0/login",
+		Methods:   []string{"GET"},
+		Direction: "outbound",
+		Internal:  false,
+	}
+
+	result := dynamicpathdetector.MergeDuplicateEndpoints([]*types.HTTPEndpoint{specificInternal, wildcardExternal})
+
+	assert.Equal(t, 2, len(result),
+		"wildcard with Internal=false must NOT absorb a specific-port sibling with Internal=true")
+}
+
+// TestMergeDuplicateEndpoints_InternalFieldGuardsSpecificFoldingIntoWildcard
+// pins the wildcard-first path: a previously-recorded Internal=true wildcard
+// must NOT absorb a later Internal=false specific-port sibling.
+func TestMergeDuplicateEndpoints_InternalFieldGuardsSpecificFoldingIntoWildcard(t *testing.T) {
+	wildcardInternal := &types.HTTPEndpoint{
+		Endpoint:  ":0/login",
+		Methods:   []string{"GET"},
+		Direction: "outbound",
+		Internal:  true,
+	}
+	specificExternal := &types.HTTPEndpoint{
+		Endpoint:  ":443/login",
+		Methods:   []string{"POST"},
+		Direction: "outbound",
+		Internal:  false,
+	}
+
+	result := dynamicpathdetector.MergeDuplicateEndpoints([]*types.HTTPEndpoint{wildcardInternal, specificExternal})
+
+	assert.Equal(t, 2, len(result),
+		"specific-port with Internal=false must NOT fold into a wildcard sibling with Internal=true")
+}
+
+// TestMergeDuplicateEndpoints_InternalFieldMatching_StillFolds is the
+// positive sanity check: when Internal DOES match, the existing
+// path+direction merge contract still holds. A regression here would mean
+// the Internal guard accidentally blocks legitimate folding.
+func TestMergeDuplicateEndpoints_InternalFieldMatching_StillFolds(t *testing.T) {
+	wildcard := &types.HTTPEndpoint{
+		Endpoint:  ":0/login",
+		Methods:   []string{"GET"},
+		Direction: "outbound",
+		Internal:  true,
+	}
+	specific := &types.HTTPEndpoint{
+		Endpoint:  ":443/login",
+		Methods:   []string{"POST"},
+		Direction: "outbound",
+		Internal:  true,
+	}
+
+	result := dynamicpathdetector.MergeDuplicateEndpoints([]*types.HTTPEndpoint{wildcard, specific})
+
+	assert.Equal(t, 1, len(result), "matching Internal => specific-port sibling still folds into wildcard")
+	assert.Equal(t, ":0/login", result[0].Endpoint)
+	assert.True(t, result[0].Internal, "merged endpoint must preserve Internal=true")
+	assert.ElementsMatch(t, []string{"GET", "POST"}, result[0].Methods)
 }

--- a/pkg/registry/file/dynamicpathdetector/tests/analyze_endpoints_test.go
+++ b/pkg/registry/file/dynamicpathdetector/tests/analyze_endpoints_test.go
@@ -9,6 +9,7 @@ import (
 	types "github.com/kubescape/storage/pkg/apis/softwarecomposition"
 	"github.com/kubescape/storage/pkg/registry/file/dynamicpathdetector"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAnalyzeEndpoints(t *testing.T) {
@@ -170,6 +171,11 @@ func TestAnalyzeEndpoints(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(dynamicpathdetector.EndpointDynamicThreshold, nil)
 			result := dynamicpathdetector.AnalyzeEndpoints(&tt.input, analyzer)
+			// Length gate: ranging over result and indexing tt.expected[i]
+			// silently passes if result is shorter than expected (missing
+			// endpoints stay invisible). Assert equal length first.
+			// CodeRabbit upstream PR #326 outside-diff-range finding.
+			require.Len(t, result, len(tt.expected))
 			ja := jsonassert.New(t)
 			for i := range result {
 				assert.Equal(t, tt.expected[i].Endpoint, result[i].Endpoint)

--- a/pkg/registry/file/dynamicpathdetector/tests/analyze_opens_test.go
+++ b/pkg/registry/file/dynamicpathdetector/tests/analyze_opens_test.go
@@ -2,6 +2,8 @@ package dynamicpathdetectortests
 
 import (
 	"fmt"
+	"sort"
+	"strings"
 	"testing"
 
 	mapset "github.com/deckarep/golang-set/v2"
@@ -10,11 +12,26 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// testCollapseConfigs gives the per-prefix thresholds this file's
+// assertions expect. It is intentionally decoupled from the production
+// DefaultCollapseConfigs so the deployed defaults and the test suite's
+// collapse-behavior coverage can evolve independently — tests that
+// probe threshold-1 / threshold-3 / threshold-5 edge cases shouldn't
+// constrain what values ship.
+var testCollapseConfigs = []dynamicpathdetector.CollapseConfig{
+	{Prefix: "/etc", Threshold: 100},
+	{Prefix: "/etc/apache2", Threshold: 5},
+	{Prefix: "/opt", Threshold: 5},
+	{Prefix: "/var/run", Threshold: 3},
+	{Prefix: "/app", Threshold: 1},
+}
+
 func TestAnalyzeOpensWithThreshold(t *testing.T) {
-	analyzer := dynamicpathdetector.NewPathAnalyzer(100)
+	threshold := dynamicpathdetector.OpenDynamicThreshold
+	analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(threshold, nil)
 
 	var input []types.OpenCalls
-	for i := 0; i < 101; i++ {
+	for i := 0; i < threshold+1; i++ {
 		input = append(input, types.OpenCalls{
 			Path: fmt.Sprintf("/home/user%d/file.txt", i),
 		})
@@ -32,49 +49,20 @@ func TestAnalyzeOpensWithThreshold(t *testing.T) {
 	assert.Equal(t, expected, result)
 }
 
-func TestAnalyzeOpensWithThresholdAndExclusion(t *testing.T) {
-	analyzer := dynamicpathdetector.NewPathAnalyzer(100)
-
-	var input []types.OpenCalls
-	for i := 0; i < 101; i++ {
-		input = append(input, types.OpenCalls{
-			Path:  fmt.Sprintf("/home/user%d/file.txt", i),
-			Flags: []string{"READ"},
-		})
-	}
-
-	expected := []types.OpenCalls{
-		{
-			Path:  "/home/user42/file.txt",
-			Flags: []string{"READ"},
-		},
-		{
-			Path:  "/home/\u22ef/file.txt",
-			Flags: []string{"READ"},
-		},
-	}
-
-	result, err := dynamicpathdetector.AnalyzeOpens(input, analyzer, mapset.NewSet[string]("/home/user42/file.txt"))
-	assert.NoError(t, err)
-	assert.Equal(t, expected, result)
-}
-
 func TestAnalyzeOpensWithFlagMergingAndThreshold(t *testing.T) {
+	// Use /var/run threshold (3) — low enough that hand-written subtests work
+	threshold := configThreshold("/var/run")
+
 	tests := []struct {
 		name     string
 		input    []types.OpenCalls
 		expected []types.OpenCalls
 	}{
 		{
-			name: "Merge flags for paths exceeding threshold",
-			input: []types.OpenCalls{
-				{Path: "/home/user1/file.txt", Flags: []string{"READ"}},
-				{Path: "/home/user2/file.txt", Flags: []string{"WRITE"}},
-				{Path: "/home/user3/file.txt", Flags: []string{"APPEND"}},
-				{Path: "/home/user4/file.txt", Flags: []string{"READ", "WRITE"}},
-			},
+			name:  "Merge flags for paths exceeding threshold",
+			input: generateOpenCallsWithFlags("/home", "file.txt", threshold+1),
 			expected: []types.OpenCalls{
-				{Path: "/home/\u22ef/file.txt", Flags: []string{"APPEND", "READ", "WRITE"}},
+				{Path: "/home/\u22ef/file.txt", Flags: flagsForN(threshold + 1)},
 			},
 		},
 		{
@@ -90,42 +78,33 @@ func TestAnalyzeOpensWithFlagMergingAndThreshold(t *testing.T) {
 		},
 		{
 			name: "Partial merging for some paths exceeding threshold",
-			input: []types.OpenCalls{
-				{Path: "/home/user1/common.txt", Flags: []string{"READ"}},
-				{Path: "/home/user2/common.txt", Flags: []string{"WRITE"}},
-				{Path: "/home/user3/common.txt", Flags: []string{"APPEND"}},
-				{Path: "/home/user4/common.txt", Flags: []string{"READ", "WRITE"}},
-				{Path: "/var/log/app1.log", Flags: []string{"READ"}},
-				{Path: "/var/log/app2.log", Flags: []string{"WRITE"}},
-			},
+			input: append(
+				generateOpenCallsWithFlags("/home", "common.txt", threshold+1),
+				types.OpenCalls{Path: "/var/log/app1.log", Flags: []string{"READ"}},
+				types.OpenCalls{Path: "/var/log/app2.log", Flags: []string{"WRITE"}},
+			),
 			expected: []types.OpenCalls{
-				{Path: "/home/\u22ef/common.txt", Flags: []string{"APPEND", "READ", "WRITE"}},
+				{Path: "/home/\u22ef/common.txt", Flags: flagsForN(threshold + 1)},
 				{Path: "/var/log/app1.log", Flags: []string{"READ"}},
 				{Path: "/var/log/app2.log", Flags: []string{"WRITE"}},
 			},
 		},
 		{
 			name: "Multiple dynamic segments",
-			input: []types.OpenCalls{
-				{Path: "/home/user1/file1.txt", Flags: []string{"READ"}},
-				{Path: "/home/user2/file1.txt", Flags: []string{"WRITE"}},
-				{Path: "/home/user3/file1.txt", Flags: []string{"APPEND"}},
-				{Path: "/home/user4/file1.txt", Flags: []string{"READ", "WRITE"}},
-				{Path: "/home/user1/file2.txt", Flags: []string{"READ"}},
-				{Path: "/home/user2/file2.txt", Flags: []string{"WRITE"}},
-				{Path: "/home/user3/file2.txt", Flags: []string{"APPEND"}},
-				{Path: "/home/user4/file2.txt", Flags: []string{"READ", "WRITE"}},
-			},
+			input: append(
+				generateOpenCallsWithFlags("/home", "file1.txt", threshold+1),
+				generateOpenCallsWithFlags("/home", "file2.txt", threshold+1)...,
+			),
 			expected: []types.OpenCalls{
-				{Path: "/home/\u22ef/file1.txt", Flags: []string{"APPEND", "READ", "WRITE"}},
-				{Path: "/home/\u22ef/file2.txt", Flags: []string{"APPEND", "READ", "WRITE"}},
+				{Path: "/home/\u22ef/file1.txt", Flags: flagsForN(threshold + 1)},
+				{Path: "/home/\u22ef/file2.txt", Flags: flagsForN(threshold + 1)},
 			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			analyzer := dynamicpathdetector.NewPathAnalyzer(3)
+			analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(threshold, nil)
 			result, err := dynamicpathdetector.AnalyzeOpens(tt.input, analyzer, mapset.NewSet[string]())
 			assert.NoError(t, err)
 
@@ -139,7 +118,591 @@ func TestAnalyzeOpensWithFlagMergingAndThreshold(t *testing.T) {
 	}
 }
 
-// Helper function to check if a slice of strings contains only unique elements
+func TestAnalyzeOpensWithAsteriskAndEllipsis(t *testing.T) {
+	threshold := configThreshold("/var/run")
+	analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(threshold, nil)
+
+	// Generate threshold paths + one ⋯ path to trigger collapse
+	var input []types.OpenCalls
+	for i := 0; i < threshold; i++ {
+		input = append(input, types.OpenCalls{
+			Path: fmt.Sprintf("/home/user%d/file.txt", i), Flags: []string{"READ"},
+		})
+	}
+	input = append(input,
+		types.OpenCalls{Path: "/home/\u22ef/file.txt", Flags: []string{"READ"}},
+		types.OpenCalls{Path: fmt.Sprintf("/home/user%d/file.txt", threshold), Flags: []string{"READ"}},
+	)
+
+	expected := []types.OpenCalls{
+		{Path: "/home/\u22ef/file.txt", Flags: []string{"READ"}},
+	}
+
+	result, err := dynamicpathdetector.AnalyzeOpens(input, analyzer, mapset.NewSet[string]())
+	assert.NoError(t, err)
+
+	assert.ElementsMatch(t, expected, result)
+}
+
+func TestAnalyzeOpensWithMultiCollapse(t *testing.T) {
+	// NewPathAnalyzerWithConfigs with nil configs uses a uniform threshold (no per-prefix configs).
+	threshold := dynamicpathdetector.DefaultCollapseConfig.Threshold
+	analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(threshold, nil)
+
+	// Only 3 paths under /var/run — uniform threshold is 5, so 3 children <= 5.
+	// These should NOT collapse.
+	input := []types.OpenCalls{
+		{Path: "/var/run/txt/file.txt", Flags: []string{"READ"}},
+		{Path: "/var/run/txt1/file.txt", Flags: []string{"READ"}},
+		{Path: "/var/run/txt2/file.txt", Flags: []string{"READ"}},
+	}
+
+	expected := []types.OpenCalls{
+		{Path: "/var/run/txt/file.txt", Flags: []string{"READ"}},
+		{Path: "/var/run/txt1/file.txt", Flags: []string{"READ"}},
+		{Path: "/var/run/txt2/file.txt", Flags: []string{"READ"}},
+	}
+
+	result, err := dynamicpathdetector.AnalyzeOpens(input, analyzer, mapset.NewSet[string]())
+	assert.NoError(t, err)
+
+	assert.ElementsMatch(t, expected, result)
+}
+
+func TestAnalyzeOpensWithDynamicConfigs(t *testing.T) {
+	etcThreshold := configThreshold("/etc")
+	optThreshold := configThreshold("/opt")
+	varRunThreshold := configThreshold("/var/run")
+	appThreshold := configThreshold("/app")
+	tmpThreshold := 10 // custom for this test
+
+	analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(dynamicpathdetector.OpenDynamicThreshold, []dynamicpathdetector.CollapseConfig{
+		{Prefix: "/etc", Threshold: etcThreshold},
+		{Prefix: "/opt", Threshold: optThreshold},
+		{Prefix: "/var/run", Threshold: varRunThreshold},
+		{Prefix: "/app", Threshold: appThreshold},
+		{Prefix: "/tmp", Threshold: tmpThreshold},
+	})
+
+	var pathsToAdd []string
+
+	// /etc paths (high threshold) - should not collapse
+	for i := 0; i < 8; i++ {
+		pathsToAdd = append(pathsToAdd, fmt.Sprintf("/etc/config/item%d", i))
+	}
+	pathsToAdd = append(pathsToAdd,
+		"/etc/hosts",
+		"/etc/resolv.conf",
+		"/etc/hostname",
+		"/etc/systemd/system.conf",
+	)
+	// Total /etc: 12, well below etcThreshold (50)
+
+	// /opt paths — exceed optThreshold to trigger collapse
+	for i := 0; i < optThreshold+1; i++ {
+		pathsToAdd = append(pathsToAdd, fmt.Sprintf("/opt/app%d/binary", i))
+	}
+
+	// /var/run paths — exceed varRunThreshold to trigger collapse
+	for i := 0; i < varRunThreshold+1; i++ {
+		pathsToAdd = append(pathsToAdd, fmt.Sprintf("/var/run/pid%d.pid", i))
+	}
+
+	// /app paths — appThreshold is 1, so second child triggers wildcard
+	pathsToAdd = append(pathsToAdd,
+		"/app/some/deep/path",
+		"/app/another/path",
+	)
+
+	// /tmp paths — exceed tmpThreshold to trigger collapse
+	for i := 0; i < tmpThreshold+1; i++ {
+		pathsToAdd = append(pathsToAdd, fmt.Sprintf("/tmp/user%d/a", i))
+	}
+
+	var input []types.OpenCalls
+	for _, p := range pathsToAdd {
+		input = append(input, types.OpenCalls{Path: p, Flags: []string{"READ"}})
+	}
+
+	result, err := dynamicpathdetector.AnalyzeOpens(input, analyzer, mapset.NewSet[string]())
+	assert.NoError(t, err)
+
+	// /etc paths (threshold 50) should NOT be collapsed
+	etcPaths := filterByPrefix(result, "/etc/")
+	assert.Equal(t, 12, len(etcPaths), "/etc paths should remain individual (below threshold %d)", etcThreshold)
+
+	// /app (threshold 1) - immediately collapses to wildcard
+	assertContainsPath(t, result, "/app/*")
+
+	// /opt — collapses; both wildcard and dynamic-with-subtree are acceptable
+	assertContainsOneOfPaths(t, result, "/opt/*", "/opt/\u22ef/binary")
+
+	// /tmp — collapses
+	assertContainsOneOfPaths(t, result, "/tmp/*", "/tmp/\u22ef/a")
+
+	// /var/run — collapses
+	assertContainsOneOfPaths(t, result, "/var/run/*", "/var/run/\u22ef")
+
+	// Total: 12 etc + 1 app + 1 opt + 1 tmp + 1 var/run = 16
+	assert.Equal(t, 16, len(result), "expected 16 total paths, got %d: %v", len(result), pathsFromResult(result))
+}
+
+// TestAnalyzeOpensCollapseExactBoundary verifies that threshold is strictly "greater than",
+// not "greater than or equal". With threshold N, exactly N children should NOT collapse,
+// but N+1 children SHOULD.
+func TestAnalyzeOpensCollapseExactBoundary(t *testing.T) {
+	threshold := dynamicpathdetector.DefaultCollapseConfig.Threshold
+
+	t.Run("at threshold - no collapse", func(t *testing.T) {
+		analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(threshold, nil)
+		var input []types.OpenCalls
+		for i := 0; i < threshold; i++ {
+			input = append(input, types.OpenCalls{
+				Path:  fmt.Sprintf("/data/item%d/info", i),
+				Flags: []string{"READ"},
+			})
+		}
+		result, err := dynamicpathdetector.AnalyzeOpens(input, analyzer, mapset.NewSet[string]())
+		assert.NoError(t, err)
+		assert.Equal(t, threshold, len(result), "at exact threshold, paths should NOT collapse")
+		for _, r := range result {
+			assert.NotContains(t, r.Path, "\u22ef", "no dynamic segment expected")
+			assert.NotContains(t, r.Path, "*", "no wildcard expected")
+		}
+	})
+
+	t.Run("above threshold - collapse", func(t *testing.T) {
+		analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(threshold, nil)
+		var input []types.OpenCalls
+		for i := 0; i < threshold+1; i++ {
+			input = append(input, types.OpenCalls{
+				Path:  fmt.Sprintf("/data/item%d/info", i),
+				Flags: []string{"READ"},
+			})
+		}
+		result, err := dynamicpathdetector.AnalyzeOpens(input, analyzer, mapset.NewSet[string]())
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(result), "above threshold, paths should collapse to 1")
+		assert.Equal(t, "/data/\u22ef/info", result[0].Path, "single \u22ef should not collapse to *")
+	})
+}
+
+// TestAnalyzeOpensDuplicatePathsNoCollapse verifies that repeating the same path
+// many times does NOT trigger a collapse - only unique segment names count.
+func TestAnalyzeOpensDuplicatePathsNoCollapse(t *testing.T) {
+	threshold := configThreshold("/var/run")
+	analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(threshold, nil)
+	var input []types.OpenCalls
+	// Repeat the same path many times — should NOT trigger collapse
+	for i := 0; i < threshold*10; i++ {
+		input = append(input, types.OpenCalls{
+			Path:  "/data/same-child/file.txt",
+			Flags: []string{"READ"},
+		})
+	}
+	result, err := dynamicpathdetector.AnalyzeOpens(input, analyzer, mapset.NewSet[string]())
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(result))
+	assert.Equal(t, "/data/same-child/file.txt", result[0].Path, "duplicate paths should not trigger collapse")
+}
+
+// TestAnalyzeOpensVaryingDepthsUnderPrefix verifies collapse behavior when paths
+// under the same prefix have different depths.
+func TestAnalyzeOpensVaryingDepthsUnderPrefix(t *testing.T) {
+	threshold := configThreshold("/var/run")
+	analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(threshold, nil)
+
+	// Generate threshold+1 unique children under /data to trigger collapse
+	var input []types.OpenCalls
+	for i := 0; i < threshold+1; i++ {
+		input = append(input, types.OpenCalls{
+			Path:  fmt.Sprintf("/data/%c/deep/file", 'a'+rune(i)),
+			Flags: []string{"READ"},
+		})
+	}
+	result, err := dynamicpathdetector.AnalyzeOpens(input, analyzer, mapset.NewSet[string]())
+	assert.NoError(t, err)
+	for _, r := range result {
+		assert.True(t,
+			strings.Contains(r.Path, "\u22ef") || strings.Contains(r.Path, "*"),
+			"path %q should contain a dynamic or wildcard segment after collapse", r.Path)
+	}
+}
+
+// TestAnalyzeOpensNewPathAfterCollapse verifies that a new path arriving after
+// the threshold was already crossed gets absorbed by the collapsed node.
+func TestAnalyzeOpensNewPathAfterCollapse(t *testing.T) {
+	threshold := configThreshold("/var/run")
+	analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(threshold, nil)
+
+	// First batch: trigger collapse with threshold+1 children
+	var batch1 []types.OpenCalls
+	for i := 0; i < threshold+1; i++ {
+		batch1 = append(batch1, types.OpenCalls{
+			Path: fmt.Sprintf("/srv/%c/log", 'a'+rune(i)), Flags: []string{"READ"},
+		})
+	}
+	result1, err := dynamicpathdetector.AnalyzeOpens(batch1, analyzer, mapset.NewSet[string]())
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(result1), "first batch should collapse to 1 path")
+
+	// Second batch: add a completely new child — it should be absorbed
+	batch2 := append(batch1, types.OpenCalls{
+		Path: "/srv/new-service/log", Flags: []string{"WRITE"},
+	})
+	result2, err := dynamicpathdetector.AnalyzeOpens(batch2, analyzer, mapset.NewSet[string]())
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(result2), "new path after collapse should be absorbed")
+	assert.Contains(t, result2[0].Flags, "WRITE", "flags from new path should be merged")
+}
+
+// TestAnalyzeOpensDefaultThresholdForUnconfiguredPrefix verifies that paths under
+// a prefix without a specific config use the default threshold.
+func TestAnalyzeOpensDefaultThresholdForUnconfiguredPrefix(t *testing.T) {
+	analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(dynamicpathdetector.OpenDynamicThreshold, []dynamicpathdetector.CollapseConfig{
+		{Prefix: "/configured", Threshold: 2},
+	})
+
+	// /configured has threshold 2: 3 children should collapse
+	configuredInput := []types.OpenCalls{
+		{Path: "/configured/a/file", Flags: []string{"READ"}},
+		{Path: "/configured/b/file", Flags: []string{"READ"}},
+		{Path: "/configured/c/file", Flags: []string{"READ"}},
+	}
+	result, err := dynamicpathdetector.AnalyzeOpens(configuredInput, analyzer, mapset.NewSet[string]())
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(result), "/configured should collapse with threshold 2")
+
+	// /unconfigured uses default threshold: 3 children should NOT collapse
+	defaultThreshold := dynamicpathdetector.DefaultCollapseConfig.Threshold
+	analyzer2 := dynamicpathdetector.NewPathAnalyzerWithConfigs(dynamicpathdetector.OpenDynamicThreshold, []dynamicpathdetector.CollapseConfig{
+		{Prefix: "/configured", Threshold: 2},
+	})
+	unconfiguredInput := []types.OpenCalls{
+		{Path: "/unconfigured/a/file", Flags: []string{"READ"}},
+		{Path: "/unconfigured/b/file", Flags: []string{"READ"}},
+		{Path: "/unconfigured/c/file", Flags: []string{"READ"}},
+	}
+	result2, err := dynamicpathdetector.AnalyzeOpens(unconfiguredInput, analyzer2, mapset.NewSet[string]())
+	assert.NoError(t, err)
+	assert.Equal(t, 3, len(result2),
+		"/unconfigured should NOT collapse with default threshold %d", defaultThreshold)
+}
+
+// TestAnalyzeOpensThreshold1ImmediateWildcard verifies that threshold 1 produces
+// a wildcard (*) on the very first additional child.
+func TestAnalyzeOpensThreshold1ImmediateWildcard(t *testing.T) {
+	appThreshold := configThreshold("/app") // threshold 1
+	analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(dynamicpathdetector.OpenDynamicThreshold, []dynamicpathdetector.CollapseConfig{
+		{Prefix: "/instant", Threshold: appThreshold},
+	})
+
+	t.Run("single path - no collapse yet", func(t *testing.T) {
+		input := []types.OpenCalls{
+			{Path: "/instant/only-child/data", Flags: []string{"READ"}},
+		}
+		result, err := dynamicpathdetector.AnalyzeOpens(input, analyzer, mapset.NewSet[string]())
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(result))
+		assert.Equal(t, "/instant/*", result[0].Path, "threshold 1 should wildcard immediately")
+	})
+
+	t.Run("two paths - collapsed", func(t *testing.T) {
+		analyzer2 := dynamicpathdetector.NewPathAnalyzerWithConfigs(dynamicpathdetector.OpenDynamicThreshold, []dynamicpathdetector.CollapseConfig{
+			{Prefix: "/instant", Threshold: appThreshold},
+		})
+		input := []types.OpenCalls{
+			{Path: "/instant/first/data", Flags: []string{"READ"}},
+			{Path: "/instant/second/data", Flags: []string{"WRITE"}},
+		}
+		result, err := dynamicpathdetector.AnalyzeOpens(input, analyzer2, mapset.NewSet[string]())
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(result))
+		assert.Equal(t, "/instant/*", result[0].Path)
+		assert.ElementsMatch(t, []string{"READ", "WRITE"}, result[0].Flags)
+	})
+}
+
+// TestAnalyzeOpensCollapseDoesNotAffectSiblingPrefixes verifies that collapsing
+// one prefix does not affect paths under a sibling prefix.
+func TestAnalyzeOpensCollapseDoesNotAffectSiblingPrefixes(t *testing.T) {
+	threshold := configThreshold("/var/run")
+	analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(threshold, nil)
+
+	// /alpha: threshold+1 children → should collapse
+	var input []types.OpenCalls
+	for i := 0; i < threshold+1; i++ {
+		input = append(input, types.OpenCalls{
+			Path: fmt.Sprintf("/alpha/a%d/file", i), Flags: []string{"READ"},
+		})
+	}
+	// /beta: 2 children → should NOT collapse (2 <= threshold)
+	input = append(input,
+		types.OpenCalls{Path: "/beta/b1/file", Flags: []string{"WRITE"}},
+		types.OpenCalls{Path: "/beta/b2/file", Flags: []string{"WRITE"}},
+	)
+
+	result, err := dynamicpathdetector.AnalyzeOpens(input, analyzer, mapset.NewSet[string]())
+	assert.NoError(t, err)
+
+	betaPaths := filterByPrefix(result, "/beta/")
+	assert.Equal(t, 2, len(betaPaths), "/beta paths should remain individual")
+
+	alphaPaths := filterByPrefix(result, "/alpha/")
+	assert.Equal(t, 1, len(alphaPaths), "/alpha paths should collapse to 1")
+}
+
+// TestAnalyzeOpensFlagMergingAfterCollapse verifies that flags from all paths
+// that collapse into the same dynamic node are properly merged and deduplicated.
+func TestAnalyzeOpensFlagMergingAfterCollapse(t *testing.T) {
+	threshold := configThreshold("/var/run")
+	analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(threshold, nil)
+
+	// Generate threshold+1 children to trigger collapse, with varied flags
+	var input []types.OpenCalls
+	flags := [][]string{{"READ", "WRITE"}, {"WRITE", "APPEND"}, {"READ"}, {"APPEND", "READ"}}
+	for i := 0; i < threshold+1; i++ {
+		input = append(input, types.OpenCalls{
+			Path:  fmt.Sprintf("/logs/service%d/app.log", i),
+			Flags: flags[i%len(flags)],
+		})
+	}
+	result, err := dynamicpathdetector.AnalyzeOpens(input, analyzer, mapset.NewSet[string]())
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(result))
+	assert.ElementsMatch(t, []string{"APPEND", "READ", "WRITE"}, result[0].Flags, "flags should be merged and deduplicated")
+	assert.True(t, areStringSlicesUnique(result[0].Flags), "flags must be unique")
+}
+
+// TestAnalyzeOpensMultipleLevelsOfCollapse verifies behavior when both parent and
+// grandchild segments independently exceed their thresholds.
+func TestAnalyzeOpensMultipleLevelsOfCollapse(t *testing.T) {
+	threshold := configThreshold("/var/run")
+	analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(threshold, nil)
+
+	var input []types.OpenCalls
+	// threshold+1 unique children under /multi, each with threshold+1 unique grandchildren
+	for i := 0; i < threshold+1; i++ {
+		for j := 0; j < threshold+1; j++ {
+			input = append(input, types.OpenCalls{
+				Path:  fmt.Sprintf("/multi/level%d/sub%d/file", i, j),
+				Flags: []string{"READ"},
+			})
+		}
+	}
+
+	result, err := dynamicpathdetector.AnalyzeOpens(input, analyzer, mapset.NewSet[string]())
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(result), "double collapse should yield a single path")
+	assert.True(t,
+		strings.Contains(result[0].Path, "\u22ef") || strings.Contains(result[0].Path, "*"),
+		"result %q should contain dynamic or wildcard segments", result[0].Path)
+}
+
+// TestAnalyzeOpensExistingDynamicSegmentInInput verifies that input paths
+// already containing ⋯ are handled correctly and merge with new paths.
+func TestAnalyzeOpensExistingDynamicSegmentInInput(t *testing.T) {
+	// Use a high threshold so that the two paths alone don't trigger collapse —
+	// instead, the existing ⋯ segment absorbs the specific path.
+	analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(dynamicpathdetector.OpenDynamicThreshold, nil)
+	input := []types.OpenCalls{
+		{Path: "/data/\u22ef/config", Flags: []string{"READ"}},
+		{Path: "/data/specific/config", Flags: []string{"WRITE"}},
+	}
+	result, err := dynamicpathdetector.AnalyzeOpens(input, analyzer, mapset.NewSet[string]())
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(result))
+	assert.Equal(t, "/data/\u22ef/config", result[0].Path)
+	assert.ElementsMatch(t, []string{"READ", "WRITE"}, result[0].Flags)
+}
+
+// TestAnalyzeOpens_NilSbomSetNoError verifies that passing a nil sbomSet
+// does not return an error.
+func TestAnalyzeOpens_NilSbomSetNoError(t *testing.T) {
+	threshold := configThreshold("/var/run")
+	analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(threshold, nil)
+	input := []types.OpenCalls{
+		{Path: "/usr/lib/libfoo.so", Flags: []string{"READ"}},
+		{Path: "/usr/lib/libbar.so", Flags: []string{"READ"}},
+	}
+	result, err := dynamicpathdetector.AnalyzeOpens(input, analyzer, nil)
+	assert.NoError(t, err, "nil sbomSet should not cause an error")
+	assert.Equal(t, 2, len(result), "paths below threshold should remain individual")
+}
+
+// TestAnalyzeOpens_NilSbomSetWithCollapse verifies that collapse works
+// correctly even when sbomSet is nil.
+func TestAnalyzeOpens_NilSbomSetWithCollapse(t *testing.T) {
+	threshold := configThreshold("/var/run")
+	analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(threshold, nil)
+
+	var input []types.OpenCalls
+	for i := 0; i < threshold+1; i++ {
+		input = append(input, types.OpenCalls{
+			Path:  fmt.Sprintf("/usr/lib/lib%c.so", 'a'+rune(i)),
+			Flags: []string{"READ"},
+		})
+	}
+	result, err := dynamicpathdetector.AnalyzeOpens(input, analyzer, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(result), "%d children > threshold %d, should collapse", threshold+1, threshold)
+	assert.True(t,
+		strings.Contains(result[0].Path, "\u22ef") || strings.Contains(result[0].Path, "*"),
+		"collapsed path should contain dynamic or wildcard segment, got %q", result[0].Path)
+}
+
+// TestAnalyzeOpens_SbomPathsNeverCollapsed proves that paths present in the
+// sbomSet are always preserved verbatim, even when surrounding paths exceed
+// the collapse threshold. This is critical: SBOM paths map to specific
+// library files used for vulnerability scanning — collapsing them would
+// make vulnerability results non-reproducible.
+func TestAnalyzeOpens_SbomPathsNeverCollapsed(t *testing.T) {
+	threshold := configThreshold("/var/run") // low threshold to trigger collapse easily
+
+	sbomPaths := []string{
+		"/usr/lib/libcrypto.so.3",
+		"/usr/lib/libssl.so.3",
+		"/usr/lib/libz.so.1",
+	}
+	sbomSet := mapset.NewSet[string](sbomPaths...)
+
+	t.Run("sbom paths survive collapse when siblings exceed threshold", func(t *testing.T) {
+		analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(threshold, nil)
+
+		// Generate threshold+1 non-SBOM paths under /usr/lib to trigger collapse
+		var input []types.OpenCalls
+		for i := 0; i < threshold+1; i++ {
+			input = append(input, types.OpenCalls{
+				Path:  fmt.Sprintf("/usr/lib/libextra_%d.so", i),
+				Flags: []string{"READ"},
+			})
+		}
+		// Add SBOM paths — these must survive even though /usr/lib/ children > threshold
+		for _, p := range sbomPaths {
+			input = append(input, types.OpenCalls{
+				Path:  p,
+				Flags: []string{"READ"},
+			})
+		}
+
+		result, err := dynamicpathdetector.AnalyzeOpens(input, analyzer, sbomSet)
+		assert.NoError(t, err)
+
+		// Every SBOM path must appear in the output with its exact original path
+		resultPaths := pathsFromResult(result)
+		for _, sp := range sbomPaths {
+			assert.Contains(t, resultPaths, sp,
+				"SBOM path %q must be preserved verbatim in output, got: %v", sp, resultPaths)
+		}
+	})
+
+	t.Run("sbom paths retain their original flags", func(t *testing.T) {
+		analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(threshold, nil)
+
+		var input []types.OpenCalls
+		for i := 0; i < threshold+1; i++ {
+			input = append(input, types.OpenCalls{
+				Path:  fmt.Sprintf("/usr/lib/libother_%d.so", i),
+				Flags: []string{"WRITE"},
+			})
+		}
+		input = append(input, types.OpenCalls{
+			Path:  "/usr/lib/libcrypto.so.3",
+			Flags: []string{"READ", "MMAP"},
+		})
+
+		result, err := dynamicpathdetector.AnalyzeOpens(input, analyzer, sbomSet)
+		assert.NoError(t, err)
+
+		for _, r := range result {
+			if r.Path == "/usr/lib/libcrypto.so.3" {
+				assert.ElementsMatch(t, []string{"READ", "MMAP"}, r.Flags,
+					"SBOM path flags must be preserved exactly, not merged with collapsed siblings")
+				return
+			}
+		}
+		t.Fatal("SBOM path /usr/lib/libcrypto.so.3 not found in output")
+	})
+
+	t.Run("non-sbom paths still collapse normally", func(t *testing.T) {
+		analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(threshold, nil)
+
+		var input []types.OpenCalls
+		for i := 0; i < threshold+1; i++ {
+			input = append(input, types.OpenCalls{
+				Path:  fmt.Sprintf("/var/data/file%d.dat", i),
+				Flags: []string{"READ"},
+			})
+		}
+		// Add one SBOM path under a different prefix — should be preserved but
+		// should not prevent /var/data from collapsing
+		input = append(input, types.OpenCalls{
+			Path:  "/usr/lib/libcrypto.so.3",
+			Flags: []string{"READ"},
+		})
+
+		result, err := dynamicpathdetector.AnalyzeOpens(input, analyzer, sbomSet)
+		assert.NoError(t, err)
+
+		varDataPaths := filterByPrefix(result, "/var/data/")
+		assert.Equal(t, 1, len(varDataPaths),
+			"non-SBOM paths under /var/data should still collapse, got: %v", pathsFromResult(varDataPaths))
+		assert.True(t,
+			strings.Contains(varDataPaths[0].Path, "\u22ef") || strings.Contains(varDataPaths[0].Path, "*"),
+			"collapsed path should contain dynamic segment, got %q", varDataPaths[0].Path)
+
+		// SBOM path must still be present
+		assert.Contains(t, pathsFromResult(result), "/usr/lib/libcrypto.so.3")
+	})
+
+	t.Run("empty sbomSet does not protect any paths", func(t *testing.T) {
+		analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(threshold, nil)
+		emptySbom := mapset.NewSet[string]()
+
+		var input []types.OpenCalls
+		for i := 0; i < threshold+1; i++ {
+			input = append(input, types.OpenCalls{
+				Path:  fmt.Sprintf("/usr/lib/lib%d.so", i),
+				Flags: []string{"READ"},
+			})
+		}
+
+		result, err := dynamicpathdetector.AnalyzeOpens(input, analyzer, emptySbom)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(result), "with empty sbomSet, all paths should collapse normally")
+	})
+}
+
+// --- Helpers ---
+
+// generateOpenCallsWithFlags creates N OpenCalls under prefix/userN/filename with rotating flags.
+func generateOpenCallsWithFlags(prefix, filename string, n int) []types.OpenCalls {
+	allFlags := []string{"READ", "WRITE", "APPEND"}
+	var result []types.OpenCalls
+	for i := 0; i < n; i++ {
+		result = append(result, types.OpenCalls{
+			Path:  fmt.Sprintf("%s/user%d/%s", prefix, i, filename),
+			Flags: []string{allFlags[i%len(allFlags)]},
+		})
+	}
+	return result
+}
+
+// flagsForN returns the sorted, unique flags that generateOpenCallsWithFlags would produce for N items.
+func flagsForN(n int) []string {
+	allFlags := []string{"READ", "WRITE", "APPEND"}
+	seen := map[string]bool{}
+	for i := 0; i < n; i++ {
+		seen[allFlags[i%len(allFlags)]] = true
+	}
+	var result []string
+	for f := range seen {
+		result = append(result, f)
+	}
+	sort.Strings(result)
+	return result
+}
+
 func areStringSlicesUnique(slice []string) bool {
 	seen := make(map[string]struct{})
 	for _, s := range slice {
@@ -149,4 +712,260 @@ func areStringSlicesUnique(slice []string) bool {
 		seen[s] = struct{}{}
 	}
 	return true
+}
+
+func assertContainsPath(t *testing.T, result []types.OpenCalls, path string) {
+	t.Helper()
+	for _, r := range result {
+		if r.Path == path {
+			return
+		}
+	}
+	assert.Fail(t, fmt.Sprintf("result does not contain path %q, got: %v", path, pathsFromResult(result)))
+}
+
+func assertContainsOneOfPaths(t *testing.T, result []types.OpenCalls, alternatives ...string) {
+	t.Helper()
+	for _, r := range result {
+		for _, alt := range alternatives {
+			if r.Path == alt {
+				return
+			}
+		}
+	}
+	assert.Fail(t, fmt.Sprintf("result does not contain any of %v, got: %v", alternatives, pathsFromResult(result)))
+}
+
+
+func filterByPrefix(result []types.OpenCalls, prefix string) []types.OpenCalls {
+	var filtered []types.OpenCalls
+	for _, r := range result {
+		if strings.HasPrefix(r.Path, prefix) {
+			filtered = append(filtered, r)
+		}
+	}
+	return filtered
+}
+
+func pathsFromResult(result []types.OpenCalls) []string {
+	paths := make([]string, len(result))
+	for i, r := range result {
+		paths[i] = r.Path
+	}
+	return paths
+}
+
+// TestAnalyzeOpensOverlappingPrefixConfigs verifies that overlapping prefix configs
+// (e.g., /etc at 100 and /etc/apache2 at 5) work correctly: the most specific prefix wins.
+func TestAnalyzeOpensOverlappingPrefixConfigs(t *testing.T) {
+	t.Run("/etc/apache2 uses threshold 5, not /etc's threshold 100", func(t *testing.T) {
+		analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(dynamicpathdetector.OpenDynamicThreshold, testCollapseConfigs)
+		// 6 paths under /etc/apache2/mods-enabled/ — should collapse (6 > 5)
+		var input []types.OpenCalls
+		for i := 0; i < 6; i++ {
+			input = append(input, types.OpenCalls{
+				Path:  fmt.Sprintf("/etc/apache2/mods-enabled/mod%d.conf", i),
+				Flags: []string{"READ"},
+			})
+		}
+		result, err := dynamicpathdetector.AnalyzeOpens(input, analyzer, mapset.NewSet[string]())
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(result), "6 paths > threshold 5 should collapse to 1, got: %v", pathsFromResult(result))
+		assert.True(t,
+			strings.Contains(result[0].Path, "\u22ef") || strings.Contains(result[0].Path, "*"),
+			"collapsed path should contain dynamic segment, got %q", result[0].Path)
+	})
+
+	t.Run("/etc uses threshold 100, unaffected by /etc/apache2", func(t *testing.T) {
+		analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(dynamicpathdetector.OpenDynamicThreshold, testCollapseConfigs)
+		// 8 paths directly under /etc/ — should NOT collapse (8 < 100)
+		input := []types.OpenCalls{
+			{Path: "/etc/config1", Flags: []string{"READ"}},
+			{Path: "/etc/config2", Flags: []string{"READ"}},
+			{Path: "/etc/config3", Flags: []string{"READ"}},
+			{Path: "/etc/config4", Flags: []string{"READ"}},
+			{Path: "/etc/config5", Flags: []string{"READ"}},
+			{Path: "/etc/config6", Flags: []string{"READ"}},
+			{Path: "/etc/config7", Flags: []string{"READ"}},
+			{Path: "/etc/config8", Flags: []string{"READ"}},
+		}
+		result, err := dynamicpathdetector.AnalyzeOpens(input, analyzer, mapset.NewSet[string]())
+		assert.NoError(t, err)
+		assert.Equal(t, 8, len(result), "/etc paths should NOT collapse (8 < 100), got: %v", pathsFromResult(result))
+	})
+
+	t.Run("unconfigured prefix /var/log uses default threshold", func(t *testing.T) {
+		defaultThreshold := dynamicpathdetector.DefaultCollapseConfig.Threshold
+		// At threshold — should NOT collapse
+		analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(dynamicpathdetector.OpenDynamicThreshold, testCollapseConfigs)
+		var input []types.OpenCalls
+		for i := 0; i < defaultThreshold; i++ {
+			input = append(input, types.OpenCalls{
+				Path:  fmt.Sprintf("/var/log/app%d.log", i),
+				Flags: []string{"READ"},
+			})
+		}
+		result, err := dynamicpathdetector.AnalyzeOpens(input, analyzer, mapset.NewSet[string]())
+		assert.NoError(t, err)
+		assert.Equal(t, defaultThreshold, len(result),
+			"/var/log at exactly default threshold %d should NOT collapse", defaultThreshold)
+
+		// One more — should collapse
+		analyzer2 := dynamicpathdetector.NewPathAnalyzerWithConfigs(dynamicpathdetector.OpenDynamicThreshold, testCollapseConfigs)
+		input = append(input, types.OpenCalls{
+			Path:  fmt.Sprintf("/var/log/app%d.log", defaultThreshold),
+			Flags: []string{"READ"},
+		})
+		result2, err := dynamicpathdetector.AnalyzeOpens(input, analyzer2, mapset.NewSet[string]())
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(result2),
+			"/var/log exceeding default threshold %d should collapse", defaultThreshold)
+	})
+
+	t.Run("/var/run uses its own threshold 3, not default", func(t *testing.T) {
+		analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(dynamicpathdetector.OpenDynamicThreshold, testCollapseConfigs)
+		// 4 paths under /var/run/ — should collapse (4 > 3)
+		input := []types.OpenCalls{
+			{Path: "/var/run/pid1.pid", Flags: []string{"READ"}},
+			{Path: "/var/run/pid2.pid", Flags: []string{"READ"}},
+			{Path: "/var/run/pid3.pid", Flags: []string{"READ"}},
+			{Path: "/var/run/pid4.pid", Flags: []string{"READ"}},
+		}
+		result, err := dynamicpathdetector.AnalyzeOpens(input, analyzer, mapset.NewSet[string]())
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(result), "4 paths > threshold 3 should collapse, got: %v", pathsFromResult(result))
+	})
+
+	t.Run("/app uses threshold 1 (immediate wildcard)", func(t *testing.T) {
+		analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(dynamicpathdetector.OpenDynamicThreshold, testCollapseConfigs)
+		input := []types.OpenCalls{
+			{Path: "/app/service1/config", Flags: []string{"READ"}},
+		}
+		result, err := dynamicpathdetector.AnalyzeOpens(input, analyzer, mapset.NewSet[string]())
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(result))
+		assert.Equal(t, "/app/*", result[0].Path, "threshold 1 should produce wildcard immediately")
+	})
+
+	t.Run("mixed overlapping: /etc and /etc/apache2 coexist correctly", func(t *testing.T) {
+		analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(dynamicpathdetector.OpenDynamicThreshold, testCollapseConfigs)
+		var input []types.OpenCalls
+
+		// 6 paths under /etc/apache2/conf.d/ (should collapse at threshold 5)
+		for i := 0; i < 6; i++ {
+			input = append(input, types.OpenCalls{
+				Path:  fmt.Sprintf("/etc/apache2/conf.d/site%d.conf", i),
+				Flags: []string{"READ"},
+			})
+		}
+
+		// 8 paths directly under /etc/ (should NOT collapse at threshold 100)
+		for i := 0; i < 8; i++ {
+			input = append(input, types.OpenCalls{
+				Path:  fmt.Sprintf("/etc/setting%d.conf", i),
+				Flags: []string{"READ"},
+			})
+		}
+
+		result, err := dynamicpathdetector.AnalyzeOpens(input, analyzer, mapset.NewSet[string]())
+		assert.NoError(t, err)
+
+		// /etc/apache2 paths should have collapsed
+		apache2Paths := filterByPrefix(result, "/etc/apache2/")
+		assert.Equal(t, 1, len(apache2Paths),
+			"/etc/apache2 paths (6 > threshold 5) should collapse to 1, got: %v", pathsFromResult(apache2Paths))
+		assert.True(t,
+			strings.Contains(apache2Paths[0].Path, "\u22ef") || strings.Contains(apache2Paths[0].Path, "*"),
+			"collapsed apache2 path should contain dynamic segment, got %q", apache2Paths[0].Path)
+
+		// /etc direct paths should remain individual
+		etcDirectPaths := []types.OpenCalls{}
+		for _, r := range result {
+			if strings.HasPrefix(r.Path, "/etc/") && !strings.HasPrefix(r.Path, "/etc/apache2/") {
+				etcDirectPaths = append(etcDirectPaths, r)
+			}
+		}
+		assert.Equal(t, 8, len(etcDirectPaths),
+			"/etc direct paths (8 < threshold 100) should remain individual, got: %v", pathsFromResult(etcDirectPaths))
+	})
+}
+
+// TestFindConfigForPath verifies the config lookup returns the most specific matching prefix.
+func TestFindConfigForPath(t *testing.T) {
+	analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(dynamicpathdetector.OpenDynamicThreshold, testCollapseConfigs)
+
+	tests := []struct {
+		path              string
+		expectedPrefix    string
+		expectedThreshold int
+	}{
+		{
+			path:              "/etc/apache2/mods-enabled/file",
+			expectedPrefix:    "/etc/apache2",
+			expectedThreshold: 5,
+		},
+		{
+			path:              "/etc/hosts",
+			expectedPrefix:    "/etc",
+			expectedThreshold: 100,
+		},
+		{
+			path:              "/var/run/pid1.pid",
+			expectedPrefix:    "/var/run",
+			expectedThreshold: 3,
+		},
+		{
+			path:              "/var/log/app.log",
+			expectedPrefix:    "/",
+			expectedThreshold: dynamicpathdetector.DefaultCollapseConfig.Threshold,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			config := analyzer.FindConfigForPath(tt.path)
+			assert.Equal(t, tt.expectedPrefix, config.Prefix,
+				"path %q should match prefix %q", tt.path, tt.expectedPrefix)
+			assert.Equal(t, tt.expectedThreshold, config.Threshold,
+				"path %q should have threshold %d", tt.path, tt.expectedThreshold)
+		})
+	}
+}
+
+// TestFindConfigForPath_DefensiveCopy pins the contract that the
+// returned CollapseConfig is a value copy, so mutating it does NOT
+// alter the analyzer's internal state. Same defensive philosophy as
+// DefaultCollapseConfigs(): the caller cannot accidentally turn an
+// introspection helper into a hidden mutator.
+func TestFindConfigForPath_DefensiveCopy(t *testing.T) {
+	analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(
+		dynamicpathdetector.OpenDynamicThreshold,
+		dynamicpathdetector.DefaultCollapseConfigs(),
+	)
+
+	// Per-prefix override path: snapshot, mutate the copy, look up
+	// again, expect the analyzer to be unaffected.
+	first := analyzer.FindConfigForPath("/etc/file")
+	originalThreshold := first.Threshold
+	first.Threshold = 999_999
+	first.Prefix = "/poisoned"
+
+	second := analyzer.FindConfigForPath("/etc/file")
+	assert.Equal(t, originalThreshold, second.Threshold,
+		"mutating the first call's CollapseConfig must not change the analyzer state")
+	assert.NotEqual(t, "/poisoned", second.Prefix,
+		"mutating the first call's Prefix must not leak into the second call")
+
+	// Default-fallback path: same contract for the path that doesn't
+	// match any per-prefix override.
+	firstDefault := analyzer.FindConfigForPath("/no/match/anywhere")
+	originalDefaultThreshold := firstDefault.Threshold
+	firstDefault.Threshold = 12345
+	firstDefault.Prefix = "/poisoned-default"
+
+	secondDefault := analyzer.FindConfigForPath("/no/match/anywhere")
+	assert.Equal(t, originalDefaultThreshold, secondDefault.Threshold,
+		"mutating the default config copy must not change the analyzer state")
+	assert.NotEqual(t, "/poisoned-default", secondDefault.Prefix,
+		"mutating the default config Prefix must not leak into a future call")
 }

--- a/pkg/registry/file/dynamicpathdetector/tests/analyze_opens_test.go
+++ b/pkg/registry/file/dynamicpathdetector/tests/analyze_opens_test.go
@@ -146,7 +146,7 @@ func TestAnalyzeOpensWithAsteriskAndEllipsis(t *testing.T) {
 
 func TestAnalyzeOpensWithMultiCollapse(t *testing.T) {
 	// NewPathAnalyzerWithConfigs with nil configs uses a uniform threshold (no per-prefix configs).
-	threshold := dynamicpathdetector.DefaultCollapseConfig.Threshold
+	threshold := dynamicpathdetector.DefaultCollapseConfig().Threshold
 	analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(threshold, nil)
 
 	// Only 3 paths under /var/run — uniform threshold is 5, so 3 children <= 5.
@@ -251,7 +251,7 @@ func TestAnalyzeOpensWithDynamicConfigs(t *testing.T) {
 // not "greater than or equal". With threshold N, exactly N children should NOT collapse,
 // but N+1 children SHOULD.
 func TestAnalyzeOpensCollapseExactBoundary(t *testing.T) {
-	threshold := dynamicpathdetector.DefaultCollapseConfig.Threshold
+	threshold := dynamicpathdetector.DefaultCollapseConfig().Threshold
 
 	t.Run("at threshold - no collapse", func(t *testing.T) {
 		analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(threshold, nil)
@@ -374,7 +374,7 @@ func TestAnalyzeOpensDefaultThresholdForUnconfiguredPrefix(t *testing.T) {
 	assert.Equal(t, 1, len(result), "/configured should collapse with threshold 2")
 
 	// /unconfigured uses default threshold: 3 children should NOT collapse
-	defaultThreshold := dynamicpathdetector.DefaultCollapseConfig.Threshold
+	defaultThreshold := dynamicpathdetector.DefaultCollapseConfig().Threshold
 	analyzer2 := dynamicpathdetector.NewPathAnalyzerWithConfigs(dynamicpathdetector.OpenDynamicThreshold, []dynamicpathdetector.CollapseConfig{
 		{Prefix: "/configured", Threshold: 2},
 	})
@@ -795,7 +795,7 @@ func TestAnalyzeOpensOverlappingPrefixConfigs(t *testing.T) {
 	})
 
 	t.Run("unconfigured prefix /var/log uses default threshold", func(t *testing.T) {
-		defaultThreshold := dynamicpathdetector.DefaultCollapseConfig.Threshold
+		defaultThreshold := dynamicpathdetector.DefaultCollapseConfig().Threshold
 		// At threshold — should NOT collapse
 		analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(dynamicpathdetector.OpenDynamicThreshold, testCollapseConfigs)
 		var input []types.OpenCalls
@@ -917,7 +917,7 @@ func TestFindConfigForPath(t *testing.T) {
 		{
 			path:              "/var/log/app.log",
 			expectedPrefix:    "/",
-			expectedThreshold: dynamicpathdetector.DefaultCollapseConfig.Threshold,
+			expectedThreshold: dynamicpathdetector.DefaultCollapseConfig().Threshold,
 		},
 	}
 

--- a/pkg/registry/file/dynamicpathdetector/tests/benchmark_test.go
+++ b/pkg/registry/file/dynamicpathdetector/tests/benchmark_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func BenchmarkAnalyzePath(b *testing.B) {
-	analyzer := dynamicpathdetector.NewPathAnalyzer(100)
+	analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(dynamicpathdetector.OpenDynamicThreshold, nil)
 	paths := generateMixedPaths(10000, 0) // 0 means use default mixed lengths
 
 	identifier := "test"
@@ -33,7 +33,7 @@ func BenchmarkAnalyzePathWithDifferentLengths(b *testing.B) {
 
 	for _, length := range pathLengths {
 		b.Run(fmt.Sprintf("PathLength-%d", length), func(b *testing.B) {
-			analyzer := dynamicpathdetector.NewPathAnalyzer(100)
+			analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(dynamicpathdetector.OpenDynamicThreshold, nil)
 			paths := generateMixedPaths(10000, length)
 			identifier := "test"
 
@@ -52,7 +52,7 @@ func BenchmarkAnalyzePathWithDifferentLengths(b *testing.B) {
 
 func BenchmarkAnalyzeOpensVsDeflateStringer(b *testing.B) {
 	paths := pathsToOpens(generateMixedPaths(10000, 0))
-	analyzer := dynamicpathdetector.NewPathAnalyzer(100)
+	analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(dynamicpathdetector.OpenDynamicThreshold, nil)
 
 	b.Run("AnalyzeOpens", func(b *testing.B) {
 		b.ResetTimer()
@@ -72,13 +72,43 @@ func BenchmarkAnalyzeOpensVsDeflateStringer(b *testing.B) {
 	})
 }
 
+// BenchmarkCompareDynamic exercises the matcher under realistic shapes.
+// Run with -benchmem; the goal is the zero-alloc target Matthias called
+// out on upstream PR #316. Until the perf rewrite lands the numbers
+// document the current cost so regressions show up. Inputs are split
+// across cases so the benchmark covers:
+//
+//   - DynamicIdentifier-only paths (auto-generated short patterns)
+//   - DynamicIdentifier-only paths (deeper, more typical R0002 traffic)
+//   - WildcardIdentifier with mid-path zero-or-more semantics
+//   - Trailing WildcardIdentifier (the regression-prone path)
+//   - Anchored / unanchored boundary cases (the new `*` vs `/*` contract)
 func BenchmarkCompareDynamic(b *testing.B) {
-	dynamicPath := "/api/\u22ef/\u22ef"
-	regularPath := "/api/users/123"
-	for i := 0; i < b.N; i++ {
-		_ = dynamicpathdetector.CompareDynamic(dynamicPath, regularPath)
+	cases := []struct {
+		name    string
+		dynamic string
+		regular string
+	}{
+		{"ellipsis_short", "/api/\u22ef/\u22ef", "/api/users/123"},
+		{"ellipsis_deep", "/api/\u22ef/\u22ef/\u22ef/\u22ef", "/api/users/123/posts/42"},
+		{"trailing_star", "/etc/*", "/etc/ssh/sshd_config"},
+		{"trailing_star_no_match_on_parent", "/etc/*", "/etc"},
+		{"mid_star_zero_consumed", "/a/*/b", "/a/b"},
+		{"mid_star_many_consumed", "/a/*/b", "/a/x/y/z/b"},
+		{"anchored_root_no_match", "/*", "/"},
+		{"unanchored_star_root", "*", "/"},
+		{"deep_literal_match", "/var/log/syslog", "/var/log/syslog"},
+		{"deep_literal_mismatch", "/var/log/syslog", "/var/log/messages"},
 	}
-	b.ReportAllocs()
+	for _, c := range cases {
+		b.Run(c.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_ = dynamicpathdetector.CompareDynamic(c.dynamic, c.regular)
+			}
+		})
+	}
 }
 
 func generateMixedPaths(count int, fixedLength int) []string {

--- a/pkg/registry/file/dynamicpathdetector/tests/benchmark_test.go
+++ b/pkg/registry/file/dynamicpathdetector/tests/benchmark_test.go
@@ -99,6 +99,14 @@ func BenchmarkCompareDynamic(b *testing.B) {
 		{"unanchored_star_root", "*", "/"},
 		{"deep_literal_match", "/var/log/syslog", "/var/log/syslog"},
 		{"deep_literal_mismatch", "/var/log/syslog", "/var/log/messages"},
+		// Consecutive `*` runs \u2014 pre-collapse experiment.
+		// These shapes used to hit the memoised path (2+ `*` segments)
+		// and allocate ~6.5 KB per call. With collapse_consecutive_stars
+		// at matcher entry they should fold to a single `*` and run
+		// through the zero-alloc linear path.
+		{"consec_two_stars_mid", "/a/*/*/b", "/a/x/y/b"},
+		{"consec_four_stars_trail", "/a/*/*/*/*", "/a/b/c/d/e"},
+		{"consec_redos_adversarial", "/*/*/*/*/sentinel", "/a/b/c/d/e/f/g/h/sentinel"},
 	}
 	for _, c := range cases {
 		b.Run(c.name, func(b *testing.B) {

--- a/pkg/registry/file/dynamicpathdetector/tests/compare_dynamic_memoise_test.go
+++ b/pkg/registry/file/dynamicpathdetector/tests/compare_dynamic_memoise_test.go
@@ -1,0 +1,285 @@
+package dynamicpathdetectortests
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kubescape/storage/pkg/registry/file/dynamicpathdetector"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// CodeRabbit upstream PR #326 finding #4 (Major) — analyzer.go:419-433:
+//
+//   "Memoize `*` backtracking in `compareSegments` to avoid exponential
+//    blowups. The recursive expansion at Line 419 explores all suffix
+//    splits without caching, which can become exponential for
+//    multi-wildcard patterns in a hot runtime path matcher."
+//
+// This file pins the contract end-to-end:
+//
+//   1. Behavioural parity: every existing accept/reject decision the
+//      pre-memoisation matcher made is preserved exactly. The cases
+//      below cover the same shapes the in-tree coverage_test.go file
+//      already validates (anchored vs trailing `*`, mid-path `*`,
+//      ellipsis `⋯`, multi-`*` patterns, edge inputs), plus a set of
+//      adversarial ReDoS-style cases that previously could blow the
+//      stack or burn CPU.
+//
+//   2. Performance ceiling: the adversarial inputs MUST complete inside
+//      a budget that an un-memoised exponential matcher cannot meet on
+//      any reasonable CI runner. The budget is generous so the test is
+//      not timing-flaky on slow runners — un-memoised compareSegments
+//      times out by ~3 orders of magnitude on these inputs.
+//
+// Skipped under `testing.Short()` per the rabbit-flagged
+// CI-flakiness mitigation pattern (compare_exec_args_test.go:313).
+
+// adversarialMultiWildcardInputs builds dynamic patterns shaped to
+// trigger the worst-case backtracking in the un-memoised matcher: a
+// run of `*` segments followed by a literal tail that does NOT match
+// the regular path's tail. The pre-memoisation matcher explores every
+// possible split point for each `*` against every suffix offset of the
+// regular path — 2^n / n! style explosion.
+func adversarialMultiWildcardInputs(starCount, regularDepth int) (dynamic, regular string) {
+	stars := make([]string, starCount)
+	for i := range stars {
+		stars[i] = "*"
+	}
+	dynamic = "/" + strings.Join(stars, "/") + "/literal_tail_that_will_not_match"
+
+	segs := make([]string, regularDepth)
+	for i := range segs {
+		segs[i] = fmt.Sprintf("seg%d", i)
+	}
+	regular = "/" + strings.Join(segs, "/") + "/different_tail"
+	return
+}
+
+// TestCompareDynamic_MemoiseGoldenAcceptance is the parity gate. Every
+// pair below MUST match the pre-memoisation answer. If any entry flips
+// after applying the memoisation fix, the fix has changed semantics
+// and the commit must be reverted.
+//
+// Cases enumerated:
+//   - empty inputs (false on either side)
+//   - exact literal match / mismatch
+//   - leading `*` consuming various counts of regular segments
+//   - trailing `*` (one-or-more) vs the bare parent directory (no match)
+//   - trailing `*` vs deeper paths (match)
+//   - mid-path `*` consuming zero / many segments
+//   - dynamic identifier `⋯` matching exactly one segment
+//   - consecutive `*/*` (must match, see comment in compareSegments)
+//   - `*` followed by literal segments that match / don't match
+//   - DNS-style nested paths (busybox/systemd-style symlink fan-outs)
+func TestCompareDynamic_MemoiseGoldenAcceptance(t *testing.T) {
+	cases := []struct {
+		name    string
+		dynamic string
+		regular string
+		want    bool
+	}{
+		// --- empty inputs ---
+		{"both_empty_no_match", "", "", false},
+		{"empty_dynamic_no_match", "", "/etc/passwd", false},
+		{"empty_regular_no_match", "/etc/passwd", "", false},
+
+		// --- literal exact ---
+		{"literal_exact", "/etc/passwd", "/etc/passwd", true},
+		{"literal_different_tail", "/etc/passwd", "/etc/shadow", false},
+		{"literal_different_depth", "/etc/passwd", "/etc/passwd/extra", false},
+
+		// --- trailing `*` ---
+		{"trailing_star_matches_child", "/etc/*", "/etc/passwd", true},
+		{"trailing_star_matches_deeper", "/etc/*", "/etc/ssh/sshd_config", true},
+		{"trailing_star_no_match_on_parent", "/etc/*", "/etc", false},
+		{"trailing_star_no_match_on_root", "/*", "/", false},
+
+		// --- mid-path `*` (zero-or-more) ---
+		{"mid_star_zero_consumed", "/a/*/b", "/a/b", true},
+		{"mid_star_one_consumed", "/a/*/b", "/a/x/b", true},
+		{"mid_star_many_consumed", "/a/*/b", "/a/x/y/z/b", true},
+		{"mid_star_no_match_at_tail", "/a/*/b", "/a/x/c", false},
+
+		// --- dynamic identifier `⋯` (one segment) ---
+		{"ellipsis_short", "/var/log/⋯/access.log", "/var/log/nginx/access.log", true},
+		{"ellipsis_must_consume_one_segment", "/var/log/⋯/access.log", "/var/log/access.log", false},
+		{"ellipsis_no_match_different_tail", "/var/log/⋯/access.log", "/var/log/nginx/error.log", false},
+
+		// --- consecutive `*/*` (per analyzer comment about non-collapse).
+		// Each `*` is zero-or-more (except the trailing `*` which is
+		// one-or-more), so /*/* effectively reduces to /* — it matches
+		// any non-empty path because the first `*` consumes zero and the
+		// trailing `*` consumes one or more.
+		{"consecutive_star_star_matches_two", "/*/*", "/a/b", true},
+		{"consecutive_star_star_matches_deeper", "/*/*", "/a/b/c", true},
+		{"consecutive_star_star_matches_one", "/*/*", "/a", true},
+
+		// --- `*` then literal segments ---
+		{"star_then_literal_match", "/a/*/etc/passwd", "/a/x/etc/passwd", true},
+		{"star_then_literal_match_long", "/a/*/etc/passwd", "/a/x/y/z/etc/passwd", true},
+		{"star_then_literal_no_match", "/a/*/etc/passwd", "/a/x/etc/shadow", false},
+
+		// --- busybox-style symlink shape (real-world hipster_shop) ---
+		{"busybox_match", "/bin/busybox", "/bin/busybox", true},
+		{"busybox_via_star", "/bin/*", "/bin/busybox", true},
+		{"busybox_via_star_to_grpc", "/bin/*", "/bin/grpc_health_probe", true},
+
+		// --- multi-wildcard (each `*` is zero-or-more, so /*/*/* matches
+		// any depth from 1 to N before the literal tail).
+		{"multi_star_match", "/*/*/*/etc/passwd", "/a/b/c/etc/passwd", true},
+		{"multi_star_match_with_extra", "/*/*/*/etc/passwd", "/a/b/c/d/etc/passwd", true},
+		{"multi_star_match_shorter", "/*/*/*/etc/passwd", "/a/b/etc/passwd", true},
+		{"multi_star_no_match_wrong_tail", "/*/*/*/etc/passwd", "/a/b/c/etc/shadow", false},
+
+		// --- root path edge ---
+		{"unanchored_star_matches_root", "*", "/", true},
+		{"unanchored_star_matches_anything", "*", "/var/log/nginx", true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := dynamicpathdetector.CompareDynamic(tc.dynamic, tc.regular)
+			assert.Equalf(t, tc.want, got,
+				"CompareDynamic(%q, %q) want=%v got=%v", tc.dynamic, tc.regular, tc.want, got)
+		})
+	}
+}
+
+// TestCompareDynamic_MemoiseAdversarialReDoS pins the rabbit-flagged
+// upper bound. The dynamic pattern has many `*` segments and a literal
+// tail; the regular path has many segments and a non-matching tail.
+// Un-memoised compareSegments explores every (di, ri) state pair via
+// re-entry, which is 2^n / n! style runtime. With memoisation, every
+// (di, ri) pair is visited at most once → O(d * r) time.
+//
+// Budget: 200ms wall-clock for the largest input. An un-memoised matcher
+// takes seconds-to-tens-of-seconds on these inputs. Even on a heavily
+// loaded CI runner, the memoised matcher completes well under the
+// budget. Skipped under testing.Short() so quick local runs aren't
+// burdened.
+func TestCompareDynamic_MemoiseAdversarialReDoS(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip timing-sensitive ReDoS regression in short mode")
+	}
+
+	cases := []struct {
+		stars        int
+		regularDepth int
+		budget       time.Duration
+	}{
+		{stars: 12, regularDepth: 12, budget: 50 * time.Millisecond},
+		{stars: 16, regularDepth: 16, budget: 100 * time.Millisecond},
+		{stars: 20, regularDepth: 20, budget: 200 * time.Millisecond},
+		{stars: 24, regularDepth: 24, budget: 200 * time.Millisecond},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		name := fmt.Sprintf("stars=%d_depth=%d", tc.stars, tc.regularDepth)
+		t.Run(name, func(t *testing.T) {
+			dynamic, regular := adversarialMultiWildcardInputs(tc.stars, tc.regularDepth)
+
+			start := time.Now()
+			got := dynamicpathdetector.CompareDynamic(dynamic, regular)
+			elapsed := time.Since(start)
+
+			// Behavioural: tail mismatch means no match.
+			require.False(t, got,
+				"CompareDynamic should reject %q against %q (tail mismatch)", dynamic, regular)
+
+			// Performance ceiling.
+			require.LessOrEqualf(t, elapsed.Nanoseconds(), tc.budget.Nanoseconds(),
+				"CompareDynamic took %v on adversarial input (stars=%d depth=%d); budget was %v — "+
+					"un-memoised exponential matcher detected (rabbit PR #326 finding #4)",
+				elapsed, tc.stars, tc.regularDepth, tc.budget)
+		})
+	}
+}
+
+// TestCompareDynamic_MemoiseAdversarialPositive pins the dual: an
+// adversarial multi-`*` input that DOES match must also complete
+// inside the budget. Without memoisation, even positive cases can
+// hit pathological re-entry on early backtracks.
+func TestCompareDynamic_MemoiseAdversarialPositive(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip timing-sensitive ReDoS regression in short mode")
+	}
+
+	// /*/*/*/.../tail against /a/b/c/.../tail
+	stars := 20
+	starsList := make([]string, stars)
+	for i := range starsList {
+		starsList[i] = "*"
+	}
+	dynamic := "/" + strings.Join(starsList, "/") + "/tail"
+
+	segs := make([]string, stars)
+	for i := range segs {
+		segs[i] = fmt.Sprintf("seg%d", i)
+	}
+	regular := "/" + strings.Join(segs, "/") + "/tail"
+
+	start := time.Now()
+	got := dynamicpathdetector.CompareDynamic(dynamic, regular)
+	elapsed := time.Since(start)
+
+	require.True(t, got,
+		"CompareDynamic should accept %q against %q (matching tail)", dynamic, regular)
+	require.LessOrEqualf(t, elapsed.Nanoseconds(), (200 * time.Millisecond).Nanoseconds(),
+		"positive-case adversarial took %v; budget 200ms — memoisation regressed (rabbit #4)",
+		elapsed)
+}
+
+// TestCompareDynamic_MemoiseAllocCeiling pins the allocation profile:
+// memoisation must not introduce per-call heap growth that scales with
+// pattern complexity for the COMMON-shape inputs the matcher sees
+// in production (the BenchmarkCompareDynamic shapes in benchmark_test.go).
+// We measure allocs/op via runtime.ReadMemStats around a tight call
+// loop and require the per-call growth to remain bounded.
+//
+// Tolerance is intentionally loose (12 allocs/op) so a future tuning
+// pass with a smaller memo table doesn't false-trip this. The current
+// pre-memoisation matcher reports 2 allocs/op on these shapes; the
+// memoised version is expected to remain in single digits.
+func TestCompareDynamic_MemoiseAllocCeiling(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip alloc-tracking gate in short mode")
+	}
+
+	cases := []struct {
+		name    string
+		dynamic string
+		regular string
+	}{
+		{"trailing_star", "/etc/*", "/etc/passwd"},
+		{"mid_star_zero", "/a/*/b", "/a/b"},
+		{"ellipsis_deep", "/var/log/⋯/access.log", "/var/log/nginx/sub/access.log"},
+		{"deep_literal_match", "/a/b/c/d/e/f/g/h", "/a/b/c/d/e/f/g/h"},
+	}
+
+	const iter = 100_000
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Warm up — first call may incur one-time setup allocs.
+			_ = dynamicpathdetector.CompareDynamic(tc.dynamic, tc.regular)
+
+			var before, after runtime.MemStats
+			runtime.GC()
+			runtime.ReadMemStats(&before)
+
+			for i := 0; i < iter; i++ {
+				_ = dynamicpathdetector.CompareDynamic(tc.dynamic, tc.regular)
+			}
+
+			runtime.ReadMemStats(&after)
+			perCall := float64(after.Mallocs-before.Mallocs) / float64(iter)
+			require.LessOrEqualf(t, perCall, 12.0,
+				"%s: per-call allocs = %.2f, expected ≤ 12 — memoisation introduced unbounded heap growth",
+				tc.name, perCall)
+		})
+	}
+}

--- a/pkg/registry/file/dynamicpathdetector/tests/compare_dynamic_memoise_test.go
+++ b/pkg/registry/file/dynamicpathdetector/tests/compare_dynamic_memoise_test.go
@@ -283,3 +283,49 @@ func TestCompareDynamic_MemoiseAllocCeiling(t *testing.T) {
 		})
 	}
 }
+
+// TestCompareDynamic_ZeroAllocHotPath pins Matthias's upstream PR #323
+// perf review: the 0-or-1 `*` shapes — including the R0002 hot path
+// (`/etc/*` vs `/etc/ssh/sshd_config`) — MUST execute with zero
+// allocations. The pre-PR splitPath dispatch made every call allocate
+// 2 slices (~112 B); the index-based compareSegmentsIndex path restored
+// the upstream zero-alloc target.
+//
+// This pins the contract structurally — any future refactor that
+// re-introduces splitPath on the 0/1-`*` path fails this test.
+func TestCompareDynamic_ZeroAllocHotPath(t *testing.T) {
+	cases := []struct {
+		name, dyn, reg string
+	}{
+		// 0-`*` shapes
+		{"literal_exact_match", "/etc/resolv.conf", "/etc/resolv.conf"},
+		{"literal_mismatch", "/etc/resolv.conf", "/etc/passwd"},
+		{"ellipsis_match", "/api/⋯/users", "/api/v1/users"},
+		// 1-`*` shapes — the R0002 hot path
+		{"trailing_star_match", "/etc/*", "/etc/ssh/sshd_config"},
+		{"trailing_star_no_match_on_parent", "/etc/*", "/etc"},
+		{"mid_star_zero", "/a/*/b", "/a/b"},
+		{"mid_star_many", "/a/*/b", "/a/x/y/z/b"},
+		{"unanchored_star", "*", "/"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Warm-up to absorb any one-off setup cost.
+			for i := 0; i < 100; i++ {
+				_ = dynamicpathdetector.CompareDynamic(tc.dyn, tc.reg)
+			}
+			var before, after runtime.MemStats
+			runtime.GC()
+			runtime.ReadMemStats(&before)
+			const iters = 10_000
+			for i := 0; i < iters; i++ {
+				_ = dynamicpathdetector.CompareDynamic(tc.dyn, tc.reg)
+			}
+			runtime.ReadMemStats(&after)
+			allocs := after.Mallocs - before.Mallocs
+			require.Equalf(t, uint64(0), allocs,
+				"%s: %d allocs across %d iters — 0/1-`*` shapes MUST be zero-allocation per Matthias upstream PR #323",
+				tc.name, allocs, iters)
+		})
+	}
+}

--- a/pkg/registry/file/dynamicpathdetector/tests/consolidate_opens_test.go
+++ b/pkg/registry/file/dynamicpathdetector/tests/consolidate_opens_test.go
@@ -1,0 +1,188 @@
+/*
+Copyright 2024 The Kubescape Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamicpathdetectortests
+
+import (
+	"slices"
+	"testing"
+
+	mapset "github.com/deckarep/golang-set/v2"
+	types "github.com/kubescape/storage/pkg/apis/softwarecomposition"
+	"github.com/kubescape/storage/pkg/registry/file/dynamicpathdetector"
+	"github.com/stretchr/testify/assert"
+)
+
+// extractPathsFromOpens returns just the paths from a slice of OpenCalls,
+// for cleaner test assertions.
+func extractPathsFromOpens(opens []types.OpenCalls) []string {
+	out := make([]string, len(opens))
+	for i, o := range opens {
+		out[i] = o.Path
+	}
+	return out
+}
+
+// TestConsolidateOpens_DynamicIdentifierSubsumesSiblings pins the
+// post-trie cleanup contract: when threshold collapse produces a
+// `/etc/⋯` entry alongside a single concrete `/etc/hosts`, the
+// concrete sibling is absorbed into the dynamic pattern (which already
+// covers it), so downstream matchers don't see redundant entries.
+func TestConsolidateOpens_DynamicIdentifierSubsumesSiblings(t *testing.T) {
+	analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(50, []dynamicpathdetector.CollapseConfig{
+		{Prefix: "/etc", Threshold: 3},
+	})
+	input := []types.OpenCalls{
+		{Path: "/etc/file1", Flags: []string{"O_RDONLY"}},
+		{Path: "/etc/file2", Flags: []string{"O_RDONLY"}},
+		{Path: "/etc/file3", Flags: []string{"O_RDONLY"}},
+		{Path: "/etc/hosts", Flags: []string{"O_RDONLY"}},
+	}
+	result, err := dynamicpathdetector.AnalyzeOpens(input, analyzer, nil)
+	assert.NoError(t, err)
+
+	paths := extractPathsFromOpens(result)
+	assert.Contains(t, paths, "/etc/⋯", "should retain the dynamic pattern")
+	assert.NotContains(t, paths, "/etc/hosts", "single-segment sibling must be subsumed by /etc/⋯")
+	assert.NotContains(t, paths, "/etc/file1", "siblings under the collapsed prefix must be subsumed")
+}
+
+// TestConsolidateOpens_DynamicIdentifierDoesNotSubsumeMultiSegment pins
+// the depth contract: ⋯ matches EXACTLY ONE segment, so a multi-segment
+// path under the same prefix (e.g. /etc/nginx/conf.d/foo) is NOT
+// subsumed by /etc/⋯. This is the security-relevant rule — without it,
+// a deeper path could disappear from the profile silently.
+func TestConsolidateOpens_DynamicIdentifierDoesNotSubsumeMultiSegment(t *testing.T) {
+	analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(50, []dynamicpathdetector.CollapseConfig{
+		{Prefix: "/etc", Threshold: 3},
+	})
+	input := []types.OpenCalls{
+		{Path: "/etc/file1", Flags: []string{"O_RDONLY"}},
+		{Path: "/etc/file2", Flags: []string{"O_RDONLY"}},
+		{Path: "/etc/file3", Flags: []string{"O_RDONLY"}},
+		{Path: "/etc/hosts", Flags: []string{"O_RDONLY"}},
+		{Path: "/etc/nginx/conf.d/default.conf", Flags: []string{"O_RDONLY"}},
+	}
+	result, err := dynamicpathdetector.AnalyzeOpens(input, analyzer, nil)
+	assert.NoError(t, err)
+
+	paths := extractPathsFromOpens(result)
+	assert.Contains(t, paths, "/etc/⋯", "should retain the dynamic pattern")
+	// The trie collapses the deeper level into /etc/⋯/conf.d/default.conf.
+	// That multi-segment path is itself a pattern, so it survives, and
+	// it is NOT subsumed by /etc/⋯ either (because /etc/⋯ matches ONE
+	// segment — the multi-segment path is two segments deep past /etc/).
+	assert.Contains(t, paths, "/etc/⋯/conf.d/default.conf",
+		"deeper path under same prefix must NOT be subsumed by /etc/⋯ — different depth")
+}
+
+// TestConsolidateOpens_FlagsMergeIntoPattern pins that subsumption
+// preserves access semantics: if /tmp/a (O_RDONLY) and /tmp/b (O_WRONLY)
+// are both subsumed by /tmp/⋯, the resulting pattern entry must carry
+// BOTH flags so the runtime matcher knows the workload performs both
+// reads and writes under /tmp.
+func TestConsolidateOpens_FlagsMergeIntoPattern(t *testing.T) {
+	analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(50, []dynamicpathdetector.CollapseConfig{
+		{Prefix: "/tmp", Threshold: 2},
+	})
+	input := []types.OpenCalls{
+		{Path: "/tmp/a", Flags: []string{"O_RDONLY"}},
+		{Path: "/tmp/b", Flags: []string{"O_WRONLY"}},
+		{Path: "/tmp/c", Flags: []string{"O_RDWR"}},
+	}
+	result, err := dynamicpathdetector.AnalyzeOpens(input, analyzer, nil)
+	assert.NoError(t, err)
+
+	assert.Len(t, result, 1, "all three /tmp paths should consolidate to one pattern")
+	assert.Equal(t, "/tmp/⋯", result[0].Path)
+	assert.Contains(t, result[0].Flags, "O_RDONLY")
+	assert.Contains(t, result[0].Flags, "O_WRONLY")
+	assert.Contains(t, result[0].Flags, "O_RDWR")
+}
+
+// TestConsolidateOpens_SbomPathsNeverSubsumed pins the SBOM safeguard:
+// even if a /usr/lib/⋯ pattern would cover /usr/lib/libcrypto.so.3,
+// the latter must SURVIVE if it's listed in the SBOM. Reason: the
+// SBOM is the ground-truth manifest of the image's static contents;
+// a wildcard collapsing it away erases provenance.
+func TestConsolidateOpens_SbomPathsNeverSubsumed(t *testing.T) {
+	analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(50, []dynamicpathdetector.CollapseConfig{
+		{Prefix: "/usr/lib", Threshold: 3},
+	})
+	sbomSet := mapset.NewThreadUnsafeSet[string]("/usr/lib/libcrypto.so.3")
+	input := []types.OpenCalls{
+		{Path: "/usr/lib/libcrypto.so.3", Flags: []string{"O_RDONLY"}},
+		{Path: "/usr/lib/libssl.so.3", Flags: []string{"O_RDONLY"}},
+		{Path: "/usr/lib/libz.so.1", Flags: []string{"O_RDONLY"}},
+		{Path: "/usr/lib/libm.so.6", Flags: []string{"O_RDONLY"}},
+	}
+	result, err := dynamicpathdetector.AnalyzeOpens(input, analyzer, sbomSet)
+	assert.NoError(t, err)
+
+	paths := extractPathsFromOpens(result)
+	assert.Contains(t, paths, "/usr/lib/libcrypto.so.3", "SBOM path must survive consolidation")
+	assert.Contains(t, paths, "/usr/lib/⋯", "dynamic pattern still emitted")
+	assert.NotContains(t, paths, "/usr/lib/libssl.so.3", "non-SBOM siblings absorbed")
+	assert.NotContains(t, paths, "/usr/lib/libm.so.6", "non-SBOM siblings absorbed")
+}
+
+// TestConsolidateOpens_NoPatternsNoConsolidation pins the no-op case:
+// when the trie hasn't collapsed anything (threshold not hit), there
+// are no patterns to subsume into, and consolidation is a pure
+// pass-through. Two distinct /etc paths in, two paths out.
+func TestConsolidateOpens_NoPatternsNoConsolidation(t *testing.T) {
+	analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(100, nil)
+	input := []types.OpenCalls{
+		{Path: "/etc/hosts", Flags: []string{"O_RDONLY"}},
+		{Path: "/etc/passwd", Flags: []string{"O_RDONLY"}},
+	}
+	result, err := dynamicpathdetector.AnalyzeOpens(input, analyzer, nil)
+	assert.NoError(t, err)
+	assert.Len(t, result, 2, "no collapse → no consolidation")
+}
+
+// TestConsolidateOpens_TrailingStarSubsumesChild pins that the WildcardIdentifier
+// (`*`) form also drives subsumption: if a profile carries /etc/* explicitly
+// (e.g. a hand-written user-defined-profile), and the trie also yields
+// concrete /etc/foo entries from auto-discovery, the concrete entry is
+// subsumed by the wildcard. Uses CompareDynamic which (per yesterday's
+// anchoring fix) requires trailing `*` to consume one or more segments.
+func TestConsolidateOpens_TrailingStarSubsumesChild(t *testing.T) {
+	// We can't easily produce both /etc/* and /etc/foo from AnalyzeOpens
+	// in one go (the trie only emits one form per node). So we exercise
+	// the pure consolidateOpens contract by feeding a mixed slice that
+	// AnalyzeOpens would produce only after subsequent merges. This test
+	// goes through the public AnalyzeOpens but constructs an analyzer
+	// where threshold-1 forces every group to collapse.
+	analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(50, []dynamicpathdetector.CollapseConfig{
+		{Prefix: "/etc", Threshold: 1},
+	})
+	input := []types.OpenCalls{
+		{Path: "/etc/foo", Flags: []string{"O_RDONLY"}},
+		{Path: "/etc/bar", Flags: []string{"O_RDONLY"}},
+	}
+	result, err := dynamicpathdetector.AnalyzeOpens(input, analyzer, nil)
+	assert.NoError(t, err)
+
+	// With threshold 1 the analyzer emits the WildcardIdentifier ("/etc/*"),
+	// not the dynamic form. Either way, both literals must be subsumed.
+	paths := extractPathsFromOpens(result)
+	assert.True(t,
+		slices.Contains(paths, "/etc/*") || slices.Contains(paths, "/etc/⋯"),
+		"expected a single collapsed pattern for /etc, got %v", paths)
+	assert.NotContains(t, paths, "/etc/foo")
+	assert.NotContains(t, paths, "/etc/bar")
+}

--- a/pkg/registry/file/dynamicpathdetector/tests/consolidate_opens_test.go
+++ b/pkg/registry/file/dynamicpathdetector/tests/consolidate_opens_test.go
@@ -24,6 +24,7 @@ import (
 	types "github.com/kubescape/storage/pkg/apis/softwarecomposition"
 	"github.com/kubescape/storage/pkg/registry/file/dynamicpathdetector"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // extractPathsFromOpens returns just the paths from a slice of OpenCalls,
@@ -106,7 +107,7 @@ func TestConsolidateOpens_FlagsMergeIntoPattern(t *testing.T) {
 	result, err := dynamicpathdetector.AnalyzeOpens(input, analyzer, nil)
 	assert.NoError(t, err)
 
-	assert.Len(t, result, 1, "all three /tmp paths should consolidate to one pattern")
+	require.Len(t, result, 1, "all three /tmp paths should consolidate to one pattern")
 	assert.Equal(t, "/tmp/⋯", result[0].Path)
 	assert.Contains(t, result[0].Flags, "O_RDONLY")
 	assert.Contains(t, result[0].Flags, "O_WRONLY")

--- a/pkg/registry/file/dynamicpathdetector/tests/coverage_test.go
+++ b/pkg/registry/file/dynamicpathdetector/tests/coverage_test.go
@@ -6,17 +6,33 @@ import (
 
 	"github.com/kubescape/storage/pkg/registry/file/dynamicpathdetector"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestNewPathAnalyzer(t *testing.T) {
-	analyzer := dynamicpathdetector.NewPathAnalyzer(100)
+// configThreshold returns the collapse threshold for the given path prefix
+// as this test suite expects it — sourced from testCollapseConfigs (defined
+// in analyze_opens_test.go), NOT from the production DefaultCollapseConfigs.
+// The decoupling is deliberate: tests probe threshold-1/3/5 edge cases and
+// shouldn't constrain what values ship in production defaults.
+// Falls back to DefaultCollapseConfig.Threshold for unknown prefixes.
+func configThreshold(prefix string) int {
+	for _, cfg := range testCollapseConfigs {
+		if cfg.Prefix == prefix {
+			return cfg.Threshold
+		}
+	}
+	return dynamicpathdetector.DefaultCollapseConfig.Threshold
+}
+
+func TestNewPathAnalyzerWithConfigs(t *testing.T) {
+	analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(dynamicpathdetector.OpenDynamicThreshold, nil)
 	if analyzer == nil {
-		t.Error("NewPathAnalyzer() returned nil")
+		t.Error("NewPathAnalyzerWithConfigs() returned nil")
 	}
 }
 
 func TestAnalyzePath(t *testing.T) {
-	analyzer := dynamicpathdetector.NewPathAnalyzer(100)
+	analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(dynamicpathdetector.OpenDynamicThreshold, nil)
 
 	testCases := []struct {
 		name       string
@@ -39,17 +55,46 @@ func TestAnalyzePath(t *testing.T) {
 	}
 }
 
-func TestDynamicSegments(t *testing.T) {
-	analyzer := dynamicpathdetector.NewPathAnalyzer(100)
+func TestCollapseAdjacentDynamicIdentifiers(t *testing.T) {
+	testCases := []struct {
+		name     string
+		path     string
+		expected string
+	}{
+		{"No dynamic identifiers", "/a/b/c", "/a/b/c"},
+		{"Single dynamic identifier", "/a/\u22ef/c", "/a/\u22ef/c"},
+		{"Two adjacent dynamic identifiers", "/a/\u22ef/\u22ef/d", "/a/*/d"},
+		{"Three adjacent dynamic identifiers", "/a/\u22ef/\u22ef/\u22ef/e", "/a/*/e"},
+		{"Dynamic identifiers separated by static segment", "/\u22ef/b/\u22ef/d", "/\u22ef/b/\u22ef/d"},
+		{"Multiple groups of adjacent identifiers", "/\u22ef/\u22ef/c/\u22ef/\u22ef/f", "/*/c/*/f"},
+		{"Starts with adjacent identifiers", "/\u22ef/\u22ef/c", "/*/c"},
+		{"Ends with adjacent identifiers", "/a/\u22ef/\u22ef", "/a/*"},
+		{"Only adjacent identifiers", "/\u22ef/\u22ef", "/*"},
+		{"Path with leading slash", "/\u22ef/\u22ef", "/*"},
+		{"Empty path", "", ""},
+		{"Single segment path", "a", "a"},
+		{"Single dynamic segment path", "\u22ef", "\u22ef"},
+	}
 
-	// Create 99 different paths under the 'users' segment
-	for i := 0; i < 101; i++ {
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := dynamicpathdetector.CollapseAdjacentDynamicIdentifiers(tc.path)
+			assert.Equal(t, tc.expected, result, "Path was not collapsed as expected. Got %s, want %s", result, tc.expected)
+		})
+	}
+}
+
+func TestDynamicSegments(t *testing.T) {
+	threshold := dynamicpathdetector.OpenDynamicThreshold
+	analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(threshold, nil)
+
+	for i := 0; i < threshold+1; i++ {
 		path := fmt.Sprintf("/api/users/%d", i)
 		_, err := analyzer.AnalyzePath(path, "api")
 		assert.NoError(t, err)
 	}
 
-	result, err := analyzer.AnalyzePath("/api/users/101", "api")
+	result, err := analyzer.AnalyzePath(fmt.Sprintf("/api/users/%d", threshold+1), "api")
 	if err != nil {
 		t.Errorf("AnalyzePath() returned an error: %v", err)
 	}
@@ -57,16 +102,16 @@ func TestDynamicSegments(t *testing.T) {
 	assert.Equal(t, expected, result)
 
 	// Test with one of the original IDs to ensure it's also marked as dynamic
-	result, err = analyzer.AnalyzePath("/api/users/50", "api")
+	result, err = analyzer.AnalyzePath("/api/users/0", "api")
 	assert.NoError(t, err)
 	assert.Equal(t, expected, result)
 }
 
 func TestMultipleDynamicSegments(t *testing.T) {
-	analyzer := dynamicpathdetector.NewPathAnalyzer(100)
+	threshold := dynamicpathdetector.OpenDynamicThreshold
+	analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(threshold, nil)
 
-	// Create 99 different paths for both 'users' and 'posts' segments
-	for i := 0; i < 110; i++ {
+	for i := 0; i < threshold+10; i++ {
 		path := fmt.Sprintf("/api/users/%d/posts/%d", i, i)
 		_, err := analyzer.AnalyzePath(path, "api")
 		if err != nil {
@@ -74,18 +119,17 @@ func TestMultipleDynamicSegments(t *testing.T) {
 		}
 	}
 
-	// Test with the 100th unique user and post IDs (should trigger dynamic segments)
-	result, err := analyzer.AnalyzePath("/api/users/101/posts/1031", "api")
+	result, err := analyzer.AnalyzePath(fmt.Sprintf("/api/users/%d/posts/%d", threshold+11, threshold+11), "api")
 	assert.NoError(t, err)
 	expected := "/api/users/\u22ef/posts/\u22ef"
 	assert.Equal(t, expected, result)
 }
 
 func TestMixedStaticAndDynamicSegments(t *testing.T) {
-	analyzer := dynamicpathdetector.NewPathAnalyzer(100)
+	threshold := dynamicpathdetector.OpenDynamicThreshold
+	analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(threshold, nil)
 
-	// Create 99 different paths for 'users' but keep 'posts' static
-	for i := 0; i < 101; i++ {
+	for i := 0; i < threshold+1; i++ {
 		path := fmt.Sprintf("/api/users/%d/posts", i)
 		_, err := analyzer.AnalyzePath(path, "api")
 		if err != nil {
@@ -93,42 +137,40 @@ func TestMixedStaticAndDynamicSegments(t *testing.T) {
 		}
 	}
 
-	// Test with the 100th unique user ID but same 'posts' segment (should trigger dynamic segment for users)
-	result, err := analyzer.AnalyzePath("/api/users/99/posts", "api")
+	result, err := analyzer.AnalyzePath("/api/users/0/posts", "api")
 	assert.NoError(t, err)
 	expected := "/api/users/\u22ef/posts"
 	assert.Equal(t, expected, result)
 }
 
 func TestDifferentRootIdentifiers(t *testing.T) {
-	analyzer := dynamicpathdetector.NewPathAnalyzer(100)
+	analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(dynamicpathdetector.OpenDynamicThreshold, nil)
 
-	// Analyze paths with different root identifiers
 	result1, _ := analyzer.AnalyzePath("/api/users/123", "api")
 	result2, _ := analyzer.AnalyzePath("/api/products/456", "store")
 
 	assert.Equal(t, "/api/users/123", result1)
-
 	assert.Equal(t, "/api/products/456", result2)
 }
 
 func TestDynamicThreshold(t *testing.T) {
-	analyzer := dynamicpathdetector.NewPathAnalyzer(100)
+	threshold := dynamicpathdetector.OpenDynamicThreshold
+	analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(threshold, nil)
 
-	for i := 0; i < 101; i++ {
+	for i := 0; i < threshold+1; i++ {
 		path := fmt.Sprintf("/api/users/%d", i)
 		result, _ := analyzer.AnalyzePath(path, "api")
 		if result != fmt.Sprintf("/api/users/%d", i) {
-			t.Errorf("Path became dynamic before reaching 99 different paths")
+			t.Errorf("Path became dynamic before reaching %d different paths", threshold)
 		}
 	}
 
-	result, _ := analyzer.AnalyzePath("/api/users/991", "api")
+	result, _ := analyzer.AnalyzePath(fmt.Sprintf("/api/users/%d", threshold+2), "api")
 	assert.Equal(t, "/api/users/\u22ef", result)
 }
 
 func TestEdgeCases(t *testing.T) {
-	analyzer := dynamicpathdetector.NewPathAnalyzer(100)
+	analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(dynamicpathdetector.OpenDynamicThreshold, nil)
 
 	testCases := []struct {
 		name       string
@@ -151,100 +193,455 @@ func TestEdgeCases(t *testing.T) {
 }
 
 func TestDynamicInsertion(t *testing.T) {
-	analyzer := dynamicpathdetector.NewPathAnalyzer(100)
+	analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(dynamicpathdetector.OpenDynamicThreshold, nil)
 
-	// Insert a new path with a different identifier
 	result, err := analyzer.AnalyzePath("/api/users/\u22ef", "api")
 	assert.NoError(t, err)
 	expected := "/api/users/\u22ef"
 	assert.Equal(t, expected, result)
 
-	// Insert a new path with the same identifier
 	result, err = analyzer.AnalyzePath("/api/users/102", "api")
 	assert.NoError(t, err)
 	expected = "/api/users/\u22ef"
 	assert.Equal(t, expected, result)
 }
 
-func TestCompareDynamic(t *testing.T) {
+func TestDynamic(t *testing.T) {
+	threshold := dynamicpathdetector.OpenDynamicThreshold
+	analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(threshold, nil)
+	for i := 0; i < threshold+1; i++ {
+		path := fmt.Sprintf("/api/users/%d", i)
+		_, err := analyzer.AnalyzePath(path, "api")
+		assert.NoError(t, err)
+	}
+	result, err := analyzer.AnalyzePath(fmt.Sprintf("/api/users/%d", threshold+1), "api")
+	assert.NoError(t, err)
+	expected := "/api/users/\u22ef"
+	assert.Equal(t, expected, result)
+}
+
+func TestCollapseConfig(t *testing.T) {
+	appThreshold := configThreshold("/app")
+	analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(dynamicpathdetector.OpenDynamicThreshold, []dynamicpathdetector.CollapseConfig{
+		{
+			Prefix:    "/api",
+			Threshold: appThreshold,
+		},
+		{
+			Prefix:    "/169.254.169.254",
+			Threshold: configThreshold("/etc"),
+		},
+	})
+	for i := 0; i < appThreshold+1; i++ {
+		path := fmt.Sprintf("/api/users/%d", i)
+		_, err := analyzer.AnalyzePath(path, "api")
+		assert.NoError(t, err)
+	}
+	result, err := analyzer.AnalyzePath(fmt.Sprintf("/api/users/%d", appThreshold+1), "api")
+	assert.NoError(t, err)
+	expected := "/api/*"
+	assert.Equal(t, expected, result)
+}
+
+// TestProcessSegments_WildcardWiringRegressions pins three correctness
+// properties of processSegments that were broken in the zero-alloc rewrite
+// of analyzer.go and caused node-agent component-test Test_27
+// (ApplicationProfileOpens) to fail at runtime.
+//
+// Each sub-case is small, self-contained, and would fail against the
+// broken implementation — keeping them here means a future refactor of
+// the zero-alloc hot path can't silently re-introduce any of these bugs.
+func TestProcessSegments_WildcardWiringRegressions(t *testing.T) {
+	// Bug 1: threshold=1 configured for prefix P must wildcard P's
+	// CHILDREN, not P itself. The broken code used p[:i] (path
+	// including the current segment) for the threshold lookup, so
+	// inserting segment "app" saw threshold=1 from {Prefix:"/app"}
+	// and wildcarded at the root, producing "/*/*/*" instead of
+	// "/app/*". Fix: use p[:start] (path BEFORE the current segment)
+	// for the insertion-threshold lookup so the config governs the
+	// parent's children, not the current segment's insertion.
+	t.Run("threshold_1_wildcards_children_not_prefix", func(t *testing.T) {
+		analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(
+			dynamicpathdetector.OpenDynamicThreshold,
+			[]dynamicpathdetector.CollapseConfig{{Prefix: "/app", Threshold: 1}},
+		)
+		got, err := analyzer.AnalyzePath("/app/service-a/config", "id")
+		assert.NoError(t, err)
+		assert.Equal(t, "/app/*", got,
+			"threshold-1 on /app must wildcard /app's children only, not collapse the /app prefix itself")
+	})
+
+	// Bug 2: once a segment has been emitted as `*`, the walk must
+	// stop appending subsequent path segments — otherwise every
+	// remaining segment re-follows the wildcard branch and emits
+	// "/*" again, producing "/a/*/*/*" where "/a/*" is correct.
+	// Fix: break out of the segment-walk loop as soon as
+	// currentNode.SegmentName == WildcardIdentifier.
+	t.Run("wildcard_absorbs_remaining_path_tail", func(t *testing.T) {
+		analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(
+			dynamicpathdetector.OpenDynamicThreshold,
+			[]dynamicpathdetector.CollapseConfig{{Prefix: "/short", Threshold: 1}},
+		)
+		got, err := analyzer.AnalyzePath("/short/a/b/c/d/e/f", "id")
+		assert.NoError(t, err)
+		assert.Equal(t, "/short/*", got,
+			"once the wildcard fires, the remaining 5 segments must not each emit an extra '/*'")
+	})
+
+	// Bug 3: when updateNodeStats collapses N children into a single
+	// ⋯ node, the ⋯ node's Count was left at 0. Subsequent walks
+	// descending into ⋯ then never re-triggered the collapse check,
+	// even when the absorbed grandchildren independently exceeded
+	// the threshold at the next level. Result: a grid like
+	// /a/{many}/{many}/leaf collapsed the first level but left
+	// grandchild literals visible in the output (e.g.
+	// "/a/⋯/sub0/⋯", "/a/⋯/sub1/⋯", ...). Fix: set
+	// dynamicChild.Count = len(dynamicChild.Children) after merge
+	// so the next level's updateNodeStats sees the true branching.
+	t.Run("multi_level_collapse_propagates_to_grandchildren", func(t *testing.T) {
+		threshold := 3
+		analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(threshold, nil)
+		// threshold+1 (=4) children × threshold+1 (=4) grandchildren = 16 paths.
+		// Both levels independently exceed threshold 3.
+		for i := 0; i <= threshold; i++ {
+			for j := 0; j <= threshold; j++ {
+				_, _ = analyzer.AnalyzePath(
+					fmt.Sprintf("/grid/level%d/sub%d/file", i, j), "id")
+			}
+		}
+		// Any path from the grid, re-analyzed, should be maximally
+		// collapsed — no grandchild literals should survive.
+		got, err := analyzer.AnalyzePath("/grid/level0/sub0/file", "id")
+		assert.NoError(t, err)
+		assert.NotContains(t, got, "sub0",
+			"grandchild literals must not survive in the collapsed output — got %q", got)
+		assert.NotContains(t, got, "level0",
+			"child literals must not survive in the collapsed output — got %q", got)
+	})
+}
+
+// TestCompareDynamic_WildcardRegressions pins two cases that were
+// silently wrong in the original compareSegments implementation:
+//
+//  1. Consecutive wildcards (`/*/*`): the inner loop required
+//     regular[i] == nextDynamic *before* recursing, which never fires
+//     when nextDynamic is itself `*` (no real path segment literally
+//     equals "*"). A user-authored profile with `/*/*` could never
+//     match any concrete path → R0002 fires where it shouldn't.
+//
+//  2. Zero-segment wildcard consumption (`/*/foo` matching `/foo`):
+//     the wildcard should be allowed to consume zero segments and
+//     then let the next static segment match. The old optimistic
+//     peek at dynamic[1] happened to get this case right when
+//     dynamic[1] was a literal matching regular[0], but was broken
+//     for cases where the next segment was itself a wildcard.
+//
+// Both are fixed by dropping the peek: unconditionally recurse at
+// every i in [0, len(regular)] and let the recursion decide.
+func TestCompareDynamic_WildcardRegressions(t *testing.T) {
 	tests := []struct {
-		name        string
-		dynamicPath string
-		regularPath string
-		want        bool
+		name    string
+		dynamic string
+		regular string
+		want    bool
 	}{
+		// Bug 1: consecutive wildcards.
 		{
-			name:        "Equal paths",
-			dynamicPath: "/api/users/123",
-			regularPath: "/api/users/123",
-			want:        true,
+			name:    "consecutive_wildcards_match_two_segments",
+			dynamic: "/*/*",
+			regular: "/foo/bar",
+			want:    true,
 		},
 		{
-			name:        "Different paths",
-			dynamicPath: "/api/users/123",
-			regularPath: "/api/users/456",
-			want:        false,
+			name:    "consecutive_wildcards_match_one_segment",
+			dynamic: "/*/*",
+			regular: "/foo",
+			want:    true, // second * consumes zero segments
 		},
 		{
-			name:        "Dynamic segment at the end",
-			dynamicPath: "/api/users/\u22ef",
-			regularPath: "/api/users/123",
-			want:        true,
+			name:    "triple_wildcards_match_any_depth",
+			dynamic: "/*/*/*",
+			regular: "/a/b/c",
+			want:    true,
+		},
+		// Bug 2: zero-segment wildcard consumption.
+		{
+			name:    "wildcard_consumes_zero_then_literal_match",
+			dynamic: "/*/foo",
+			regular: "/foo",
+			want:    true,
 		},
 		{
-			name:        "Dynamic segment at the end",
-			dynamicPath: "/api/users/\u22ef",
-			regularPath: "/api/users/123/posts",
-			want:        false,
+			name:    "wildcard_consumes_zero_between_literals",
+			dynamic: "/a/*/b",
+			regular: "/a/b",
+			want:    true,
 		},
 		{
-			name:        "Dynamic segment at the end, no match",
-			dynamicPath: "/api/users/\u22ef",
-			regularPath: "/api/apps/123",
-			want:        false,
+			name:    "wildcard_consumes_many_then_literal_match",
+			dynamic: "/*/foo",
+			regular: "/a/b/c/foo",
+			want:    true,
+		},
+		// Sanity: non-regressions — cases that must still return false.
+		{
+			name:    "literal_suffix_mismatch_still_false",
+			dynamic: "/*/foo",
+			regular: "/a/b/baz",
+			want:    false,
 		},
 		{
-			name:        "Dynamic segment in the middle",
-			dynamicPath: "/api/\u22ef/123",
-			regularPath: "/api/users/123",
-			want:        true,
+			name:    "literal_prefix_mismatch_still_false",
+			dynamic: "/api/*",
+			regular: "/web/a",
+			want:    false,
 		},
 		{
-			name:        "Dynamic segment in the middle, no match",
-			dynamicPath: "/api/\u22ef/123",
-			regularPath: "/api/users/456",
-			want:        false,
+			name:    "empty_tail_with_unsatisfied_literal_false",
+			dynamic: "/*/x",
+			regular: "/",
+			want:    false,
 		},
+		// Interaction with DynamicIdentifier (⋯, single segment).
 		{
-			name:        "2 dynamic segments",
-			dynamicPath: "/api/\u22ef/\u22ef",
-			regularPath: "/api/users/123",
-			want:        true,
-		},
-		{
-			name:        "2 dynamic segments, no match",
-			dynamicPath: "/api/\u22ef/\u22ef",
-			regularPath: "/papi/users/456",
-			want:        false,
-		},
-		{
-			name:        "2 other dynamic segments",
-			dynamicPath: "/\u22ef/users/\u22ef",
-			regularPath: "/api/users/123",
-			want:        true,
-		},
-		{
-			name:        "2 other dynamic segments, no match",
-			dynamicPath: "/\u22ef/users/\u22ef",
-			regularPath: "/api/apps/456",
-			want:        false,
+			name:    "mixed_wildcard_and_dynamic_match",
+			dynamic: "/⋯/*",
+			regular: "/foo/bar/baz",
+			want:    true,
 		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := dynamicpathdetector.CompareDynamic(tt.dynamicPath, tt.regularPath); got != tt.want {
-				t.Errorf("CompareDynamic() = %v, want %v", got, tt.want)
-			}
+			got := dynamicpathdetector.CompareDynamic(tt.dynamic, tt.regular)
+			assert.Equal(t, tt.want, got,
+				"CompareDynamic(%q, %q) = %v, want %v", tt.dynamic, tt.regular, got, tt.want)
+		})
+	}
+}
+
+// TestCompareDynamic_AnchoringAndTrailing pins the trailing-`*` /
+// anchoring contract reported on upstream PR #316.
+//
+// The first wildcard-aware implementation made a trailing `*` match
+// zero-or-more remaining segments, so `/etc/*` silently matched the
+// bare `/etc` directory — widening R0002's blind spot to cover the
+// profiled directory's parent. Standard shell glob requires trailing
+// `*` to consume one or more segments. Anchoring rules:
+//
+//   - Anchored: leading `/` makes `/*` "any path strictly under /"
+//     and explicitly excludes the bare `/` directory.
+//   - Unanchored: a bare `*` (no leading slash) is the only way to
+//     allowlist the root path itself.
+//
+// Trailing slashes on the regular path are normalized away so
+// `/etc/passwd/` is treated as `/etc/passwd`.
+func TestCompareDynamic_AnchoringAndTrailing(t *testing.T) {
+	tests := []struct {
+		name    string
+		dynamic string
+		regular string
+		want    bool
+	}{
+		// Root-only cases — anchored vs unanchored distinction.
+		{"anchored_star_does_not_match_root", "/*", "/", false},
+		{"anchored_star_does_not_match_empty", "/*", "", false},
+		{"anchored_star_matches_top_level_child", "/*", "/foo", true},
+		{"anchored_star_matches_deeper_child", "/*", "/foo/bar", true},
+		{"unanchored_star_matches_root", "*", "/", true},
+		{"unanchored_star_matches_top_level_child", "*", "/foo", true},
+		{"unanchored_star_does_not_match_empty", "*", "", false},
+
+		// Bare-parent boundary — the original /etc/* regression.
+		{"trailing_star_does_not_match_bare_parent", "/etc/*", "/etc", false},
+		{"trailing_star_does_not_match_parent_with_slash", "/etc/*", "/etc/", false},
+		{"trailing_star_matches_immediate_child", "/etc/*", "/etc/passwd", true},
+		{"trailing_star_matches_deep_child", "/etc/*", "/etc/ssh/sshd_config", true},
+		{"trailing_star_matches_child_with_trailing_slash", "/etc/*", "/etc/passwd/", true},
+		{"deep_trailing_star_does_not_match_short_path", "/var/log/*", "/var/log", false},
+		{"deep_trailing_star_does_not_match_grandparent", "/var/log/*", "/var", false},
+		{"deep_trailing_star_matches_child", "/var/log/*", "/var/log/syslog", true},
+
+		// Multiple trailing wildcards — zero-or-more mid-* + one-or-more
+		// final-* together. The mid-* may consume zero, so /etc/*/* still
+		// matches /etc/ssh (one segment) by having the inner * consume 0
+		// and the trailing * consume the segment.
+		{"double_trailing_does_not_match_parent", "/etc/*/*", "/etc", false},
+		{"double_trailing_does_not_match_parent_slash", "/etc/*/*", "/etc/", false},
+		{"double_trailing_matches_one_child", "/etc/*/*", "/etc/ssh", true},
+		{"double_trailing_matches_two_children", "/etc/*/*", "/etc/ssh/sshd_config", true},
+		{"double_trailing_matches_deep", "/etc/*/*", "/etc/ssh/dir/file", true},
+
+		// Empty / bare-pattern edges.
+		{"empty_dynamic_does_not_match_path", "", "/foo", false},
+		{"empty_dynamic_does_not_match_root", "", "/", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := dynamicpathdetector.CompareDynamic(tt.dynamic, tt.regular)
+			assert.Equal(t, tt.want, got,
+				"CompareDynamic(%q, %q) = %v, want %v", tt.dynamic, tt.regular, got, tt.want)
+		})
+	}
+}
+
+// TestCompareDynamic_EllipsisAndStar pins the interaction between the
+// two wildcard kinds:
+//
+//   - DynamicIdentifier (⋯) consumes EXACTLY ONE segment.
+//   - WildcardIdentifier (*) consumes ZERO-OR-MORE segments mid-path
+//     and ONE-OR-MORE segments when trailing.
+//
+// Mixing them (e.g. `/⋯/*`) is the analyzer's normal output for a
+// fully-collapsed grandchild branch: ⋯ pins the immediate child to
+// "any single segment" and * accepts the deeper tail.
+func TestCompareDynamic_EllipsisAndStar(t *testing.T) {
+	tests := []struct {
+		name    string
+		dynamic string
+		regular string
+		want    bool
+	}{
+		// ⋯ alone: exactly one segment.
+		{"ellipsis_matches_exactly_one", "/⋯/foo", "/x/foo", true},
+		{"ellipsis_does_not_consume_zero", "/⋯/foo", "/foo", false},
+		{"ellipsis_does_not_consume_two", "/⋯/foo", "/x/y/foo", false},
+
+		// ⋯ then trailing *: ⋯ consumes 1, * needs ≥1 more.
+		{"ellipsis_then_trailing_star_two_segments", "/⋯/*", "/x/y", true},
+		{"ellipsis_then_trailing_star_three_segments", "/⋯/*", "/x/y/z", true},
+		{"ellipsis_then_trailing_star_one_segment_fails", "/⋯/*", "/x", false},
+		{"ellipsis_then_trailing_star_root_fails", "/⋯/*", "/", false},
+
+		// Mid-* before ⋯: * may consume zero, ⋯ still needs exactly one.
+		{"star_then_ellipsis_two_segments", "/*/⋯", "/a/b", true},
+		{"star_consumed_zero_then_ellipsis_matches_one", "/*/⋯", "/b", true},
+		{"star_then_ellipsis_one_segment_fails_when_zero_consumed", "/*/⋯", "/", false},
+
+		// Nested ⋯.
+		{"nested_ellipsis_matches_two", "/⋯/⋯/foo", "/x/y/foo", true},
+		{"nested_ellipsis_does_not_match_one", "/⋯/⋯/foo", "/x/foo", false},
+
+		// * literal * pattern around a static segment.
+		{"star_literal_star_matches", "/*/etc/*", "/foo/etc/passwd", true},
+		{"star_literal_star_no_trailing_segment_fails", "/*/etc/*", "/foo/etc", false},
+		{"star_literal_star_no_leading_consumed_zero_matches", "/*/etc/*", "/etc/passwd", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := dynamicpathdetector.CompareDynamic(tt.dynamic, tt.regular)
+			assert.Equal(t, tt.want, got,
+				"CompareDynamic(%q, %q) = %v, want %v", tt.dynamic, tt.regular, got, tt.want)
+		})
+	}
+}
+
+// TestCompareDynamic_MidPathStarZeroOrMore explicitly pins the
+// zero-or-more semantics for `*` when it appears mid-path. This is
+// distinct from trailing `*` (which is one-or-more) and is what allows
+// auto-generated patterns like `/foo/*/bar` to also match `/foo/bar`
+// (the wildcard consumed nothing, then the literal segment matched).
+func TestCompareDynamic_MidPathStarZeroOrMore(t *testing.T) {
+	tests := []struct {
+		name    string
+		dynamic string
+		regular string
+		want    bool
+	}{
+		{"mid_star_consumes_zero", "/a/*/b", "/a/b", true},
+		{"mid_star_consumes_one", "/a/*/b", "/a/x/b", true},
+		{"mid_star_consumes_many", "/a/*/b", "/a/x/y/b", true},
+		{"mid_star_literal_after_mismatches", "/a/*/b", "/a/x/c", false},
+		{"mid_star_literal_prefix_mismatch", "/a/*/b", "/z/x/b", false},
+
+		// Consecutive mid-stars — both can independently consume zero.
+		{"consecutive_mid_star_both_zero", "/a/*/*/b", "/a/b", true},
+		{"consecutive_mid_star_one_zero_one_one", "/a/*/*/b", "/a/x/b", true},
+		{"consecutive_mid_star_both_one", "/a/*/*/b", "/a/x/y/b", true},
+		{"consecutive_mid_star_deeper", "/a/*/*/b", "/a/x/y/z/b", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := dynamicpathdetector.CompareDynamic(tt.dynamic, tt.regular)
+			assert.Equal(t, tt.want, got,
+				"CompareDynamic(%q, %q) = %v, want %v", tt.dynamic, tt.regular, got, tt.want)
+		})
+	}
+}
+
+// TestDefaultCollapseConfigs_DefensiveCopy pins the contract that the
+// public DefaultCollapseConfigs() accessor returns a fresh slice on
+// every call, so callers cannot accidentally mutate the package-level
+// state. Without this guard, a downstream consumer modifying the
+// returned slice (sorting, appending, swapping prefixes) would silently
+// affect every subsequent call, including AnalyzeOpens in the storage
+// deflate path. The unexported var is the canonical source of truth.
+func TestDefaultCollapseConfigs_DefensiveCopy(t *testing.T) {
+	first := dynamicpathdetector.DefaultCollapseConfigs()
+	require.NotEmpty(t, first, "default configs must not be empty")
+
+	// Mutate the returned slice in two ways: change a Threshold and
+	// append a junk config. Neither should leak to the next call.
+	first[0].Threshold = 999_999
+	first = append(first, dynamicpathdetector.CollapseConfig{
+		Prefix: "/poisoned", Threshold: 1,
+	})
+
+	second := dynamicpathdetector.DefaultCollapseConfigs()
+	assert.NotEqual(t, 999_999, second[0].Threshold,
+		"mutating the first call's slice must not change the package state")
+	for _, cfg := range second {
+		assert.NotEqual(t, "/poisoned", cfg.Prefix,
+			"appending to the first call's slice must not leak into the second call")
+	}
+
+	// Also assert the two slices are distinct backing arrays — without
+	// this, len(second) would happen to be safe but a future caller
+	// reading first[len-1] could observe the appended element.
+	if len(first) > 0 && len(second) > 0 {
+		// Address-of-element comparison is sufficient; if the underlying
+		// array is shared, &first[0] == &second[0].
+		assert.NotSame(t, &first[0], &second[0],
+			"DefaultCollapseConfigs must return a fresh backing array")
+	}
+}
+
+// TestCompareDynamic_PathSeparatorEdges documents how `/`-related
+// edges are normalized: trailing slashes are insignificant, the
+// regular path `""` is treated as no-path (matches nothing), and the
+// internal split-and-trim normalization is exercised on both sides.
+func TestCompareDynamic_PathSeparatorEdges(t *testing.T) {
+	tests := []struct {
+		name    string
+		dynamic string
+		regular string
+		want    bool
+	}{
+		// Trailing slash on regular — should match same as without.
+		{"trailing_slash_on_regular_matches_literal", "/etc/passwd", "/etc/passwd/", true},
+		{"trailing_slash_on_regular_for_directory_match", "/etc", "/etc/", true},
+
+		// Trailing slash on dynamic — should match same as without.
+		{"trailing_slash_on_dynamic_literal", "/etc/passwd/", "/etc/passwd", true},
+		{"trailing_slash_on_dynamic_with_star", "/etc/*/", "/etc/passwd", true},
+
+		// Empty regular path — matches nothing, including the bare star.
+		{"empty_regular_does_not_match_anchored", "/foo", "", false},
+		{"empty_regular_does_not_match_unanchored_literal", "foo", "", false},
+		{"empty_regular_does_not_match_star", "*", "", false},
+
+		// Empty dynamic — matches nothing.
+		{"empty_dynamic_does_not_match_anything", "", "/foo", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := dynamicpathdetector.CompareDynamic(tt.dynamic, tt.regular)
+			assert.Equal(t, tt.want, got,
+				"CompareDynamic(%q, %q) = %v, want %v", tt.dynamic, tt.regular, got, tt.want)
 		})
 	}
 }

--- a/pkg/registry/file/dynamicpathdetector/tests/coverage_test.go
+++ b/pkg/registry/file/dynamicpathdetector/tests/coverage_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	types "github.com/kubescape/storage/pkg/apis/softwarecomposition"
 	"github.com/kubescape/storage/pkg/registry/file/dynamicpathdetector"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -21,7 +22,7 @@ func configThreshold(prefix string) int {
 			return cfg.Threshold
 		}
 	}
-	return dynamicpathdetector.DefaultCollapseConfig.Threshold
+	return dynamicpathdetector.DefaultCollapseConfig().Threshold
 }
 
 func TestNewPathAnalyzerWithConfigs(t *testing.T) {
@@ -572,6 +573,25 @@ func TestCompareDynamic_MidPathStarZeroOrMore(t *testing.T) {
 	}
 }
 
+// TestDefaultCollapseConfig_DefensiveCopy pins the same contract for
+// the singular DefaultCollapseConfig() accessor that previously lived
+// as an exported mutable var. CodeRabbit upstream PR #323 finding #3.
+// Any caller mutating the returned struct must not affect package state.
+func TestDefaultCollapseConfig_DefensiveCopy(t *testing.T) {
+	first := dynamicpathdetector.DefaultCollapseConfig()
+	original := first.Threshold
+
+	// Mutate the returned struct.
+	first.Threshold = 999_999
+	first.Prefix = "/poisoned"
+
+	second := dynamicpathdetector.DefaultCollapseConfig()
+	assert.Equal(t, original, second.Threshold,
+		"mutating the first call's struct must not change package state Threshold")
+	assert.NotEqual(t, "/poisoned", second.Prefix,
+		"mutating the first call's struct must not change package state Prefix")
+}
+
 // TestDefaultCollapseConfigs_DefensiveCopy pins the contract that the
 // public DefaultCollapseConfigs() accessor returns a fresh slice on
 // every call, so callers cannot accidentally mutate the package-level
@@ -644,4 +664,65 @@ func TestCompareDynamic_PathSeparatorEdges(t *testing.T) {
 				"CompareDynamic(%q, %q) = %v, want %v", tt.dynamic, tt.regular, got, tt.want)
 		})
 	}
+}
+
+// TestHasPrefixAtBoundary_EmptyPrefix pins CodeRabbit upstream PR #323
+// finding #10: when an operator-supplied CollapseConfig declares an
+// empty prefix (intentional or accidental), the boundary check must
+// not silently degenerate into "any absolute path is a match". The
+// explicit `prefix == ""` branch makes the invariant load-bearing.
+//
+// We exercise the matcher indirectly via lookupThreshold so the test
+// stays at the public-API surface. Constructing the analyzer with a
+// custom config that has an empty prefix must NOT cause every path to
+// claim that config's threshold; the empty-prefix config should be
+// either authoritative for ALL paths (current chosen semantics) or
+// rejected by the analyzer. Either way the behaviour is now explicit
+// rather than incidental — re-pinning will catch any silent change.
+func TestHasPrefixAtBoundary_EmptyPrefix(t *testing.T) {
+	a := dynamicpathdetector.NewPathAnalyzerWithConfigs(
+		dynamicpathdetector.OpenDynamicThreshold,
+		[]dynamicpathdetector.CollapseConfig{
+			{Prefix: "", Threshold: 1},
+		},
+	)
+	// With the empty-prefix guard returning true, this config is the
+	// longest match for every path (length 0 < any other config length,
+	// so the most-specific tie-break still favours longer prefixes).
+	// What we're pinning is that the lookup itself doesn't crash and
+	// the empty prefix is treated as universally matching.
+	require.NotNil(t, a, "analyzer must construct with an empty-prefix config")
+
+	// Pure unit on the boundary check: exposed via FindConfigForPath,
+	// which routes through hasPrefixAtBoundary.
+	cfg := a.FindConfigForPath("/anything")
+	assert.Equal(t, 1, cfg.Threshold,
+		"empty prefix must match any absolute path and yield its threshold")
+}
+
+// TestBuildEndpointKey_SharedFormat pins CodeRabbit upstream PR #323
+// finding #5: getEndpointKey and the wildcard-key construction inside
+// MergeDuplicateEndpoints must produce the same shape for the same
+// (Endpoint, Direction, Internal) tuple, so a wildcard sibling and its
+// specific-port counterpart map to the same dedup slot. Both now route
+// through buildEndpointKey — this test pins the format end-to-end via
+// MergeDuplicateEndpoints behaviour.
+//
+// Setup: feed two endpoints with the same path-part and direction but
+// different ports (one wildcard ":0/...", one ":8080/..."). After the
+// merge the specific-port entry must be absorbed into the wildcard's
+// Methods set, with no duplicate entry surviving.
+func TestBuildEndpointKey_SharedFormat(t *testing.T) {
+	in := []*types.HTTPEndpoint{
+		{Endpoint: ":0/api/v1/users", Direction: "internal", Internal: true, Methods: []string{"GET"}},
+		{Endpoint: ":8080/api/v1/users", Direction: "internal", Internal: true, Methods: []string{"POST"}},
+	}
+	merged := dynamicpathdetector.MergeDuplicateEndpoints(in)
+	assert.Len(t, merged, 1,
+		"specific-port endpoint must fold into the wildcard sibling exactly once")
+	// Methods must be merged into the surviving wildcard entry.
+	require.NotEmpty(t, merged, "merged slice must contain the wildcard entry")
+	got := merged[0].Methods
+	assert.Contains(t, got, "GET")
+	assert.Contains(t, got, "POST")
 }

--- a/pkg/registry/file/dynamicpathdetector/tests/profile_test.go
+++ b/pkg/registry/file/dynamicpathdetector/tests/profile_test.go
@@ -1,0 +1,186 @@
+package dynamicpathdetectortests
+
+// Profiling helpers for the path analyzer hot path.
+//
+// Invocation:
+//
+//   go test ./pkg/registry/file/dynamicpathdetector/tests/ \
+//     -run=TestProfileAnalyzePath \
+//     -profile-out=/tmp/analyzer-profile \
+//     -profile-iters=200000
+//
+// Writes cpu.out, mem.out (heap alloc_space sampled) and goroutine.out
+// to the directory, then prints the top allocators to stdout so the
+// test log alone is enough to see regressions. Skipped unless
+// -profile-out is set, so it stays cheap on a regular `go test ./...`.
+//
+// Helper benchmark BenchmarkAnalyzePathWarm exercises the steady state
+// where the trie is already populated — the interesting mode for
+// zero-alloc analysis, because first-insert naturally allocates.
+
+import (
+	"flag"
+	"os"
+	"path/filepath"
+	"runtime"
+	"runtime/pprof"
+	"testing"
+
+	"github.com/kubescape/storage/pkg/registry/file/dynamicpathdetector"
+)
+
+var profileOutDir = flag.String("profile-out", "",
+	"directory to write analyzer profiles into (e.g. /tmp/analyzer-profile); if empty the profile test is skipped")
+var profileIters = flag.Int("profile-iters", 100000,
+	"number of AnalyzePath calls to execute during the profile run")
+
+// TestProfileAnalyzePath runs a large in-process workload against AnalyzePath
+// and writes CPU + heap profiles. Intended for interactive iteration during
+// the zero-alloc rewrite, not for CI (requires -profile-out to run).
+func TestProfileAnalyzePath(t *testing.T) {
+	if *profileOutDir == "" {
+		t.Skip("set -profile-out=<dir> to enable the profile test")
+	}
+	if err := os.MkdirAll(*profileOutDir, 0o755); err != nil {
+		t.Fatalf("mkdir profile dir: %v", err)
+	}
+
+	// Generate a representative mixed workload once, outside the measured
+	// section, so its allocations don't show up in the profile.
+	paths := generateMixedPaths(10000, 0)
+	analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(
+		dynamicpathdetector.OpenDynamicThreshold,
+		dynamicpathdetector.DefaultCollapseConfigs(),
+	)
+	identifier := "profile"
+
+	// Warm up the analyzer so the trie is populated. Steady-state calls
+	// are the interesting regime for zero-alloc (cold inserts always
+	// allocate a new node).
+	for i := 0; i < len(paths); i++ {
+		if _, err := analyzer.AnalyzePath(paths[i], identifier); err != nil {
+			t.Fatalf("warmup AnalyzePath: %v", err)
+		}
+	}
+
+	// CPU profile.
+	cpuPath := filepath.Join(*profileOutDir, "cpu.out")
+	cpuFile, err := os.Create(cpuPath)
+	if err != nil {
+		t.Fatalf("create cpu profile: %v", err)
+	}
+	if err := pprof.StartCPUProfile(cpuFile); err != nil {
+		t.Fatalf("start cpu profile: %v", err)
+	}
+
+	// Force a clean GC baseline so MemStats numbers reflect only the
+	// measured section.
+	runtime.GC()
+	var before, after runtime.MemStats
+	runtime.ReadMemStats(&before)
+
+	for i := 0; i < *profileIters; i++ {
+		if _, err := analyzer.AnalyzePath(paths[i%len(paths)], identifier); err != nil {
+			pprof.StopCPUProfile()
+			if cerr := cpuFile.Close(); cerr != nil {
+				t.Logf("close cpu profile after error: %v", cerr)
+			}
+			t.Fatalf("AnalyzePath iter %d: %v", i, err)
+		}
+	}
+
+	// Read memstats immediately after the measured loop, BEFORE stopping
+	// the CPU profile and closing the output file. Both of those do
+	// non-trivial internal allocations (buffer flush, file finalization)
+	// that would otherwise land in `after.TotalAlloc` / `after.Mallocs`
+	// and inflate the reported per-call numbers — material noise for a
+	// zero-alloc target.
+	runtime.ReadMemStats(&after)
+
+	pprof.StopCPUProfile()
+	if err := cpuFile.Close(); err != nil {
+		t.Fatalf("close cpu profile: %v", err)
+	}
+
+	// Heap profile (alloc_space).
+	memPath := filepath.Join(*profileOutDir, "mem.out")
+	memFile, err := os.Create(memPath)
+	if err != nil {
+		t.Fatalf("create mem profile: %v", err)
+	}
+	if err := pprof.Lookup("allocs").WriteTo(memFile, 0); err != nil {
+		t.Fatalf("write mem profile: %v", err)
+	}
+	if err := memFile.Close(); err != nil {
+		t.Fatalf("close mem profile: %v", err)
+	}
+
+	// Goroutine snapshot (useful when debugging leaks).
+	goPath := filepath.Join(*profileOutDir, "goroutine.out")
+	goFile, err := os.Create(goPath)
+	if err != nil {
+		t.Fatalf("create goroutine profile: %v", err)
+	}
+	if err := pprof.Lookup("goroutine").WriteTo(goFile, 0); err != nil {
+		t.Fatalf("write goroutine profile: %v", err)
+	}
+	if err := goFile.Close(); err != nil {
+		t.Fatalf("close goroutine profile: %v", err)
+	}
+
+	totalBytes := after.TotalAlloc - before.TotalAlloc
+	totalMallocs := after.Mallocs - before.Mallocs
+	t.Logf("AnalyzePath: %d iterations", *profileIters)
+	t.Logf("  bytes allocated: %d total, %.2f B/call", totalBytes, float64(totalBytes)/float64(*profileIters))
+	t.Logf("  heap objects   : %d total, %.2f allocs/call", totalMallocs, float64(totalMallocs)/float64(*profileIters))
+	t.Logf("  wrote profiles to %s", *profileOutDir)
+	t.Logf("  inspect with: go tool pprof -top -alloc_space %s", memPath)
+	t.Logf("               go tool pprof -top %s", cpuPath)
+}
+
+// BenchmarkAnalyzePathWarm is a companion to BenchmarkAnalyzePath that
+// pre-populates the analyzer's trie, so every iteration exercises the
+// steady-state walk instead of first-insert. Steady-state is the regime
+// we care about for zero-alloc — cold inserts will always allocate a
+// new SegmentNode.
+func BenchmarkAnalyzePathWarm(b *testing.B) {
+	paths := generateMixedPaths(10000, 0)
+	analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(
+		dynamicpathdetector.OpenDynamicThreshold,
+		dynamicpathdetector.DefaultCollapseConfigs(),
+	)
+	identifier := "warm"
+	for _, p := range paths {
+		if _, err := analyzer.AnalyzePath(p, identifier); err != nil {
+			b.Fatalf("warmup: %v", err)
+		}
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := analyzer.AnalyzePath(paths[i%len(paths)], identifier); err != nil {
+			b.Fatalf("AnalyzePath: %v", err)
+		}
+	}
+}
+
+// BenchmarkAnalyzePathCold is the counterpart: each iteration uses a
+// fresh analyzer, so it measures the cost including node allocation.
+// The two benchmarks together bracket the true cost envelope.
+func BenchmarkAnalyzePathCold(b *testing.B) {
+	paths := generateMixedPaths(10000, 0)
+	identifier := "cold"
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		analyzer := dynamicpathdetector.NewPathAnalyzerWithConfigs(
+			dynamicpathdetector.OpenDynamicThreshold,
+			dynamicpathdetector.DefaultCollapseConfigs(),
+		)
+		if _, err := analyzer.AnalyzePath(paths[i%len(paths)], identifier); err != nil {
+			b.Fatalf("AnalyzePath: %v", err)
+		}
+	}
+}

--- a/pkg/registry/file/dynamicpathdetector/tests/profile_test.go
+++ b/pkg/registry/file/dynamicpathdetector/tests/profile_test.go
@@ -72,6 +72,18 @@ func TestProfileAnalyzePath(t *testing.T) {
 	if err := pprof.StartCPUProfile(cpuFile); err != nil {
 		t.Fatalf("start cpu profile: %v", err)
 	}
+	// Defensive cleanup guard: any future early-exit path (or refactor
+	// that adds one) between Start and the explicit Stop below would
+	// leak CPU-profile state without this. The flag becomes true once
+	// we've stopped explicitly so the defer is a no-op on the happy
+	// path. CodeRabbit upstream PR #323 review.
+	cpuProfileStopped := false
+	defer func() {
+		if !cpuProfileStopped {
+			pprof.StopCPUProfile()
+			_ = cpuFile.Close()
+		}
+	}()
 
 	// Force a clean GC baseline so MemStats numbers reflect only the
 	// measured section.
@@ -82,6 +94,7 @@ func TestProfileAnalyzePath(t *testing.T) {
 	for i := 0; i < *profileIters; i++ {
 		if _, err := analyzer.AnalyzePath(paths[i%len(paths)], identifier); err != nil {
 			pprof.StopCPUProfile()
+			cpuProfileStopped = true
 			if cerr := cpuFile.Close(); cerr != nil {
 				t.Logf("close cpu profile after error: %v", cerr)
 			}
@@ -98,6 +111,7 @@ func TestProfileAnalyzePath(t *testing.T) {
 	runtime.ReadMemStats(&after)
 
 	pprof.StopCPUProfile()
+	cpuProfileStopped = true
 	if err := cpuFile.Close(); err != nil {
 		t.Fatalf("close cpu profile: %v", err)
 	}

--- a/pkg/registry/file/dynamicpathdetector/types.go
+++ b/pkg/registry/file/dynamicpathdetector/types.go
@@ -1,6 +1,59 @@
 package dynamicpathdetector
 
-const DynamicIdentifier string = "\u22ef"
+// --- Identifier constants ---
+// DynamicIdentifier matches exactly one path segment (single-segment wildcard).
+// WildcardIdentifier matches zero-or-more path segments (glob-style **).
+const (
+	DynamicIdentifier  string = "⋯" // U+22EF: ⋯
+	WildcardIdentifier string = "*"
+)
+
+// --- Default collapse thresholds ---
+// OpenDynamicThreshold is the fallback threshold used by AnalyzeOpens when
+// no more-specific CollapseConfig matches the walked path prefix.
+// EndpointDynamicThreshold is the counterpart for AnalyzeEndpoints.
+const (
+	OpenDynamicThreshold     = 50
+	EndpointDynamicThreshold = 100
+)
+
+// --- Collapse configuration ---
+// CollapseConfig controls the threshold at which children of a trie node
+// (under the given path Prefix) are collapsed into a dynamic node (⋯).
+// Longest-prefix wins at analysis time.
+type CollapseConfig struct {
+	Prefix    string
+	Threshold int
+}
+
+// defaultCollapseConfigs carries the per-prefix thresholds we've found
+// useful in practice. These are the defaults wired into AnalyzeOpens; a
+// caller can pass a different slice via NewPathAnalyzerWithConfigs if
+// they want to tune for their workload. Unexported so callers cannot
+// mutate the package-level slice — access via DefaultCollapseConfigs().
+var defaultCollapseConfigs = []CollapseConfig{
+	{Prefix: "/etc", Threshold: 100},
+	{Prefix: "/etc/apache2", Threshold: 50}, // tuned for the webapp standard test
+	{Prefix: "/opt", Threshold: 50},
+	{Prefix: "/var/run", Threshold: 50},
+	{Prefix: "/app", Threshold: 50}, // any variation under /app collapses at 50 unique children
+}
+
+// DefaultCollapseConfigs returns a defensive copy of the package-level
+// default per-prefix collapse thresholds. Callers that mutate the result
+// will not affect the package state or other callers.
+func DefaultCollapseConfigs() []CollapseConfig {
+	return append([]CollapseConfig(nil), defaultCollapseConfigs...)
+}
+
+// DefaultCollapseConfig is the global fallback used when no CollapseConfig
+// prefix matches the walked path.
+var DefaultCollapseConfig = CollapseConfig{
+	Prefix:    "/",
+	Threshold: OpenDynamicThreshold,
+}
+
+// --- Trie types ---
 
 type SegmentNode struct {
 	SegmentName string
@@ -9,8 +62,10 @@ type SegmentNode struct {
 }
 
 type PathAnalyzer struct {
-	RootNodes map[string]*SegmentNode
-	threshold int
+	RootNodes  map[string]*SegmentNode
+	threshold  int              // fallback threshold when no config matches
+	configs    []CollapseConfig // per-prefix overrides; longest prefix wins
+	defaultCfg CollapseConfig   // explicit fallback; equivalent to {Prefix:"/", Threshold: threshold}
 }
 
 func (sn *SegmentNode) IsNextDynamic() bool {

--- a/pkg/registry/file/dynamicpathdetector/types.go
+++ b/pkg/registry/file/dynamicpathdetector/types.go
@@ -46,11 +46,23 @@ func DefaultCollapseConfigs() []CollapseConfig {
 	return append([]CollapseConfig(nil), defaultCollapseConfigs...)
 }
 
-// DefaultCollapseConfig is the global fallback used when no CollapseConfig
-// prefix matches the walked path.
-var DefaultCollapseConfig = CollapseConfig{
+// defaultCollapseConfig is the package-private global fallback used when
+// no CollapseConfig prefix matches the walked path. Exposed via the
+// DefaultCollapseConfig() accessor so callers can't mutate the package
+// state and silently corrupt every analyzer constructed afterward.
+// CodeRabbit upstream PR #323 finding #3.
+var defaultCollapseConfig = CollapseConfig{
 	Prefix:    "/",
 	Threshold: OpenDynamicThreshold,
+}
+
+// DefaultCollapseConfig returns a value copy of the package-private
+// fallback. Mutating the returned struct does not affect package state.
+// The accessor pattern matches DefaultCollapseConfigs() — both protect
+// the threshold-tuning surface from accidental cross-test or
+// cross-caller corruption.
+func DefaultCollapseConfig() CollapseConfig {
+	return defaultCollapseConfig
 }
 
 // --- Trie types ---


### PR DESCRIPTION
  - `analyze_endpoints`: per-endpoint port handling (Internal/External merge key now includes the port so endpoints exposing the same path on different ports stay distinct)
  - `analyze_opens`: anchored trailing-`*` only matches when the wildcard is at the end of the pattern (no recursive-`*` accidents)
  - `analyzer`: `DefaultCollapseConfigs` accessor and `FindConfigForPath` value-return (used by node-agent's CEL helpers)
  
 CompareDynamic perf note: the current implementation allocates two []string slices per call. matthyx's earlier review of PR #316 line 358 called this out and indicated he'd own a zero-alloc rewrite; remains untouched

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Wildcard-port merging now only folds matching endpoints and respects internal flags; header marshal failures no longer print to stdout; SBOM-listed paths are preserved during consolidation.

* **Performance**
  * Faster and lower-allocation path analysis via pooled buffers and optimized/memoized pattern matching.

* **New Features**
  * Per-prefix collapse/configuration and deterministic consolidation of open-paths/endpoints; exposed helpers for collapse inspection.

* **Tests**
  * Large suite of new regression, consolidation, memoization, benchmark and profiling tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/storage/pull/323?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->