### PR TITLE
allowing CIDRs, wildcards and Plural in IP and DNS

### DIFF
--- a/api-rules/sample_apiserver_violation_exceptions.list
+++ b/api-rules/sample_apiserver_violation_exceptions.list
@@ -45,6 +45,7 @@ API rule violation: list_type_missing,github.com/kubescape/storage/pkg/apis/soft
 API rule violation: list_type_missing,github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1,Match,MatchDetails
 API rule violation: list_type_missing,github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1,Match,RelatedVulnerabilities
 API rule violation: list_type_missing,github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1,NetworkNeighbor,DNSNames
+API rule violation: list_type_missing,github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1,NetworkNeighbor,IPAddresses
 API rule violation: list_type_missing,github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1,NetworkNeighbor,Ports
 API rule violation: list_type_missing,github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1,NetworkNeighborhoodContainer,Egress
 API rule violation: list_type_missing,github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1,NetworkNeighborhoodContainer,Ingress

--- a/build/protoc.Dockerfile
+++ b/build/protoc.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.25-trixie AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26-trixie AS builder
 
 ENV GO111MODULE=on CGO_ENABLED=0
 WORKDIR /work

--- a/pkg/apis/softwarecomposition/network_types.go
+++ b/pkg/apis/softwarecomposition/network_types.go
@@ -65,7 +65,11 @@ type NetworkNeighbor struct {
 	Ports             []NetworkPort
 	PodSelector       *metav1.LabelSelector
 	NamespaceSelector *metav1.LabelSelector
-	IPAddress         string
+	IPAddress         string // DEPRECATED - use IPAddresses instead.
+	// IPAddresses is the v0.0.2 list-form replacement for IPAddress.
+	// Each entry MAY be a literal IP, a CIDR (a.b.c.d/n), or the "*" sentinel.
+	// See pkg/registry/file/networkmatch for matcher semantics.
+	IPAddresses []string
 }
 
 type NetworkPort struct {

--- a/pkg/apis/softwarecomposition/v1beta1/generated.pb.go
+++ b/pkg/apis/softwarecomposition/v1beta1/generated.pb.go
@@ -4207,6 +4207,15 @@ func (m *NetworkNeighbor) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
+	if len(m.IPAddresses) > 0 {
+		for iNdEx := len(m.IPAddresses) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.IPAddresses[iNdEx])
+			copy(dAtA[i:], m.IPAddresses[iNdEx])
+			i = encodeVarintGenerated(dAtA, i, uint64(len(m.IPAddresses[iNdEx])))
+			i--
+			dAtA[i] = 0x4a
+		}
+	}
 	i -= len(m.IPAddress)
 	copy(dAtA[i:], m.IPAddress)
 	i = encodeVarintGenerated(dAtA, i, uint64(len(m.IPAddress)))
@@ -10302,6 +10311,12 @@ func (m *NetworkNeighbor) Size() (n int) {
 	}
 	l = len(m.IPAddress)
 	n += 1 + l + sovGenerated(uint64(l))
+	if len(m.IPAddresses) > 0 {
+		for _, s := range m.IPAddresses {
+			l = len(s)
+			n += 1 + l + sovGenerated(uint64(l))
+		}
+	}
 	return n
 }
 
@@ -13143,6 +13158,7 @@ func (this *NetworkNeighbor) String() string {
 		`PodSelector:` + strings.Replace(fmt.Sprintf("%v", this.PodSelector), "LabelSelector", "v1.LabelSelector", 1) + `,`,
 		`NamespaceSelector:` + strings.Replace(fmt.Sprintf("%v", this.NamespaceSelector), "LabelSelector", "v1.LabelSelector", 1) + `,`,
 		`IPAddress:` + fmt.Sprintf("%v", this.IPAddress) + `,`,
+		`IPAddresses:` + fmt.Sprintf("%v", this.IPAddresses) + `,`,
 		`}`,
 	}, "")
 	return s
@@ -26885,6 +26901,38 @@ func (m *NetworkNeighbor) Unmarshal(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.IPAddress = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 9:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field IPAddresses", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.IPAddresses = append(m.IPAddresses, string(dAtA[iNdEx:postIndex]))
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/pkg/apis/softwarecomposition/v1beta1/generated.proto
+++ b/pkg/apis/softwarecomposition/v1beta1/generated.proto
@@ -878,6 +878,12 @@ message NetworkNeighbor {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector namespaceSelector = 7;
 
   optional string ipAddress = 8;
+
+  // IPAddresses is the v0.0.2 list-form replacement for the deprecated
+  // single-IP `ipAddress` field. Each entry MAY be a literal IP, a
+  // CIDR (a.b.c.d/n), or the "*" sentinel. See
+  // pkg/registry/file/networkmatch for matcher semantics.
+  repeated string ipAddresses = 9;
 }
 
 // NetworkNeighborhood represents a list of network communications for a specific workload.

--- a/pkg/apis/softwarecomposition/v1beta1/generated.proto
+++ b/pkg/apis/softwarecomposition/v1beta1/generated.proto
@@ -341,13 +341,14 @@ message ExecCalls {
 
   repeated string envs = 3;
 
-  // ArgsRequired declares the intent of args explicitly. When false
-  // (default) the args vector is informational and the legacy
-  // CompareExecArgs empty-bypass applies. When true the args vector
-  // is a strict constraint enforced by MatchExecArgs — empty args
-  // means "argv MUST be empty"; non-empty args is matched anchored.
-  // Resolves the args,omitempty / explicit-empty round-trip
-  // ambiguity that CompareExecArgs alone could not express.
+  // ArgsRequired declares the intent of Args explicitly. When false
+  // (default and the back-compat path) the Args vector is informational
+  // and CompareExecArgs's empty-bypass applies. When true the Args
+  // vector is a strict constraint enforced by MatchExecArgs — an empty
+  // Args means "argv MUST be empty"; a non-empty Args is matched
+  // anchored (wildcard tokens still apply). Resolves the
+  // args,omitempty / explicit-empty round-trip ambiguity that
+  // CompareExecArgs alone could not express.
   optional bool argsRequired = 4;
 }
 
@@ -879,10 +880,9 @@ message NetworkNeighbor {
 
   optional string ipAddress = 8;
 
-  // IPAddresses is the v0.0.2 list-form replacement for the deprecated
-  // single-IP `ipAddress` field. Each entry MAY be a literal IP, a
-  // CIDR (a.b.c.d/n), or the "*" sentinel. See
-  // pkg/registry/file/networkmatch for matcher semantics.
+  // IPAddresses is the v0.0.2 list-form replacement for IPAddress.
+  // Each entry MAY be a literal IP, a CIDR (a.b.c.d/n), or the "*" sentinel.
+  // See pkg/registry/file/networkmatch for matcher semantics.
   repeated string ipAddresses = 9;
 }
 

--- a/pkg/apis/softwarecomposition/v1beta1/network_types.go
+++ b/pkg/apis/softwarecomposition/v1beta1/network_types.go
@@ -61,7 +61,11 @@ type NetworkNeighbor struct {
 	Ports             []NetworkPort         `json:"ports" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,5,rep,name=ports"`
 	PodSelector       *metav1.LabelSelector `json:"podSelector" protobuf:"bytes,6,req,name=podSelector"`
 	NamespaceSelector *metav1.LabelSelector `json:"namespaceSelector" protobuf:"bytes,7,req,name=namespaceSelector"`
-	IPAddress         string                `json:"ipAddress" protobuf:"bytes,8,req,name=ipAddress"`
+	IPAddress         string                `json:"ipAddress" protobuf:"bytes,8,req,name=ipAddress"` // DEPRECATED - use IPAddresses instead.
+	// IPAddresses is the v0.0.2 list-form replacement for IPAddress.
+	// Each entry MAY be a literal IP, a CIDR (a.b.c.d/n), or the "*" sentinel.
+	// See pkg/registry/file/networkmatch for matcher semantics.
+	IPAddresses []string `json:"ipAddresses,omitempty" protobuf:"bytes,9,rep,name=ipAddresses"`
 }
 
 type NetworkPort struct {

--- a/pkg/apis/softwarecomposition/v1beta1/network_types_protobuf_test.go
+++ b/pkg/apis/softwarecomposition/v1beta1/network_types_protobuf_test.go
@@ -1,0 +1,74 @@
+package v1beta1
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestNetworkNeighbor_IPAddresses_ProtobufRoundtrip pins the v0.0.2
+// protobuf wire contract for the new IPAddresses field. Storage persists
+// NetworkNeighborhood objects to etcd via this protobuf encoding; if
+// the field is dropped on round-trip, the spec field is silently lost
+// and runtime matchers see an empty list.
+//
+// Protobuf field number 9 (declared on the struct tag) MUST be preserved
+// across Marshal → Unmarshal.
+func TestNetworkNeighbor_IPAddresses_ProtobufRoundtrip(t *testing.T) {
+	original := &NetworkNeighbor{
+		Identifier:  "test-entry",
+		Type:        "external",
+		IPAddress:   "10.1.2.3", // deprecated singular still works
+		IPAddresses: []string{"10.0.0.0/8", "192.168.0.0/16", "*", "2001:db8::/32"},
+		DNSNames:    []string{"api.stripe.com.", "*.stripe.com."},
+	}
+
+	wire, err := original.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	decoded := &NetworkNeighbor{}
+	if err := decoded.Unmarshal(wire); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	if !reflect.DeepEqual(decoded.IPAddresses, original.IPAddresses) {
+		t.Errorf("IPAddresses roundtrip mismatch:\n  got:  %v\n  want: %v",
+			decoded.IPAddresses, original.IPAddresses)
+	}
+
+	// Sanity: existing fields still survive (no regression).
+	if decoded.IPAddress != original.IPAddress {
+		t.Errorf("deprecated IPAddress lost: got %q want %q", decoded.IPAddress, original.IPAddress)
+	}
+	if !reflect.DeepEqual(decoded.DNSNames, original.DNSNames) {
+		t.Errorf("DNSNames lost: got %v want %v", decoded.DNSNames, original.DNSNames)
+	}
+}
+
+// TestNetworkNeighbor_IPAddresses_EmptyOmitted confirms that an empty
+// IPAddresses slice is not encoded on the wire (zero overhead for
+// existing profiles that don't use the new field).
+func TestNetworkNeighbor_IPAddresses_EmptyOmitted(t *testing.T) {
+	withField := &NetworkNeighbor{
+		Identifier:  "id",
+		Type:        "external",
+		IPAddresses: nil,
+	}
+	withoutField := &NetworkNeighbor{
+		Identifier: "id",
+		Type:       "external",
+	}
+	a, err := withField.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal(withField): %v", err)
+	}
+	b, err := withoutField.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal(withoutField): %v", err)
+	}
+	if !reflect.DeepEqual(a, b) {
+		t.Errorf("nil IPAddresses must encode identically to absent field;\n  got %d bytes vs %d bytes",
+			len(a), len(b))
+	}
+}

