### PR TITLE
fix(server): make WatchList=false effective and stop pre-closed watch retry loops

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,13 @@ TAG?=test
 IMAGE?=quay.io/kubescape/$(BINARY_NAME)
 
 
+.PHONY: build test docker-build docker-push
+
 build:
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o $(BINARY_NAME)
+
+test:
+	go test ./...
 
 docker-build:
 	docker buildx build --platform linux/amd64 -t $(IMAGE):$(TAG) --load -f $(DOCKERFILE_PATH) .

--- a/docs/features/watchlist-disabled.md
+++ b/docs/features/watchlist-disabled.md
@@ -1,0 +1,69 @@
+# WatchList disabled (streaming list / `sendInitialEvents`)
+
+## Summary
+
+The storage apiserver **disables the `WatchList` feature gate** (`feature-gates=WatchList=false`,
+set in `pkg/cmd/server/start.go`). As a result it **rejects `watch?sendInitialEvents=true`
+requests pre-stream with HTTP 422**, and WatchList-capable clients fall back to legacy
+`LIST` + `WATCH`.
+
+This is deliberate. The file/SQLite-backed storage has **no Cacher** and its watch path
+(`pkg/registry/file/watch.go`) only forwards *future* events — it never replays current
+state and **never emits the terminal `k8s.io/initial-events-end` BOOKMARK** that the
+WatchList (streaming-list) protocol requires. If the server accepted such a request, the
+client's reflector would block forever awaiting that bookmark.
+
+## Why it matters
+
+Kubernetes controllers that build **metadata informers** (`PartialObjectMetadata` LIST/WATCH)
+use WatchList by default once `WatchListClient` is on (client-go ≥ v0.35 ships it Beta /
+default-on; control planes from k8s ~1.32 enable it). Without this fix, those informers hang
+against the spdx aggregated API, which has two known, severe consequences:
+
+- **ResourceQuota controller stall.** The quota controller blocks `WaitForCacheSync` on
+  *every* discovered namespaced list+watch resource. One spdx monitor that never syncs
+  freezes **all** quota replenishment cluster-wide, so quotas stop decrementing and
+  eventually behave as if at their hard limit. (Upstream context:
+  [kubernetes/kubernetes#133737](https://github.com/kubernetes/kubernetes/issues/133737),
+  which names `spdx.softwarecomposition.kubescape.io/v1beta1`.)
+- **Rancher cattle-agent tight retry loop** ([#318](https://github.com/kubescape/storage/issues/318)):
+  reflectors awaiting the missing bookmark, plus pre-closed watch channels, drove a hot
+  re-watch loop.
+
+## How it works
+
+1. **Effective gate ordering.** `flags.Set("feature-gates", "WatchList=false")` must run
+   **before** `ComponentGlobalsRegistry.Set()` — that registry call is the only bridge that
+   propagates the parsed flag into `utilfeature.DefaultMutableFeatureGate`. If the order is
+   reversed (as it was before [#330](https://github.com/kubescape/storage/pull/330)), the
+   override is a silent no-op and the gate stays at its default (**enabled**). The apiserver's
+   watch handler then validates `ListOptions` against the now-disabled gate and returns 422
+   for `sendInitialEvents`, so clients use legacy list+watch instead.
+
+   > `ServerSideApply` is GA / non-gated in Kubernetes 1.35; it must **not** appear in the
+   > `feature-gates` override or the server fails to boot with `unrecognized feature gate`.
+
+2. **Idle watches instead of pre-closed channels.** `watch.NewEmptyWatch()` returns a
+   *pre-closed* channel; a reflector reading it sees 0 events in <1s → `VeryShortWatchError`
+   → immediate re-watch → tight loop, in both legacy and streaming modes. The namespaced
+   path in `StorageImpl.Watch` and `immutableStorage.Watch` (ConfigurationScanSummary,
+   VulnerabilitySummary, GeneratedNetworkPolicy) return an `idleWatch` instead: a
+   zero-goroutine `watch.Interface` that stays open and event-free until client disconnect
+   or `Stop()`. The real `watchDispatcher` path for cluster-scoped resources is unchanged.
+
+## Scope / limitations
+
+- This does **not** implement WatchList / `sendInitialEvents` semantics for the resources
+  served by the real watch dispatcher (tracked in
+  [#320](https://github.com/kubescape/storage/issues/320)). Correctness relies on the
+  effective `WatchList=false` producing the pre-stream 422 fallback.
+- Plain (non-streaming) `LIST` and `WATCH` are unaffected and continue to work normally.
+
+## Verifying
+
+- Server logs (debug): `effective feature gates ... WatchList=false`.
+- A `ResourceQuota` in a namespace should have a populated `status.used` / `status.hard`
+  (not `status: {}`), and the kube-controller-manager should stop logging
+  `timed out waiting for quota monitor sync`.
+- Tests: `pkg/cmd/server/start_test.go` (gate effective + 422 decision point) and
+  `pkg/registry/file/idlewatch_test.go` (idle watch stays open / closes correctly).

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/yl2chen/cidranger v1.0.2
 	go.opentelemetry.io/otel v1.43.0
+	go.uber.org/goleak v1.3.0
 	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.27.1
 	golang.org/x/text v0.37.0

--- a/pkg/cmd/server/start.go
+++ b/pkg/cmd/server/start.go
@@ -42,6 +42,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/apiserver/pkg/endpoints/openapi"
+	"k8s.io/apiserver/pkg/features"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	genericoptions "k8s.io/apiserver/pkg/server/options"
 	"k8s.io/apiserver/pkg/util/compatibility"
@@ -136,14 +137,19 @@ func NewCommandStartWardleServer(ctx context.Context, defaults *WardleServerOpti
 			if skipDefaultComponentGlobalsRegistrySet {
 				return nil
 			}
+			flags := cmd.Flags()
+			// WatchList not yet implemented in the file-based storage backend, see https://github.com/kubescape/storage/issues/320
+			// Note: ServerSideApply is GA/non-gated in Kubernetes 1.35 and cannot be disabled via feature-gates;
+			// the previous "ServerSideApply=false" token was always inert and would now fail gate validation.
+			if err := flags.Set("feature-gates", "WatchList=false"); err != nil {
+				return err
+			}
+			// ComponentGlobalsRegistry.Set is the only bridge propagating the parsed feature-gates
+			// flag into the actual feature gates, so it must run after the flag value is populated.
 			if err := defaults.ComponentGlobalsRegistry.Set(); err != nil {
 				return err
 			}
-			flags := cmd.Flags()
-			// WatchList not yet implemented in the file-based storage backend, see https://github.com/kubescape/storage/issues/320
-			if err := flags.Set("feature-gates", "ServerSideApply=false,WatchList=false"); err != nil {
-				return err
-			}
+			logger.L().Debug("effective feature gates", helpers.Interface("WatchList", utilfeature.DefaultFeatureGate.Enabled(features.WatchList)))
 			return nil
 		},
 		RunE: func(c *cobra.Command, args []string) error {

--- a/pkg/cmd/server/start_test.go
+++ b/pkg/cmd/server/start_test.go
@@ -1,0 +1,82 @@
+package server
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/kubescape/storage/pkg/config"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
+	metainternalversionvalidation "k8s.io/apimachinery/pkg/apis/meta/internalversion/validation"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/features"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	basecompatibility "k8s.io/component-base/compatibility"
+	"k8s.io/utils/ptr"
+)
+
+// newTestOptions returns WardleServerOptions with a fresh ComponentGlobalsRegistry so that
+// each test can construct its own command: the registry's AddFlags closes its feature gates,
+// so re-registering the Wardle component against the shared default registry would panic.
+// Note that the kube component still maps to the process-global
+// utilfeature.DefaultMutableFeatureGate, so gate state leaks between tests by design.
+func newTestOptions() *WardleServerOptions {
+	o := NewWardleServerOptions(io.Discard, io.Discard, afero.NewMemMapFs(), nil, config.Config{}, nil, nil)
+	o.ComponentGlobalsRegistry = basecompatibility.NewComponentGlobalsRegistry()
+	return o
+}
+
+// TestPersistentPreRunESkipLeavesGatesUntouched guards the contract relied upon by callers
+// passing skipDefaultComponentGlobalsRegistrySet=true (e.g. integration tests): no feature
+// gate is modified.
+func TestPersistentPreRunESkipLeavesGatesUntouched(t *testing.T) {
+	cmd := NewCommandStartWardleServer(context.TODO(), newTestOptions(), true)
+	before := utilfeature.DefaultFeatureGate.Enabled(features.WatchList)
+	require.NoError(t, cmd.PersistentPreRunE(cmd, nil))
+	assert.Equal(t, before, utilfeature.DefaultFeatureGate.Enabled(features.WatchList))
+}
+
+// TestPersistentPreRunEDisablesWatchList is the regression test for the feature-gate
+// ordering bug behind https://github.com/kubescape/storage/issues/318: the flag value used
+// to be populated only after ComponentGlobalsRegistry.Set() had already run, so the
+// WatchList override silently never applied. After the fix, PersistentPreRunE must succeed
+// (boot safety) and the gate must be effective at request time, which makes the apiserver
+// watch handler (k8s.io/apiserver/pkg/endpoints/handlers/get.go ListResource) reject
+// sendInitialEvents watch requests before the stream opens (HTTP 422). WatchList-enabled
+// clients (client-go >= v0.35 reflectors, Rancher) then use legacy list+watch instead of
+// hanging while awaiting an initial-events-end bookmark that the file-based storage never
+// sends.
+func TestPersistentPreRunEDisablesWatchList(t *testing.T) {
+	cmd := NewCommandStartWardleServer(context.TODO(), newTestOptions(), false)
+	require.NoError(t, cmd.PersistentPreRunE(cmd, nil))
+	assert.False(t, utilfeature.DefaultFeatureGate.Enabled(features.WatchList))
+
+	// Assert the exact decision point the watch handler uses with the now-effective gate.
+	opts := internalversion.ListOptions{
+		Watch:                true,
+		AllowWatchBookmarks:  true,
+		SendInitialEvents:    ptr.To(true),
+		ResourceVersionMatch: metav1.ResourceVersionMatchNotOlderThan,
+	}
+	errs := metainternalversionvalidation.ValidateListOptions(&opts, utilfeature.DefaultFeatureGate.Enabled(features.WatchList))
+	require.NotEmpty(t, errs, "sendInitialEvents watch requests must be rejected pre-stream when WatchList is disabled")
+	assert.Contains(t, errs.ToAggregate().Error(), "sendInitialEvents is forbidden for watch")
+}
+
+// TestPersistentPreRunERejectsUnknownGate ensures a stale feature-gate token (such as
+// ServerSideApply, which is GA and non-gated since Kubernetes 1.35) fails loudly at boot
+// instead of being silently ignored.
+//
+// This test MUST remain the last one in this file: the rejected raw override is retained by
+// the process-global kube feature gate and makes any subsequent NewCommandStartWardleServer
+// call panic when registration re-validates the stored overrides.
+func TestPersistentPreRunERejectsUnknownGate(t *testing.T) {
+	cmd := NewCommandStartWardleServer(context.TODO(), newTestOptions(), false)
+	require.NoError(t, cmd.Flags().Set("feature-gates", "ServerSideApply=false"))
+	err := cmd.PersistentPreRunE(cmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unrecognized feature gate")
+}

--- a/pkg/registry/file/idlewatch_test.go
+++ b/pkg/registry/file/idlewatch_test.go
@@ -1,0 +1,113 @@
+package file
+
+import (
+	"context"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/apiserver/pkg/storage"
+)
+
+// assertStaysOpen asserts that w neither emits an event nor closes within chanWaitTimeout.
+func assertStaysOpen(t *testing.T, w watch.Interface) {
+	t.Helper()
+	select {
+	case ev, ok := <-w.ResultChan():
+		if ok {
+			t.Fatalf("idle watch must not emit events, got %v", ev)
+		}
+		t.Fatal("idle watch must not close before ctx cancellation or Stop")
+	case <-time.After(chanWaitTimeout):
+	}
+}
+
+// assertClosed asserts that w's result channel closes within chanWaitTimeout.
+func assertClosed(t *testing.T, w watch.Interface) {
+	t.Helper()
+	select {
+	case ev, ok := <-w.ResultChan():
+		assert.False(t, ok, "idle watch must close without emitting events, got %v", ev)
+	case <-time.After(chanWaitTimeout):
+		t.Fatal("idle watch channel should be closed")
+	}
+}
+
+func TestIdleWatchClosesOnCtxCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.TODO())
+	w := newIdleWatch(ctx)
+	assertStaysOpen(t, w)
+	cancel()
+	assertClosed(t, w)
+}
+
+func TestIdleWatchStop(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.TODO())
+	w := newIdleWatch(ctx)
+	// Stop before ctx cancellation must close the channel (a fast-disconnecting client
+	// reaches the handler's deferred Stop before the request context unwinds).
+	w.Stop()
+	assertClosed(t, w)
+	// Double Stop and a late ctx cancellation must both be safe.
+	w.Stop()
+	cancel()
+	assertClosed(t, w)
+}
+
+// TestStorageImplWatchNamespacedKeyIsIdle covers the namespaced-key path of
+// StorageImpl.Watch, which used to return a pre-closed watch.NewEmptyWatch() and send
+// reflectors into a "very short watch" tight retry loop (issue #318).
+func TestStorageImplWatchNamespacedKeyIsIdle(t *testing.T) {
+	s := NewStorageImpl(afero.NewMemMapFs(), DefaultStorageRoot, nil, nil, nil)
+	ctx, cancel := context.WithCancel(context.TODO())
+	w, err := s.Watch(ctx, "/spdx.softwarecomposition.kubescape.io/sbomsyfts/kubescape", storage.ListOptions{})
+	require.NoError(t, err)
+	assertStaysOpen(t, w)
+	cancel()
+	assertClosed(t, w)
+}
+
+// TestImmutableStorageWatchIsIdle covers immutableStorage.Watch (ConfigurationScanSummary,
+// VulnerabilitySummary, GeneratedNetworkPolicy), the other pre-closed watch site of #318.
+func TestImmutableStorageWatchIsIdle(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.TODO())
+	w, err := immutableStorage{}.Watch(ctx, "/spdx.softwarecomposition.kubescape.io/vulnerabilitysummaries", storage.ListOptions{})
+	require.NoError(t, err)
+	assertStaysOpen(t, w)
+	cancel()
+	assertClosed(t, w)
+}
+
+// TestIdleWatchSpawnsNoGoroutines proves the zero-goroutine property: hundreds of concurrent
+// idle watches (Rancher steve watches every GVK) must not inflate the goroutine count, and
+// cancellation must return to baseline without leaks.
+func TestIdleWatchSpawnsNoGoroutines(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	const n = 200
+	baseline := runtime.NumGoroutine()
+	cancels := make([]context.CancelFunc, 0, n)
+	watches := make([]*idleWatch, 0, n)
+	for range n {
+		ctx, cancel := context.WithCancel(context.TODO())
+		watches = append(watches, newIdleWatch(ctx))
+		cancels = append(cancels, cancel)
+	}
+	steady := runtime.NumGoroutine()
+	assert.LessOrEqual(t, steady, baseline+2, "idle watches must not spawn goroutines")
+
+	for _, cancel := range cancels {
+		cancel()
+	}
+	for _, w := range watches {
+		assertClosed(t, w)
+	}
+	require.Eventually(t, func() bool {
+		return runtime.NumGoroutine() <= baseline+2
+	}, time.Second, 10*time.Millisecond, "goroutine count must return to baseline after cancellation")
+}

--- a/pkg/registry/file/storage.go
+++ b/pkg/registry/file/storage.go
@@ -393,7 +393,9 @@ func (s *StorageImpl) Watch(ctx context.Context, key string, opts storage.ListOp
 	if namespace != "" {
 		// FIXME find an alternative to fix NS deletion
 		logger.L().Debug("rejecting Watch called with namespace", helpers.String("key", key), helpers.String("namespace", namespace))
-		return watch.NewEmptyWatch(), nil
+		// Return an idle (open, event-free) watch instead of a pre-closed one:
+		// a pre-closed channel sends reflectors into a "very short watch" tight retry loop.
+		return newIdleWatch(ctx), nil
 	}
 	// TODO(ttimonen) Should we do ctx.WithoutCancel; or does the parent ctx lifetime match with expectations?
 	nw := newWatcher(ctx, opts.ResourceVersion == softwarecomposition.ResourceVersionFullSpec)
@@ -1218,8 +1220,10 @@ func (immutableStorage) Delete(_ context.Context, key string, _ runtime.Object, 
 }
 
 // Watch is not supported for immutable objects. Objects are generated on the fly and not stored.
-func (immutableStorage) Watch(_ context.Context, _ string, _ storage.ListOptions) (watch.Interface, error) {
-	return watch.NewEmptyWatch(), nil
+// It returns an idle, event-free watch that closes on client disconnect or Stop:
+// a pre-closed channel would send reflectors into a "very short watch" tight retry loop.
+func (immutableStorage) Watch(ctx context.Context, _ string, _ storage.ListOptions) (watch.Interface, error) {
+	return newIdleWatch(ctx), nil
 }
 
 // GuaranteedUpdate is not supported for immutable objects. Objects are generated on the fly and not stored.

--- a/pkg/registry/file/watch.go
+++ b/pkg/registry/file/watch.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"path"
 	"slices"
+	"sync"
 
 	"github.com/puzpuzpuz/xsync/v2"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -121,6 +122,31 @@ func (w *watcher) send(e watch.Event) {
 	case <-w.ctx.Done():
 	}
 }
+
+// idleWatch is a watch.Interface that stays open without ever emitting events.
+// Its result channel is closed when the request context is cancelled (client
+// disconnect) or Stop is called, whichever comes first. Unlike a pre-closed
+// watch (watch.NewEmptyWatch), it does not send reflectors into a "very short
+// watch" tight retry loop; unlike watcher, it needs no goroutine.
+type idleWatch struct {
+	ch   chan watch.Event // never written to
+	stop func() bool      // cancels the AfterFunc registration
+	once sync.Once
+}
+
+// newIdleWatch creates a new idleWatch whose lifecycle is tied to ctx.
+func newIdleWatch(ctx context.Context) *idleWatch {
+	w := &idleWatch{ch: make(chan watch.Event)}
+	w.stop = context.AfterFunc(ctx, w.close)
+	return w
+}
+
+// Stop is idempotent and safe to call before, after, or concurrently with
+// context cancellation.
+func (w *idleWatch) Stop()                          { w.stop(); w.close() }
+func (w *idleWatch) ResultChan() <-chan watch.Event { return w.ch }
+
+func (w *idleWatch) close() { w.once.Do(func() { close(w.ch) }) }
 
 type watchersList []*watcher
 


### PR DESCRIPTION
## Summary

Fixes the Rancher cattle-agent tight retry loop reported in #318, which the mitigation in #321 could not resolve (confirmed by the reporter). Two independent server defects were found and fixed:

### 1. The `WatchList=false` feature-gate override was a silent no-op

`ComponentGlobalsRegistry.Set()` — the only bridge propagating the parsed `feature-gates` flag into `utilfeature.DefaultMutableFeatureGate` — ran **before** `flags.Set("feature-gates", ...)` populated the flag value, and was never re-invoked. The WatchList gate therefore silently stayed at its default (**enabled**), so the server accepted `watch?sendInitialEvents=true` requests (HTTP 200) it could never complete: the file-based storage has no Cacher and never emits the terminal `initial-events-end` BOOKMARK. This matches the reporter's `awaiting required bookmark event for initial events stream` log lines.

The calls are now reordered so the override is effective at request time. The apiserver then rejects `sendInitialEvents` watches **pre-stream (HTTP 422)**, and WatchList-enabled clients (client-go ≥ v0.35 ships `WatchListClient` Beta default-on; Rancher uses v0.35.1) fall back gracefully to legacy list+watch.

> **Note:** `ServerSideApply` is GA/non-gated in Kubernetes 1.35; #321's `ServerSideApply=false` token was always inert and is removed to prevent a boot-time `unrecognized feature gate` error now that flag ordering is fixed. There is **no** SSA behavior change in this PR. A negative test guards against reintroducing stale gate tokens.

### 2. Pre-closed watch channels caused "very short watch" tight loops

`watch.NewEmptyWatch()` returns a **pre-closed** channel. A reflector reading it observes 0 events in <1s → `VeryShortWatchError` → immediate re-watch → tight loop, in **both** legacy and WatchList modes — which is why disabling WatchList alone could never fully fix #318. Two sites were affected:

- namespaced watch keys in `StorageImpl.Watch`
- `immutableStorage.Watch` (ConfigurationScanSummary, VulnerabilitySummary, GeneratedNetworkPolicy)

Both now return `idleWatch`: a zero-goroutine `watch.Interface` that stays open and event-free until client disconnect or `Stop()` (closure driven by `context.AfterFunc` + `sync.Once`). Reflectors hold a quiet open connection instead of tight-looping. The real `watchDispatcher` path for cluster-scoped resources is untouched.

## Scope

This does **not** implement WatchList/`sendInitialEvents` semantics (#320) for the resources served by the real watch dispatcher — they still never emit `initial-events-end` bookmarks. Correctness relies on the now-effective `WatchList=false` producing the pre-stream 422 so clients never enter that path.

## Testing

- Regression test proving the gate is effective after `PersistentPreRunE` (fails on pre-fix code) + boot-safety + unrecognized-token guard + `skip` contract
- 422 pre-stream assertion at the exact handler decision point (`ValidateListOptions`)
- Idle-watch tests: stays open with zero events, closes on ctx-cancel / `Stop()` / double-`Stop()` / Stop-before-cancel; N=200 concurrent watches add ~0 goroutines (goleak-verified)
- Full suite green (`make test` — target added in this PR), `go vet` clean, `-race -count=3` clean
- Pending before merge: kind-cluster smoke with a client-go v0.35 reflector / Rancher to confirm fallback behavior end-to-end (a test image will be posted on #318)

Refs #318, #320

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved watch behavior with idle watch support to prevent tight retry loops.
  * Enhanced feature-gate configuration handling.

* **Bug Fixes**
  * Watches now properly manage lifecycle and context cancellation.

* **Tests**
  * Added feature-gate validation and configuration tests.
  * Added idle watch behavior and performance tests.

* **Chores**
  * Updated build configuration with test runner.
  * Added testing dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->