--- a/pkg/apis/softwarecomposition/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/softwarecomposition/v1beta1/zz_generated.conversion.go
@@ -3686,6 +3686,7 @@ func autoConvert_softwarecomposition_NetworkNeighbor_To_v1beta1_NetworkNeighbor(
 	out.PodSelector = (*metav1.LabelSelector)(unsafe.Pointer(in.PodSelector))
 	out.NamespaceSelector = (*metav1.LabelSelector)(unsafe.Pointer(in.NamespaceSelector))
 	out.IPAddress = in.IPAddress
+	out.IPAddresses = *(*[]string)(unsafe.Pointer(&in.IPAddresses))
 	return nil
 }
 

--- a/pkg/apis/softwarecomposition/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/softwarecomposition/v1beta1/zz_generated.conversion.go
@@ -3669,6 +3669,7 @@ func autoConvert_v1beta1_NetworkNeighbor_To_softwarecomposition_NetworkNeighbor(
 	out.PodSelector = (*metav1.LabelSelector)(unsafe.Pointer(in.PodSelector))
 	out.NamespaceSelector = (*metav1.LabelSelector)(unsafe.Pointer(in.NamespaceSelector))
 	out.IPAddress = in.IPAddress
+	out.IPAddresses = *(*[]string)(unsafe.Pointer(&in.IPAddresses))
 	return nil
 }
 

--- a/pkg/apis/softwarecomposition/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/softwarecomposition/v1beta1/zz_generated.deepcopy.go
@@ -1963,6 +1963,11 @@ func (in *NetworkNeighbor) DeepCopyInto(out *NetworkNeighbor) {
 		*out = new(metav1.LabelSelector)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.IPAddresses != nil {
+		in, out := &in.IPAddresses, &out.IPAddresses
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/apis/softwarecomposition/zz_generated.deepcopy.go
+++ b/pkg/apis/softwarecomposition/zz_generated.deepcopy.go
@@ -1970,6 +1970,11 @@ func (in *NetworkNeighbor) DeepCopyInto(out *NetworkNeighbor) {
 		*out = new(metav1.LabelSelector)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.IPAddresses != nil {
+		in, out := &in.IPAddresses, &out.IPAddresses
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/generated/applyconfiguration/softwarecomposition/v1beta1/execcalls.go
+++ b/pkg/generated/applyconfiguration/softwarecomposition/v1beta1/execcalls.go
@@ -21,10 +21,18 @@ package v1beta1
 // ExecCallsApplyConfiguration represents a declarative configuration of the ExecCalls type for use
 // with apply.
 type ExecCallsApplyConfiguration struct {
-	Path         *string  `json:"path,omitempty"`
-	Args         []string `json:"args,omitempty"`
-	Envs         []string `json:"envs,omitempty"`
-	ArgsRequired *bool    `json:"argsRequired,omitempty"`
+	Path *string  `json:"path,omitempty"`
+	Args []string `json:"args,omitempty"`
+	Envs []string `json:"envs,omitempty"`
+	// ArgsRequired declares the intent of Args explicitly. When false
+	// (default and the back-compat path) the Args vector is informational
+	// and CompareExecArgs's empty-bypass applies. When true the Args
+	// vector is a strict constraint enforced by MatchExecArgs — an empty
+	// Args means "argv MUST be empty"; a non-empty Args is matched
+	// anchored (wildcard tokens still apply). Resolves the
+	// args,omitempty / explicit-empty round-trip ambiguity that
+	// CompareExecArgs alone could not express.
+	ArgsRequired *bool `json:"argsRequired,omitempty"`
 }
 
 // ExecCallsApplyConfiguration constructs a declarative configuration of the ExecCalls type for use with

--- a/pkg/generated/applyconfiguration/softwarecomposition/v1beta1/networkneighbor.go
+++ b/pkg/generated/applyconfiguration/softwarecomposition/v1beta1/networkneighbor.go
@@ -38,6 +38,10 @@ type NetworkNeighborApplyConfiguration struct {
 	PodSelector       *v1.LabelSelectorApplyConfiguration `json:"podSelector,omitempty"`
 	NamespaceSelector *v1.LabelSelectorApplyConfiguration `json:"namespaceSelector,omitempty"`
 	IPAddress         *string                             `json:"ipAddress,omitempty"`
+	// IPAddresses is the v0.0.2 list-form replacement for IPAddress.
+	// Each entry MAY be a literal IP, a CIDR (a.b.c.d/n), or the "*" sentinel.
+	// See pkg/registry/file/networkmatch for matcher semantics.
+	IPAddresses []string `json:"ipAddresses,omitempty"`
 }
 
 // NetworkNeighborApplyConfiguration constructs a declarative configuration of the NetworkNeighbor type for use with
@@ -114,5 +118,15 @@ func (b *NetworkNeighborApplyConfiguration) WithNamespaceSelector(value *v1.Labe
 // If called multiple times, the IPAddress field is set to the value of the last call.
 func (b *NetworkNeighborApplyConfiguration) WithIPAddress(value string) *NetworkNeighborApplyConfiguration {
 	b.IPAddress = &value
+	return b
+}
+
+// WithIPAddresses adds the given value to the IPAddresses field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, values provided by each call will be appended to the IPAddresses field.
+func (b *NetworkNeighborApplyConfiguration) WithIPAddresses(values ...string) *NetworkNeighborApplyConfiguration {
+	for i := range values {
+		b.IPAddresses = append(b.IPAddresses, values[i])
+	}
 	return b
 }

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -3759,6 +3759,21 @@ func schema_pkg_apis_softwarecomposition_v1beta1_NetworkNeighbor(ref common.Refe
 							Format:  "",
 						},
 					},
+					"ipAddresses": {
+						SchemaProps: spec.SchemaProps{
+							Description: "IPAddresses is the v0.0.2 list-form replacement for IPAddress. Each entry MAY be a literal IP, a CIDR (a.b.c.d/n), or the \"*\" sentinel. See pkg/registry/file/networkmatch for matcher semantics.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
+									},
+								},
+							},
+						},
+					},
 				},
 				Required: []string{"identifier", "type", "dns", "dnsNames", "ports", "podSelector", "namespaceSelector", "ipAddress"},
 			},

--- a/pkg/registry/file/networkmatch/README.md
+++ b/pkg/registry/file/networkmatch/README.md
@@ -5,7 +5,7 @@ Wildcard-aware matchers for the `NetworkNeighbor.IPAddresses` and
 `nn.was_address_in_{egress,ingress}` and `nn.is_domain_in_{egress,ingress}`.
 
 This package is the runtime counterpart to the spec sections §5.7 (IP)
-and §5.8 (DNS) at <https://billofbehavior.com/bob/docs/drafts/spec-v0.0.2/>.
+and §5.8 (DNS) at <https://billofbehavior.fusioncore.ai/bob/docs/drafts/spec-v0.0.2/>.
 
 ## Wildcard token vocabulary
 

--- a/pkg/registry/file/networkmatch/README.md
+++ b/pkg/registry/file/networkmatch/README.md
@@ -1,0 +1,74 @@
+# networkmatch
+
+Wildcard-aware matchers for the `NetworkNeighbor.IPAddresses` and
+`NetworkNeighbor.DNSNames` fields, used by node-agent's CEL functions
+`nn.was_address_in_{egress,ingress}` and `nn.is_domain_in_{egress,ingress}`.
+
+This package is the runtime counterpart to the spec sections §5.7 (IP)
+and §5.8 (DNS) at <https://billofbehavior.fusioncore.ai/bob/docs/drafts/spec-v0.0.2/>.
+
+## Wildcard token vocabulary
+
+Same tokens as the path / argv matchers in `dynamicpathdetector` — see
+that package's `coverage_test.go` for the contract.
+
+| Token | IP semantics | DNS semantics |
+|---|---|---|
+| Literal | byte-equality after canonicalization (net.IP) | byte-equality after trailing-dot normalization |
+| CIDR (`a.b.c.d/n`) | `net.IPNet.Contains(observed)` | — |
+| `*` as full entry | sugar for `0.0.0.0/0` ∪ `::/0` (any IP) | — |
+| `*.<suffix>` (leading) | — | RFC 4592 — exactly one DNS label before `<suffix>` |
+| `<a>.⋯.<b>` (mid) | — | DynamicIdentifier — exactly one DNS label between `<a>` and `<b>` |
+| `<prefix>.*` (trailing) | — | one or more DNS labels after `<prefix>` (never zero) |
+| `**` | reserved (rejected at admission) | reserved (rejected at admission) |
+
+## API
+
+```go
+// MatchIP reports whether observedIP matches any of the profile entries.
+// Each entry MAY be: a literal IP, a CIDR, or the "*" sentinel.
+//
+// observedIP is matched as text (the function calls net.ParseIP internally
+// so the caller does not need to pre-parse it). Empty profile slice
+// returns false (no entries → nothing to match against). Empty observedIP
+// returns false (no observation to match).
+//
+// Compile-once contract: callers running this in a hot path SHOULD wrap
+// it in a closure that captures pre-compiled *IPNet values across calls
+// (the caller knows the profile's lifecycle, this function does not).
+func MatchIP(profileEntries []string, observedIP string) bool
+
+// MatchDNS reports whether observedName matches any of the profile entries.
+// Each entry MAY use the wildcard tokens above.
+//
+// Both profile entries and observedName are normalized before
+// comparison: a trailing dot is stripped if present, and labels are
+// lowercased for case-insensitive equality.
+func MatchDNS(profileEntries []string, observedName string) bool
+```
+
+## Performance contract
+
+Both functions are called per network event from R0005 / R0011 / R1003 /
+R1009. The benchmarks in `bench_test.go` track:
+
+- `BenchmarkMatchIP_Literal` — baseline byte-equality
+- `BenchmarkMatchIP_CIDR` — single CIDR match
+- `BenchmarkMatchIP_LongMixedList` — 10-entry mixed list, observed IP not in list (worst case)
+- `BenchmarkMatchDNS_Literal` — baseline
+- `BenchmarkMatchDNS_LeadingWildcard` — RFC 4592
+- `BenchmarkMatchDNS_DeepName` — 10-label observed name against a leading-`*` profile
+
+Targets (CI runner reference):
+- IP literal / CIDR: < 200 ns per call
+- DNS literal: < 300 ns per call
+- DNS wildcard: < 600 ns per call
+
+Beat or hold these on every change; the matcher fires on every network
+event captured by the eBPF tracers.
+
+## Testing
+
+`match_ip_test.go` and `match_dns_test.go` are the contract pinning. The
+fixtures in `node-agent/tests/resources/network-wildcards/` are the
+end-to-end examples; both layers MUST agree.

--- a/pkg/registry/file/networkmatch/README.md
+++ b/pkg/registry/file/networkmatch/README.md
@@ -5,7 +5,7 @@ Wildcard-aware matchers for the `NetworkNeighbor.IPAddresses` and
 `nn.was_address_in_{egress,ingress}` and `nn.is_domain_in_{egress,ingress}`.
 
 This package is the runtime counterpart to the spec sections §5.7 (IP)
-and §5.8 (DNS) at <https://billofbehavior.fusioncore.ai/bob/docs/drafts/spec-v0.0.2/>.
+and §5.8 (DNS) at <https://billofbehavior.com/bob/docs/drafts/spec-v0.0.2/>.
 
 ## Wildcard token vocabulary
 

--- a/pkg/registry/file/networkmatch/bench_test.go
+++ b/pkg/registry/file/networkmatch/bench_test.go
@@ -1,0 +1,152 @@
+package networkmatch
+
+import "testing"
+
+// Benchmarks for the IP matcher.
+//
+// Targets (CI runner reference, see README.md):
+//   IP literal / CIDR : < 200 ns/op
+//   long mixed list    : < 1 µs/op
+//
+// Run: go test -bench=. -benchmem ./pkg/registry/file/networkmatch/
+
+func BenchmarkMatchIP_Literal(b *testing.B) {
+	profile := []string{"10.1.2.3"}
+	for i := 0; i < b.N; i++ {
+		_ = MatchIP(profile, "10.1.2.3")
+	}
+}
+
+func BenchmarkMatchIP_CIDR(b *testing.B) {
+	profile := []string{"10.0.0.0/8"}
+	for i := 0; i < b.N; i++ {
+		_ = MatchIP(profile, "10.1.2.3")
+	}
+}
+
+func BenchmarkMatchIP_AnySentinel(b *testing.B) {
+	profile := []string{"*"}
+	for i := 0; i < b.N; i++ {
+		_ = MatchIP(profile, "10.1.2.3")
+	}
+}
+
+func BenchmarkMatchIP_LongMixedList(b *testing.B) {
+	// Worst case: 10 entries, observed IP not in any of them.
+	// Validates that adding entries scales linearly without per-entry alloc.
+	profile := []string{
+		"10.1.2.3", "10.1.2.4", "10.1.2.5",
+		"192.168.0.0/16",
+		"172.16.0.0/12",
+		"8.8.8.8", "8.8.4.4",
+		"2001:db8::/32",
+		"203.0.113.0/24",
+		"198.51.100.0/24",
+	}
+	for i := 0; i < b.N; i++ {
+		_ = MatchIP(profile, "1.1.1.1")
+	}
+}
+
+func BenchmarkMatchIP_LongMixedList_HitFirst(b *testing.B) {
+	// Best case for early-exit: hit on the first entry.
+	profile := []string{
+		"10.1.2.3", "10.1.2.4", "10.1.2.5",
+		"192.168.0.0/16", "172.16.0.0/12",
+	}
+	for i := 0; i < b.N; i++ {
+		_ = MatchIP(profile, "10.1.2.3")
+	}
+}
+
+// Hot-path benchmark: compile once, match many. This is how
+// the CEL-function callers in node-agent SHOULD use the matcher.
+
+func BenchmarkCompiledIPMatcher_Literal(b *testing.B) {
+	m := CompileIP([]string{"10.1.2.3"})
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = m.Match("10.1.2.3")
+	}
+}
+
+func BenchmarkCompiledIPMatcher_CIDR(b *testing.B) {
+	m := CompileIP([]string{"10.0.0.0/8"})
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = m.Match("10.1.2.3")
+	}
+}
+
+func BenchmarkCompiledIPMatcher_LongMixedList(b *testing.B) {
+	m := CompileIP([]string{
+		"10.1.2.3", "10.1.2.4", "10.1.2.5",
+		"192.168.0.0/16",
+		"172.16.0.0/12",
+		"8.8.8.8", "8.8.4.4",
+		"2001:db8::/32",
+		"203.0.113.0/24",
+		"198.51.100.0/24",
+	})
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = m.Match("1.1.1.1")
+	}
+}
+
+// DNS matcher benchmarks. Targets (CI runner reference):
+//   DNS literal     : < 300 ns/op
+//   DNS wildcard    : < 600 ns/op
+
+func BenchmarkMatchDNS_Literal(b *testing.B) {
+	profile := []string{"api.stripe.com."}
+	for i := 0; i < b.N; i++ {
+		_ = MatchDNS(profile, "api.stripe.com.")
+	}
+}
+
+func BenchmarkMatchDNS_LeadingWildcard(b *testing.B) {
+	profile := []string{"*.stripe.com."}
+	for i := 0; i < b.N; i++ {
+		_ = MatchDNS(profile, "webhooks.stripe.com.")
+	}
+}
+
+func BenchmarkCompiledDNSMatcher_Literal(b *testing.B) {
+	m := CompileDNS([]string{"api.stripe.com."})
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = m.Match("api.stripe.com.")
+	}
+}
+
+func BenchmarkCompiledDNSMatcher_LeadingWildcard(b *testing.B) {
+	m := CompileDNS([]string{"*.stripe.com."})
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = m.Match("webhooks.stripe.com.")
+	}
+}
+
+func BenchmarkCompiledDNSMatcher_DeepName(b *testing.B) {
+	// 10-label observed name against a leading-* pattern (will miss).
+	m := CompileDNS([]string{"*.stripe.com."})
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = m.Match("a.b.c.d.e.f.g.h.stripe.com.")
+	}
+}
+
+func BenchmarkCompiledDNSMatcher_LongMixedList(b *testing.B) {
+	m := CompileDNS([]string{
+		"api.stripe.com.",
+		"*.stripe.com.",
+		"api.partner.io.",
+		"kubernetes.⋯.svc.cluster.local.",
+		"internal.*",
+	})
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = m.Match("kubernetes.production.svc.cluster.local.")
+	}
+}

--- a/pkg/registry/file/networkmatch/doc.go
+++ b/pkg/registry/file/networkmatch/doc.go
@@ -1,0 +1,9 @@
+// Package networkmatch provides wildcard-aware matchers for the
+// NetworkNeighbor.IPAddresses and NetworkNeighbor.DNSNames profile fields.
+//
+// It is the runtime counterpart to spec sections §5.7 (IP) and §5.8 (DNS)
+// of the BoB specification (v0.0.2).
+//
+// See README.md for the wildcard token vocabulary, public API, and
+// performance contract.
+package networkmatch

--- a/pkg/registry/file/networkmatch/match_dns.go
+++ b/pkg/registry/file/networkmatch/match_dns.go
@@ -1,0 +1,201 @@
+package networkmatch
+
+import "strings"
+
+// DNS wildcard tokens. These mirror the path/argv tokens in
+// dynamicpathdetector but apply with DNS-label semantics.
+const (
+	// DNSDynamicLabel is U+22EF — matches exactly one DNS label in
+	// the middle of a pattern (mirror of dynamicpathdetector.DynamicIdentifier).
+	DNSDynamicLabel = "⋯"
+
+	// DNSWildcardLabel is "*" — matches exactly one label when it's the
+	// LEADING label (RFC 4592), or one or more labels when it's the
+	// TRAILING label (project extension, spec §5.8 row 3).
+	DNSWildcardLabel = "*"
+)
+
+// DNSMatcher is the compiled form of a DNS profile.
+// Each entry compiles into one dnsPattern struct.
+type DNSMatcher struct {
+	patterns []dnsPattern
+}
+
+type dnsPattern struct {
+	labels         []string // labels in declaration order, lowercased, trailing dot stripped
+	hasLeadingStar bool     // labels[0] == "*"
+	hasTrailingStar bool    // labels[len-1] == "*"
+	valid          bool     // false if pattern was malformed (e.g. "**" or empty label)
+}
+
+// CompileDNS builds a DNSMatcher from profile entries.
+// Malformed entries (empty, "**", empty inner labels) are silently skipped.
+func CompileDNS(profileEntries []string) *DNSMatcher {
+	m := &DNSMatcher{}
+	for _, entry := range profileEntries {
+		p := compileDNSPattern(entry)
+		if !p.valid {
+			continue
+		}
+		m.patterns = append(m.patterns, p)
+	}
+	return m
+}
+
+// Match reports whether the observed DNS name is admitted by this matcher.
+func (m *DNSMatcher) Match(observed string) bool {
+	if observed == "" {
+		return false
+	}
+	obsLabels, ok := splitDNS(observed)
+	if !ok {
+		return false
+	}
+	for i := range m.patterns {
+		if matchDNSPattern(&m.patterns[i], obsLabels) {
+			return true
+		}
+	}
+	return false
+}
+
+// MatchDNS is the convenience wrapper. Hot paths SHOULD reuse a
+// compiled *DNSMatcher built once via CompileDNS.
+func MatchDNS(profileEntries []string, observed string) bool {
+	if observed == "" || len(profileEntries) == 0 {
+		return false
+	}
+	return CompileDNS(profileEntries).Match(observed)
+}
+
+// splitDNS canonicalizes a DNS name (lowercases, strips trailing dot)
+// and splits on "." into labels. Returns (labels, valid).
+// An empty inner label (e.g. "foo..bar") returns valid=false.
+func splitDNS(name string) ([]string, bool) {
+	canon := strings.ToLower(strings.TrimSuffix(name, "."))
+	if canon == "" {
+		return nil, false
+	}
+	labels := strings.Split(canon, ".")
+	for _, l := range labels {
+		if l == "" {
+			return nil, false
+		}
+	}
+	return labels, true
+}
+
+// compileDNSPattern parses one profile entry into a dnsPattern.
+// Sets valid=false on malformed input (which the caller silently skips).
+func compileDNSPattern(entry string) dnsPattern {
+	if entry == "" {
+		return dnsPattern{}
+	}
+	canon := strings.ToLower(strings.TrimSuffix(entry, "."))
+	if canon == "" {
+		return dnsPattern{}
+	}
+	labels := strings.Split(canon, ".")
+	for _, l := range labels {
+		switch {
+		case l == "":
+			// foo..bar — empty inner label is malformed.
+			return dnsPattern{}
+		case l == "**":
+			// Reserved/recursive — explicitly rejected per spec §5.8.
+			return dnsPattern{}
+		}
+	}
+	p := dnsPattern{labels: labels, valid: true}
+	if len(labels) > 0 {
+		if labels[0] == DNSWildcardLabel {
+			p.hasLeadingStar = true
+		}
+		if labels[len(labels)-1] == DNSWildcardLabel {
+			p.hasTrailingStar = true
+		}
+	}
+	// "*" alone (single-label pattern) is degenerate. Treat as
+	// leading-star with one label semantics — but since there's no suffix
+	// to match against, it's only useful matching single-label observations.
+	// Spec §5.8 doesn't bless this; reject for safety.
+	if len(labels) == 1 && p.hasLeadingStar {
+		return dnsPattern{}
+	}
+	return p
+}
+
+// matchDNSPattern evaluates one compiled pattern against observed labels.
+//
+// Algorithm: walk pattern labels left-to-right against observed labels,
+// applying token semantics:
+//
+//   leading "*"  (only at index 0): consumes EXACTLY ONE observed label  (RFC 4592)
+//   "⋯"          (any position):    consumes EXACTLY ONE observed label
+//   trailing "*" (only at last):    consumes ONE OR MORE observed labels (§5.8)
+//   literal:                        byte-equality (already lowercased)
+//
+// Mid-position "*" tokens (i.e. "*" not at index 0 and not at last index)
+// are treated as DynamicLabel-equivalent (one label) — but spec restricts
+// declaration to leading/trailing only; admission validates the position.
+func matchDNSPattern(p *dnsPattern, obs []string) bool {
+	plabels := p.labels
+	pi := 0
+	oi := 0
+	plen := len(plabels)
+	olen := len(obs)
+
+	for pi < plen {
+		tok := plabels[pi]
+		isLast := pi == plen-1
+		isFirst := pi == 0
+
+		// Trailing "*" — consume one or more remaining labels.
+		// Pattern ends here, so observed must have at least one label left
+		// AND we exit the loop after.
+		if tok == DNSWildcardLabel && isLast && !isFirst {
+			return olen-oi >= 1
+		}
+
+		// Leading "*" — consume exactly one label.
+		if tok == DNSWildcardLabel && isFirst {
+			if oi >= olen {
+				return false
+			}
+			oi++
+			pi++
+			continue
+		}
+
+		// "⋯" — consume exactly one label (any position).
+		if tok == DNSDynamicLabel {
+			if oi >= olen {
+				return false
+			}
+			oi++
+			pi++
+			continue
+		}
+
+		// Mid-position "*" (declaration-illegal but defensive): treat as one label.
+		if tok == DNSWildcardLabel {
+			if oi >= olen {
+				return false
+			}
+			oi++
+			pi++
+			continue
+		}
+
+		// Literal label — byte equality.
+		if oi >= olen || obs[oi] != tok {
+			return false
+		}
+		oi++
+		pi++
+	}
+
+	// Pattern fully consumed — observed must also be fully consumed
+	// (anchored match — DNS patterns are FQDN-anchored).
+	return oi == olen
+}

--- a/pkg/registry/file/networkmatch/match_dns_test.go
+++ b/pkg/registry/file/networkmatch/match_dns_test.go
@@ -1,0 +1,186 @@
+package networkmatch
+
+import "testing"
+
+// Contract pinning for MatchDNS / CompileDNS. Encodes spec §5.8.
+// User-facing fixtures: node-agent/tests/resources/network-wildcards/{09..14,17,18}.yaml
+
+func TestMatchDNS_LiteralEquality(t *testing.T) {
+	cases := []struct {
+		name     string
+		profile  []string
+		observed string
+		want     bool
+	}{
+		{"hit", []string{"api.stripe.com."}, "api.stripe.com.", true},
+		{"miss-different-tld", []string{"api.stripe.com."}, "api.stripe.org.", false},
+		{"miss-extra-label", []string{"api.stripe.com."}, "v1.api.stripe.com.", false},
+		{"miss-too-short", []string{"api.stripe.com."}, "stripe.com.", false},
+		{"case-insensitive", []string{"API.Stripe.com."}, "api.stripe.com.", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := MatchDNS(tc.profile, tc.observed); got != tc.want {
+				t.Errorf("MatchDNS(%v, %q) = %v, want %v", tc.profile, tc.observed, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMatchDNS_TrailingDotNormalisation(t *testing.T) {
+	// Trailing dot is the FQDN canonical form. Profile entries SHOULD have it,
+	// observed names from runtime SHOULD have it, but the matcher MUST be
+	// resilient to either form on either side.
+	cases := []struct {
+		name     string
+		profile  []string
+		observed string
+		want     bool
+	}{
+		{"both-with-dot", []string{"api.stripe.com."}, "api.stripe.com.", true},
+		{"profile-no-dot", []string{"api.stripe.com"}, "api.stripe.com.", true},
+		{"observed-no-dot", []string{"api.stripe.com."}, "api.stripe.com", true},
+		{"neither-dot", []string{"api.stripe.com"}, "api.stripe.com", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := MatchDNS(tc.profile, tc.observed); got != tc.want {
+				t.Errorf("MatchDNS(%v, %q) = %v, want %v", tc.profile, tc.observed, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMatchDNS_LeadingWildcard_RFC4592(t *testing.T) {
+	// "*.example.com." matches EXACTLY ONE label before the suffix.
+	cases := []struct {
+		name     string
+		profile  []string
+		observed string
+		want     bool
+	}{
+		{"hit-one-label", []string{"*.example.com."}, "api.example.com.", true},
+		{"miss-zero-labels", []string{"*.example.com."}, "example.com.", false},
+		{"miss-two-labels", []string{"*.example.com."}, "v1.api.example.com.", false},
+		{"miss-different-suffix", []string{"*.example.com."}, "api.example.org.", false},
+		{"hit-with-numeric-label", []string{"*.example.com."}, "v1.example.com.", true},
+		{"hit-with-hyphen", []string{"*.example.com."}, "my-app.example.com.", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := MatchDNS(tc.profile, tc.observed); got != tc.want {
+				t.Errorf("MatchDNS(%v, %q) = %v, want %v", tc.profile, tc.observed, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMatchDNS_MidEllipsis(t *testing.T) {
+	// "<a>.⋯.<b>" — DynamicIdentifier matches EXACTLY ONE label in the middle.
+	// This is the user's specific case for kubernetes service FQDNs.
+	cases := []struct {
+		name     string
+		profile  []string
+		observed string
+		want     bool
+	}{
+		{"hit-one-label-mid", []string{"kubernetes.⋯.svc.cluster.local."}, "kubernetes.default.svc.cluster.local.", true},
+		{"hit-different-ns", []string{"kubernetes.⋯.svc.cluster.local."}, "kubernetes.kube-system.svc.cluster.local.", true},
+		{"miss-zero-labels-mid", []string{"kubernetes.⋯.svc.cluster.local."}, "kubernetes.svc.cluster.local.", false},
+		{"miss-two-labels-mid", []string{"kubernetes.⋯.svc.cluster.local."}, "kubernetes.foo.bar.svc.cluster.local.", false},
+		{"miss-different-prefix", []string{"kubernetes.⋯.svc.cluster.local."}, "redis.default.svc.cluster.local.", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := MatchDNS(tc.profile, tc.observed); got != tc.want {
+				t.Errorf("MatchDNS(%v, %q) = %v, want %v", tc.profile, tc.observed, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMatchDNS_TrailingStar(t *testing.T) {
+	// "<prefix>.*" — trailing * matches ONE OR MORE labels (never zero).
+	// This is the project-specific extension (not RFC 4592 — that only
+	// covers leading *).
+	cases := []struct {
+		name     string
+		profile  []string
+		observed string
+		want     bool
+	}{
+		{"hit-one-label", []string{"internal.*"}, "internal.foo.", true},
+		{"hit-many-labels", []string{"internal.*"}, "internal.foo.bar.baz.", true},
+		{"miss-zero-labels", []string{"internal.*"}, "internal.", false},
+		{"miss-different-prefix", []string{"internal.*"}, "external.foo.", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := MatchDNS(tc.profile, tc.observed); got != tc.want {
+				t.Errorf("MatchDNS(%v, %q) = %v, want %v", tc.profile, tc.observed, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMatchDNS_ListAcceptIfAnyMatches(t *testing.T) {
+	// Disjunction across the entry list. Mirror of fixture 17.
+	profile := []string{
+		"api.stripe.com.",
+		"*.stripe.com.",
+		"api.partner.io.",
+	}
+	cases := []struct {
+		observed string
+		want     bool
+	}{
+		{"api.stripe.com.", true},        // literal hit
+		{"webhooks.stripe.com.", true},   // *.stripe.com.
+		{"v1.api.stripe.com.", false},    // two labels deep, *.stripe.com. only allows one
+		{"api.partner.io.", true},        // literal hit
+		{"api.example.com.", false},      // not in any entry
+	}
+	for _, tc := range cases {
+		t.Run(tc.observed, func(t *testing.T) {
+			if got := MatchDNS(profile, tc.observed); got != tc.want {
+				t.Errorf("MatchDNS(profile, %q) = %v, want %v", tc.observed, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMatchDNS_RejectsMalformed(t *testing.T) {
+	cases := []struct {
+		name     string
+		profile  []string
+		observed string
+		want     bool
+	}{
+		{"empty-profile", nil, "api.stripe.com.", false},
+		{"empty-observation", []string{"api.stripe.com."}, "", false},
+		{"empty-string-entry-skipped", []string{""}, "api.stripe.com.", false},
+		{"recursive-double-star-rejected", []string{"**"}, "anything.com.", false},
+		{"empty-label-in-pattern-not-recognised", []string{"foo..bar."}, "foo.bar.", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := MatchDNS(tc.profile, tc.observed); got != tc.want {
+				t.Errorf("MatchDNS(%v, %q) = %v, want %v", tc.profile, tc.observed, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCompiledDNSMatcher_Reuse(t *testing.T) {
+	// Compiled-form contract: build once, match many.
+	m := CompileDNS([]string{"*.stripe.com.", "api.partner.io."})
+	if !m.Match("webhooks.stripe.com.") {
+		t.Error("compiled matcher missed *.stripe.com. hit")
+	}
+	if m.Match("v1.api.stripe.com.") {
+		t.Error("compiled matcher should NOT match two-label-deep against *.stripe.com.")
+	}
+	if !m.Match("api.partner.io.") {
+		t.Error("compiled matcher missed literal hit")
+	}
+}

--- a/pkg/registry/file/networkmatch/match_ip.go
+++ b/pkg/registry/file/networkmatch/match_ip.go
@@ -1,0 +1,91 @@
+package networkmatch
+
+import (
+	"net"
+	"strings"
+)
+
+// AnyIPSentinel is the profile entry that matches any valid IP address.
+// Equivalent to the union of 0.0.0.0/0 and ::/0. Spec §5.7.
+const AnyIPSentinel = "*"
+
+// IPMatcher is the compiled form of an IP profile.
+// Callers in the hot path (CEL functions, runtime rules) build one per
+// profile and reuse it across every observed event for that profile.
+type IPMatcher struct {
+	any      bool        // any AnyIPSentinel ("*") entry → match anything
+	literals []net.IP    // already-parsed literal IPs (IPv4-canonicalized by net.ParseIP)
+	cidrs    []*net.IPNet // pre-compiled CIDRs
+}
+
+// CompileIP builds an IPMatcher from a profile entry list.
+// Malformed entries are silently dropped (validation is the admission layer's job).
+// Returns a usable matcher even on an empty / all-malformed input — Match will return false.
+func CompileIP(profileEntries []string) *IPMatcher {
+	m := &IPMatcher{}
+	for _, entry := range profileEntries {
+		if entry == "" {
+			continue
+		}
+		if entry == AnyIPSentinel {
+			m.any = true
+			continue
+		}
+		if strings.Contains(entry, "/") {
+			_, cidr, err := net.ParseCIDR(entry)
+			if err != nil {
+				continue
+			}
+			m.cidrs = append(m.cidrs, cidr)
+			continue
+		}
+		ip := net.ParseIP(entry)
+		if ip == nil {
+			continue
+		}
+		m.literals = append(m.literals, ip)
+	}
+	return m
+}
+
+// Match reports whether the observed IP text is admitted by this matcher.
+func (m *IPMatcher) Match(observedIP string) bool {
+	if observedIP == "" {
+		return false
+	}
+	if m.any {
+		// Even with the sentinel, the observation must be a valid IP.
+		// Empty / garbage observations always fail (admission requires a real address).
+		if net.ParseIP(observedIP) == nil {
+			return false
+		}
+		return true
+	}
+	parsed := net.ParseIP(observedIP)
+	if parsed == nil {
+		return false
+	}
+	for _, lit := range m.literals {
+		if lit.Equal(parsed) {
+			return true
+		}
+	}
+	for _, cidr := range m.cidrs {
+		if cidr.Contains(parsed) {
+			return true
+		}
+	}
+	return false
+}
+
+// MatchIP is the convenience wrapper that compiles + matches in one call.
+// Use this only on cold paths; hot paths SHOULD reuse a cached *IPMatcher
+// constructed via CompileIP.
+//
+// Empty profile or empty observation returns false.
+func MatchIP(profileEntries []string, observedIP string) bool {
+	if observedIP == "" || len(profileEntries) == 0 {
+		return false
+	}
+	return CompileIP(profileEntries).Match(observedIP)
+}

--- a/pkg/registry/file/networkmatch/match_ip_test.go
+++ b/pkg/registry/file/networkmatch/match_ip_test.go
@@ -1,0 +1,147 @@
+package networkmatch
+
+import "testing"
+
+// Contract pinning for MatchIP. These tests encode the v0.0.2 IP-matching
+// surface from spec §5.7. The fixtures in
+// node-agent/tests/resources/network-wildcards/{01..08,15..20}.yaml are
+// the user-facing examples; this file is the unit-level contract.
+
+func TestMatchIP_LiteralEquality(t *testing.T) {
+	cases := []struct {
+		name     string
+		profile  []string
+		observed string
+		want     bool
+	}{
+		{"ipv4-hit", []string{"10.1.2.3"}, "10.1.2.3", true},
+		{"ipv4-miss", []string{"10.1.2.3"}, "10.1.2.4", false},
+		{"ipv6-hit-canonical", []string{"2001:db8::1"}, "2001:db8::1", true},
+		{"ipv6-hit-different-format", []string{"2001:db8::1"}, "2001:0db8:0000:0000:0000:0000:0000:0001", true},
+		// IPv4-mapped IPv6 ::ffff:a.b.c.d MUST match its IPv4 form — same on-the-wire
+		// destination. net.IP.Equal handles this naturally; documenting it as a contract.
+		{"ipv4-mapped-v6-matches-v4", []string{"10.0.0.1"}, "::ffff:10.0.0.1", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := MatchIP(tc.profile, tc.observed); got != tc.want {
+				t.Errorf("MatchIP(%v, %q) = %v, want %v", tc.profile, tc.observed, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMatchIP_CIDRMembership(t *testing.T) {
+	cases := []struct {
+		name     string
+		profile  []string
+		observed string
+		want     bool
+	}{
+		{"ipv4-cidr-hit", []string{"10.0.0.0/8"}, "10.1.2.3", true},
+		{"ipv4-cidr-edge-network", []string{"10.0.0.0/8"}, "10.0.0.0", true},
+		{"ipv4-cidr-edge-broadcast", []string{"10.0.0.0/8"}, "10.255.255.255", true},
+		{"ipv4-cidr-miss", []string{"10.0.0.0/8"}, "11.0.0.1", false},
+		{"ipv4-cidr-32-equals-literal", []string{"10.1.2.3/32"}, "10.1.2.3", true},
+		{"ipv4-cidr-32-other-miss", []string{"10.1.2.3/32"}, "10.1.2.4", false},
+		{"ipv6-cidr-hit", []string{"2001:db8::/32"}, "2001:db8::1", true},
+		{"ipv6-cidr-miss", []string{"2001:db8::/32"}, "2001:db9::1", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := MatchIP(tc.profile, tc.observed); got != tc.want {
+				t.Errorf("MatchIP(%v, %q) = %v, want %v", tc.profile, tc.observed, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMatchIP_AnySentinel(t *testing.T) {
+	// The "*" sentinel matches any valid IP. Spec §5.7 row 3.
+	cases := []struct {
+		name     string
+		observed string
+		want     bool
+	}{
+		{"ipv4-any", "1.2.3.4", true},
+		{"ipv6-any", "2001:db8::1", true},
+		{"loopback-v4", "127.0.0.1", true},
+		{"loopback-v6", "::1", true},
+		{"empty-still-false", "", false}, // empty observation cannot match anything, even *
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := MatchIP([]string{"*"}, tc.observed); got != tc.want {
+				t.Errorf("MatchIP(['*'], %q) = %v, want %v", tc.observed, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMatchIP_AnyAsCIDR(t *testing.T) {
+	// 0.0.0.0/0 and ::/0 are the RFC-aligned alternatives to "*".
+	if !MatchIP([]string{"0.0.0.0/0"}, "1.2.3.4") {
+		t.Error("0.0.0.0/0 should match any IPv4")
+	}
+	if !MatchIP([]string{"::/0"}, "2001:db8::1") {
+		t.Error("::/0 should match any IPv6")
+	}
+	// 0.0.0.0/0 alone does NOT cover IPv6 — RFC distinct address families.
+	if MatchIP([]string{"0.0.0.0/0"}, "2001:db8::1") {
+		t.Error("0.0.0.0/0 must NOT match IPv6 — distinct address family")
+	}
+	// ::/0 alone does NOT cover IPv4 (Go's net.IPNet behavior confirms this).
+	if MatchIP([]string{"::/0"}, "1.2.3.4") {
+		t.Error("::/0 must NOT match IPv4 — distinct address family")
+	}
+}
+
+func TestMatchIP_RejectsMalformed(t *testing.T) {
+	// Malformed entries are skipped (not crashed on); other valid entries
+	// in the same list still match. This is the runtime-side defence;
+	// admission-time validation should reject them at write time.
+	cases := []struct {
+		name     string
+		profile  []string
+		observed string
+		want     bool
+	}{
+		{"garbage-only-no-match", []string{"not-an-ip"}, "1.2.3.4", false},
+		{"garbage-cidr-skipped", []string{"10.0.0.0/40"}, "10.1.2.3", false},
+		{"garbage-skipped-but-valid-still-matches", []string{"not-an-ip", "10.1.2.3"}, "10.1.2.3", true},
+		{"empty-profile", nil, "1.2.3.4", false},
+		{"empty-string-entry", []string{""}, "1.2.3.4", false},
+		{"observed-is-garbage", []string{"10.1.2.3"}, "not-an-ip", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := MatchIP(tc.profile, tc.observed); got != tc.want {
+				t.Errorf("MatchIP(%v, %q) = %v, want %v", tc.profile, tc.observed, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMatchIP_ListAcceptIfAnyMatches(t *testing.T) {
+	// Mirror of fixture 07: mixed list. Disjunctive — any single entry hit means match.
+	profile := []string{"10.1.2.3", "192.168.0.0/16", "*"}
+	if !MatchIP(profile, "10.1.2.3") {
+		t.Error("literal hit in mixed list must match")
+	}
+	if !MatchIP(profile, "192.168.5.5") {
+		t.Error("CIDR hit in mixed list must match")
+	}
+	// "*" is in the list, so anything matches via the sentinel.
+	if !MatchIP(profile, "8.8.8.8") {
+		t.Error("'*' in list must match any valid IP")
+	}
+
+	// Without the sentinel, only literal+CIDR coverage holds.
+	narrower := []string{"10.1.2.3", "192.168.0.0/16"}
+	if MatchIP(narrower, "8.8.8.8") {
+		t.Error("non-listed IP must NOT match without '*' sentinel")
+	}
+	if !MatchIP(narrower, "192.168.5.5") {
+		t.Error("CIDR-listed IP must match without '*' sentinel")
+	}
+}

--- a/pkg/registry/file/networkmatch/validate.go
+++ b/pkg/registry/file/networkmatch/validate.go
@@ -1,0 +1,79 @@
+package networkmatch
+
+import (
+	"fmt"
+	"net"
+	"strings"
+)
+
+// ValidateIPEntry returns an error describing why entry is not a valid
+// member of an IPAddresses[] list, or nil if it is valid.
+//
+// Valid forms:
+//   - literal IP    (parsed by net.ParseIP)
+//   - CIDR          (parsed by net.ParseCIDR)
+//   - the AnyIPSentinel ("*")
+//
+// This is the admission-time defence; runtime MatchIP also tolerates
+// malformed entries (silently skips them) so a bad write doesn't kill
+// the whole match.
+func ValidateIPEntry(entry string) error {
+	if entry == "" {
+		return fmt.Errorf("empty IP entry")
+	}
+	if entry == AnyIPSentinel {
+		return nil
+	}
+	if strings.Contains(entry, "/") {
+		if _, _, err := net.ParseCIDR(entry); err != nil {
+			return fmt.Errorf("malformed CIDR %q: %w", entry, err)
+		}
+		return nil
+	}
+	if net.ParseIP(entry) == nil {
+		return fmt.Errorf("malformed IP %q (not a literal, not a CIDR)", entry)
+	}
+	return nil
+}
+
+// ValidateDNSEntry returns an error describing why entry is not a valid
+// member of a DNSNames[] list, or nil if it is valid.
+//
+// Valid forms (spec §5.8):
+//   - literal name (with or without trailing dot)
+//   - leading "*"   (only as the first label, RFC 4592)
+//   - trailing "*"  (only as the last label)
+//   - mid "⋯"       (DynamicLabel, anywhere)
+//
+// Rejected:
+//   - "**" anywhere (recursive — reserved)
+//   - empty inner labels (e.g. "foo..bar")
+//   - "*" in any position other than first or last
+//   - lone "*" with no fixed anchor (degenerate single-label pattern)
+func ValidateDNSEntry(entry string) error {
+	if entry == "" {
+		return fmt.Errorf("empty DNS entry")
+	}
+	canon := strings.TrimSuffix(entry, ".")
+	if canon == "" {
+		return fmt.Errorf("DNS entry %q is just a trailing dot", entry)
+	}
+	labels := strings.Split(canon, ".")
+	if len(labels) == 1 && labels[0] == DNSWildcardLabel {
+		return fmt.Errorf("lone %q is not a valid DNS pattern — needs an anchored suffix", DNSWildcardLabel)
+	}
+	for i, l := range labels {
+		switch {
+		case l == "":
+			return fmt.Errorf("DNS entry %q has empty label at position %d", entry, i)
+		case l == "**":
+			return fmt.Errorf("DNS entry %q contains reserved recursive wildcard %q", entry, "**")
+		case l == DNSWildcardLabel && i != 0 && i != len(labels)-1:
+			return fmt.Errorf(
+				"DNS entry %q: bare %q is only allowed as the first label (RFC 4592) "+
+					"or last label (project extension); use %q for mid positions",
+				entry, DNSWildcardLabel, DNSDynamicLabel)
+		}
+	}
+	return nil
+}

--- a/pkg/registry/file/networkmatch/validate_test.go
+++ b/pkg/registry/file/networkmatch/validate_test.go
@@ -1,0 +1,60 @@
+package networkmatch
+
+import "testing"
+
+func TestValidateIPEntry(t *testing.T) {
+	cases := []struct {
+		name    string
+		entry   string
+		wantErr bool
+	}{
+		{"empty", "", true},
+		{"literal-v4", "10.1.2.3", false},
+		{"literal-v6", "2001:db8::1", false},
+		{"cidr-v4", "10.0.0.0/8", false},
+		{"cidr-v6", "2001:db8::/32", false},
+		{"any-sentinel", "*", false},
+		{"any-cidr-v4", "0.0.0.0/0", false},
+		{"any-cidr-v6", "::/0", false},
+		{"garbage", "not-an-ip", true},
+		{"bad-cidr-mask", "10.0.0.0/40", true},
+		{"bad-cidr-host", "not-an-ip/8", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateIPEntry(tc.entry)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("ValidateIPEntry(%q) err=%v, wantErr=%v", tc.entry, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateDNSEntry(t *testing.T) {
+	cases := []struct {
+		name    string
+		entry   string
+		wantErr bool
+	}{
+		{"empty", "", true},
+		{"trailing-dot-only", ".", true},
+		{"literal-with-dot", "api.stripe.com.", false},
+		{"literal-no-dot", "api.stripe.com", false},
+		{"leading-star", "*.example.com.", false},
+		{"trailing-star", "internal.*", false},
+		{"mid-ellipsis", "kubernetes.⋯.svc.cluster.local.", false},
+		{"recursive-double-star", "**", true},
+		{"recursive-in-middle", "foo.**.bar.", true},
+		{"empty-inner-label", "foo..bar.", true},
+		{"lone-star", "*", true},
+		{"mid-star-rejected", "foo.*.bar.", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateDNSEntry(tc.entry)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("ValidateDNSEntry(%q) err=%v, wantErr=%v", tc.entry, err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/registry/softwarecomposition/networkneighborhood/strategy.go
+++ b/pkg/registry/softwarecomposition/networkneighborhood/strategy.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/k8s-interface/instanceidhandler/v1/helpers"
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition"
+	"github.com/kubescape/storage/pkg/registry/file/networkmatch"
 	"github.com/kubescape/storage/pkg/registry/softwarecomposition/common"
 	"github.com/kubescape/storage/pkg/utils"
 )
@@ -104,7 +105,76 @@ func (NetworkNeighborhoodStrategy) Validate(_ context.Context, obj runtime.Objec
 		allErrors = append(allErrors, err)
 	}
 
+	allErrors = append(allErrors, validateNetworkProfileEntries(&ap.Spec)...)
+
 	return allErrors
+}
+
+// validateNetworkProfileEntries walks every NetworkNeighbor in the spec and
+// validates each IPAddresses[] and DNSNames[] entry against the v0.0.2
+// wildcard token grammar (spec §5.7, §5.8).
+//
+// This is the admission-time defence; runtime matchers also tolerate
+// malformed entries so a misconfigured profile doesn't kill the
+// detection path entirely.
+func validateNetworkProfileEntries(spec *softwarecomposition.NetworkNeighborhoodSpec) field.ErrorList {
+	var errs field.ErrorList
+	specPath := field.NewPath("spec")
+	// Ordered slice rather than a map: Go map iteration is non-deterministic,
+	// and admission errors flow back to clients via the apiserver. Stable
+	// ordering keeps error messages reproducible across requests and across
+	// test runs.
+	groups := []struct {
+		name  string
+		items []softwarecomposition.NetworkNeighborhoodContainer
+	}{
+		{name: "containers", items: spec.Containers},
+		{name: "initContainers", items: spec.InitContainers},
+		{name: "ephemeralContainers", items: spec.EphemeralContainers},
+	}
+	for _, g := range groups {
+		groupPath := specPath.Child(g.name)
+		for ci, c := range g.items {
+			containerPath := groupPath.Index(ci)
+			errs = append(errs, validateNeighborList(containerPath.Child("egress"), c.Egress)...)
+			errs = append(errs, validateNeighborList(containerPath.Child("ingress"), c.Ingress)...)
+		}
+	}
+	return errs
+}
+
+func validateNeighborList(parent *field.Path, list []softwarecomposition.NetworkNeighbor) field.ErrorList {
+	var errs field.ErrorList
+	for ni, n := range list {
+		nPath := parent.Index(ni)
+		ipsPath := nPath.Child("ipAddresses")
+		for ei, e := range n.IPAddresses {
+			if err := networkmatch.ValidateIPEntry(e); err != nil {
+				errs = append(errs, field.Invalid(ipsPath.Index(ei), e, err.Error()))
+			}
+		}
+		// Deprecated singular IPAddress is still accepted; validate it too
+		// so malformed values can't slip past admission via the old form.
+		if n.IPAddress != "" {
+			if err := networkmatch.ValidateIPEntry(n.IPAddress); err != nil {
+				errs = append(errs, field.Invalid(nPath.Child("ipAddress"), n.IPAddress, err.Error()))
+			}
+		}
+		dnsPath := nPath.Child("dnsNames")
+		for ei, e := range n.DNSNames {
+			if err := networkmatch.ValidateDNSEntry(e); err != nil {
+				errs = append(errs, field.Invalid(dnsPath.Index(ei), e, err.Error()))
+			}
+		}
+		// Deprecated singular DNS is still accepted; validate it too,
+		// mirroring the IPAddress pattern above.
+		if n.DNS != "" {
+			if err := networkmatch.ValidateDNSEntry(n.DNS); err != nil {
+				errs = append(errs, field.Invalid(nPath.Child("dns"), n.DNS, err.Error()))
+			}
+		}
+	}
+	return errs
 }
 
 // WarningsOnCreate returns warnings for the creation of the given object.
@@ -135,6 +205,8 @@ func (NetworkNeighborhoodStrategy) ValidateUpdate(_ context.Context, obj, _ runt
 	if err := utils.ValidateStatusAnnotation(ap.Annotations); err != nil {
 		allErrors = append(allErrors, err)
 	}
+
+	allErrors = append(allErrors, validateNetworkProfileEntries(&ap.Spec)...)
 
 	return allErrors
 }

--- a/pkg/registry/softwarecomposition/networkneighborhood/strategy_test.go
+++ b/pkg/registry/softwarecomposition/networkneighborhood/strategy_test.go
@@ -344,3 +344,159 @@ func TestPrepareForUpdateFullObj(t *testing.T) {
 		})
 	}
 }
+
+// TestValidate_NetworkProfileEntries pins the v0.0.2 admission contract:
+// malformed IPAddresses[] / DNSNames[] entries cause Validate to return
+// field errors that the apiserver translates into a 400 to the client.
+//
+// Runtime matchers tolerate malformed entries (silently skip), but
+// admission rejects them so the next person reviewing the profile sees
+// a clean document — and so the user gets fast feedback at write time.
+func TestValidate_NetworkProfileEntries(t *testing.T) {
+	makeNN := func(neighbor softwarecomposition.NetworkNeighbor) *softwarecomposition.NetworkNeighborhood {
+		return &softwarecomposition.NetworkNeighborhood{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "test-nn",
+				Namespace:   "default",
+				Annotations: map[string]string{helpers.CompletionMetadataKey: "complete", helpers.StatusMetadataKey: "ready"},
+			},
+			Spec: softwarecomposition.NetworkNeighborhoodSpec{
+				Containers: []softwarecomposition.NetworkNeighborhoodContainer{
+					{Name: "c", Egress: []softwarecomposition.NetworkNeighbor{neighbor}},
+				},
+			},
+		}
+	}
+
+	cases := []struct {
+		name     string
+		neighbor softwarecomposition.NetworkNeighbor
+		// wantPaths is the multiset of expected error field paths.
+		// Asserting paths (not just count) pins the field-path contract
+		// — if validation starts emitting errors on the wrong field path,
+		// downstream tooling that surfaces these to users will break.
+		wantPaths []string
+	}{
+		{
+			name:      "all valid IPs and DNSNames",
+			neighbor:  softwarecomposition.NetworkNeighbor{IPAddresses: []string{"10.0.0.0/8", "*", "1.2.3.4"}, DNSNames: []string{"*.example.com.", "api.partner.io."}},
+			wantPaths: nil,
+		},
+		{
+			name:      "single malformed IP",
+			neighbor:  softwarecomposition.NetworkNeighbor{IPAddresses: []string{"not-an-ip"}},
+			wantPaths: []string{"spec.containers[0].egress[0].ipAddresses[0]"},
+		},
+		{
+			name:      "single malformed CIDR",
+			neighbor:  softwarecomposition.NetworkNeighbor{IPAddresses: []string{"10.0.0.0/40"}},
+			wantPaths: []string{"spec.containers[0].egress[0].ipAddresses[0]"},
+		},
+		{
+			name:      "recursive DNS wildcard rejected",
+			neighbor:  softwarecomposition.NetworkNeighbor{DNSNames: []string{"**"}},
+			wantPaths: []string{"spec.containers[0].egress[0].dnsNames[0]"},
+		},
+		{
+			name:      "mid-position bare star rejected (must use ⋯)",
+			neighbor:  softwarecomposition.NetworkNeighbor{DNSNames: []string{"foo.*.bar."}},
+			wantPaths: []string{"spec.containers[0].egress[0].dnsNames[0]"},
+		},
+		{
+			name:     "mixed: some good, some bad",
+			neighbor: softwarecomposition.NetworkNeighbor{IPAddresses: []string{"10.1.2.3", "garbage", "192.168.0.0/16"}, DNSNames: []string{"api.example.com.", "**", "*.example.com."}},
+			wantPaths: []string{
+				"spec.containers[0].egress[0].ipAddresses[1]",
+				"spec.containers[0].egress[0].dnsNames[1]",
+			},
+		},
+		{
+			name:      "deprecated singular IPAddress malformed is also rejected",
+			neighbor:  softwarecomposition.NetworkNeighbor{IPAddress: "not-an-ip"},
+			wantPaths: []string{"spec.containers[0].egress[0].ipAddress"},
+		},
+		{
+			name:      "deprecated singular DNS malformed is also rejected",
+			neighbor:  softwarecomposition.NetworkNeighbor{DNS: "**"},
+			wantPaths: []string{"spec.containers[0].egress[0].dns"},
+		},
+	}
+
+	s := NetworkNeighborhoodStrategy{}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := s.Validate(context.TODO(), makeNN(tc.neighbor))
+			if len(errs) != len(tc.wantPaths) {
+				t.Fatalf("Validate returned %d errors, want %d. errs: %v", len(errs), len(tc.wantPaths), errs)
+			}
+			gotPaths := make([]string, 0, len(errs))
+			for _, e := range errs {
+				gotPaths = append(gotPaths, e.Field)
+			}
+			// Order-insensitive set comparison: build a multiset from each side.
+			gotSet := map[string]int{}
+			for _, p := range gotPaths {
+				gotSet[p]++
+			}
+			wantSet := map[string]int{}
+			for _, p := range tc.wantPaths {
+				wantSet[p]++
+			}
+			for p, n := range wantSet {
+				if gotSet[p] != n {
+					t.Errorf("expected %d errors at path %q, got %d (all paths: %v)", n, p, gotSet[p], gotPaths)
+				}
+			}
+			for p := range gotSet {
+				if _, ok := wantSet[p]; !ok {
+					t.Errorf("unexpected error at path %q (all paths: %v)", p, gotPaths)
+				}
+			}
+		})
+	}
+}
+
+// TestValidateUpdate_NetworkProfileEntries pins the same admission contract
+// for the update path. CR (storage#30) caught that ValidateUpdate originally
+// skipped network-profile validation, allowing malformed entries to land via
+// PUT after a clean POST.
+func TestValidateUpdate_NetworkProfileEntries(t *testing.T) {
+	bad := &softwarecomposition.NetworkNeighborhood{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "test-nn",
+			Namespace:   "default",
+			Annotations: map[string]string{helpers.CompletionMetadataKey: "complete", helpers.StatusMetadataKey: "ready"},
+		},
+		Spec: softwarecomposition.NetworkNeighborhoodSpec{
+			Containers: []softwarecomposition.NetworkNeighborhoodContainer{{
+				Name: "c",
+				Egress: []softwarecomposition.NetworkNeighbor{
+					{IPAddresses: []string{"not-an-ip"}, DNSNames: []string{"**"}},
+				},
+			}},
+		},
+	}
+	s := NetworkNeighborhoodStrategy{}
+	errs := s.ValidateUpdate(context.TODO(), bad, bad)
+	wantPaths := map[string]int{
+		"spec.containers[0].egress[0].ipAddresses[0]": 1,
+		"spec.containers[0].egress[0].dnsNames[0]":    1,
+	}
+	if len(errs) != 2 {
+		t.Fatalf("ValidateUpdate returned %d errors, want 2. errs: %v", len(errs), errs)
+	}
+	gotSet := map[string]int{}
+	for _, e := range errs {
+		gotSet[e.Field]++
+	}
+	for p, n := range wantPaths {
+		if gotSet[p] != n {
+			t.Errorf("expected %d errors at path %q, got %d (all: %v)", n, p, gotSet[p], errs)
+		}
+	}
+	for p := range gotSet {
+		if _, ok := wantPaths[p]; !ok {
+			t.Errorf("unexpected error at path %q (all: %v)", p, errs)
+		}
+	}
+}


### PR DESCRIPTION
Sorry, we do not accept changes directly against this repository. Please see
CONTRIBUTING.md for information on where and how to contribute instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `NetworkNeighbor.IPAddresses` (list) support for literal IPs, CIDRs, and `*`, including wildcard-aware matching.
  * Added wildcard-aware DNS name matching (including `⋯` and `*` rules).
* **Validation & API Changes**
  * Added admission-time validation for network profile IP/DNS entries, including deprecated single-value fields when set.
* **Documentation**
  * Documented the IP/DNS matching contract and performance guidance.
* **Tests**
  * Added protobuf encoding/round-trip tests plus unit tests and benchmarks for matching and validation.
* **Chores**
  * Bumped the protoc Docker build image version.
* **Deprecated**
  * Deprecated singular `IPAddress`; use `IPAddresses` instead.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->