### PR TITLE
feat(registry): stop advertising watch and mutations on computed resources

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -157,12 +157,17 @@ func (c completedConfig) New() (*WardleServer, error) {
 			}
 			return sbomregistry.RESTInPeace(f(Scheme, si, c.GenericConfig.RESTOptionsGetter))
 		}
+		// epRO registers read-only REST endpoints for computed resources: watch and mutating
+		// verbs are not advertised in discovery (there is nothing to watch or mutate).
+		epRO = func(f func(*runtime.Scheme, storage.Interface, generic.RESTOptionsGetter) (*registry.ReadOnlyREST, error), s storage.Interface) *registry.ReadOnlyREST {
+			return sbomregistry.RESTInPeace(f(Scheme, s, c.GenericConfig.RESTOptionsGetter))
+		}
 	)
 	apiGroupInfo.VersionedResourcesStorageMap["v1beta1"] = map[string]rest.Storage{
 		"applicationprofiles":                 ep(applicationprofile.NewREST, applicationProfileStorageImpl),
-		"configurationscansummaries":          ep(configurationscansummary.NewREST, configScanStorageImpl),
+		"configurationscansummaries":          epRO(configurationscansummary.NewREST, configScanStorageImpl),
 		"containerprofiles":                   ep(containerprofile.NewREST, containerProfileStorageImpl),
-		"generatednetworkpolicies":            ep(generatednetworkpolicy.NewREST, generatedNetworkPolicyStorage),
+		"generatednetworkpolicies":            epRO(generatednetworkpolicy.NewREST, generatedNetworkPolicyStorage),
 		"knownservers":                        ep(knownserver.NewREST),
 		"networkneighborhoods":                ep(networkneighborhood.NewREST, networkNeighborhoodStorageImpl),
 		"openvulnerabilityexchangecontainers": ep(openvulnerabilityexchange.NewREST),
@@ -171,7 +176,7 @@ func (c completedConfig) New() (*WardleServer, error) {
 		"seccompprofiles":                     ep(seccompprofiles.NewREST),
 		"vulnerabilitymanifests":              ep(vmstorage.NewREST),
 		"vulnerabilitymanifestsummaries":      ep(vmsumstorage.NewREST),
-		"vulnerabilitysummaries":              ep(vsumstorage.NewREST, vulnerabilitySummaryStorage),
+		"vulnerabilitysummaries":              epRO(vsumstorage.NewREST, vulnerabilitySummaryStorage),
 		"workloadconfigurationscans":          ep(wcsstorage.NewREST),
 		"workloadconfigurationscansummaries":  ep(wcssumstorage.NewREST),
 	}

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -17,9 +17,14 @@ limitations under the License.
 package registry
 
 import (
+	"context"
 	"fmt"
 
+	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
+	"k8s.io/apiserver/pkg/registry/rest"
 )
 
 // REST implements a RESTStorage for API services against etcd
@@ -30,10 +35,63 @@ type REST struct {
 // RESTInPeace is just a simple function that panics on error.
 // Otherwise returns the given storage object. It is meant to be
 // a wrapper for wardle registries.
-func RESTInPeace(storage *REST, err error) *REST {
+func RESTInPeace[T any](storage T, err error) T {
 	if err != nil {
 		err = fmt.Errorf("unable to create REST storage for a resource due to %v, will die", err)
 		panic(err)
 	}
 	return storage
+}
+
+// ReadOnlyREST exposes a genericregistry.Store as a read-only resource: it deliberately
+// implements only get and list, so that discovery does not advertise watch (computed
+// resources are generated on the fly — there is nothing to watch) nor the mutating verbs
+// (the storage layer rejects all mutations anyway). The endpoints installer decides verbs
+// by type assertion on this object, hence the Store is a field and not embedded: embedding
+// would re-promote Watch and friends.
+type ReadOnlyREST struct {
+	store *genericregistry.Store
+}
+
+var (
+	_ rest.Storage              = (*ReadOnlyREST)(nil)
+	_ rest.Scoper               = (*ReadOnlyREST)(nil)
+	_ rest.Getter               = (*ReadOnlyREST)(nil)
+	_ rest.Lister               = (*ReadOnlyREST)(nil)
+	_ rest.SingularNameProvider = (*ReadOnlyREST)(nil)
+)
+
+// NewReadOnlyREST wraps a completed genericregistry.Store in a read-only REST storage.
+func NewReadOnlyREST(store *genericregistry.Store) *ReadOnlyREST {
+	return &ReadOnlyREST{store: store}
+}
+
+// New implements rest.Storage
+func (r *ReadOnlyREST) New() runtime.Object { return r.store.New() }
+
+// Destroy implements rest.Storage
+func (r *ReadOnlyREST) Destroy() { r.store.Destroy() }
+
+// NamespaceScoped implements rest.Scoper
+func (r *ReadOnlyREST) NamespaceScoped() bool { return r.store.NamespaceScoped() }
+
+// GetSingularName implements rest.SingularNameProvider
+func (r *ReadOnlyREST) GetSingularName() string { return r.store.GetSingularName() }
+
+// Get implements rest.Getter
+func (r *ReadOnlyREST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
+	return r.store.Get(ctx, name, options)
+}
+
+// NewList implements rest.Lister
+func (r *ReadOnlyREST) NewList() runtime.Object { return r.store.NewList() }
+
+// List implements rest.Lister
+func (r *ReadOnlyREST) List(ctx context.Context, options *metainternalversion.ListOptions) (runtime.Object, error) {
+	return r.store.List(ctx, options)
+}
+
+// ConvertToTable implements rest.Lister (via rest.TableConvertor)
+func (r *ReadOnlyREST) ConvertToTable(ctx context.Context, object runtime.Object, tableOptions runtime.Object) (*metav1.Table, error) {
+	return r.store.ConvertToTable(ctx, object, tableOptions)
 }

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -1,0 +1,48 @@
+package registry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apiserver/pkg/registry/rest"
+)
+
+// TestReadOnlyRESTInterfaceSurface pins the verb surface the endpoints installer derives by
+// type assertion (k8s.io/apiserver/pkg/endpoints/installer.go): a ReadOnlyREST resource must
+// advertise get and list only — no watch (computed resources have nothing to watch) and no
+// mutating verbs (the storage layer rejects all mutations).
+func TestReadOnlyRESTInterfaceSurface(t *testing.T) {
+	var s rest.Storage = &ReadOnlyREST{}
+
+	_, isWatcher := s.(rest.Watcher)
+	assert.False(t, isWatcher, "ReadOnlyREST must not advertise the watch verb")
+	_, isCreater := s.(rest.Creater)
+	assert.False(t, isCreater, "ReadOnlyREST must not advertise the create verb")
+	_, isUpdater := s.(rest.Updater)
+	assert.False(t, isUpdater, "ReadOnlyREST must not advertise the update/patch verbs")
+	_, isGracefulDeleter := s.(rest.GracefulDeleter)
+	assert.False(t, isGracefulDeleter, "ReadOnlyREST must not advertise the delete verb")
+	_, isCollectionDeleter := s.(rest.CollectionDeleter)
+	assert.False(t, isCollectionDeleter, "ReadOnlyREST must not advertise the deletecollection verb")
+
+	_, isGetter := s.(rest.Getter)
+	assert.True(t, isGetter, "ReadOnlyREST must advertise the get verb")
+	_, isLister := s.(rest.Lister)
+	assert.True(t, isLister, "ReadOnlyREST must advertise the list verb")
+	_, isScoper := s.(rest.Scoper)
+	assert.True(t, isScoper)
+	_, isSingular := s.(rest.SingularNameProvider)
+	assert.True(t, isSingular)
+}
+
+// TestRESTKeepsWatchVerb is the keep-side regression guard of the hybrid watch strategy:
+// dispatcher-backed resources registered through REST must keep advertising watch — only
+// the computed resources wrapped in ReadOnlyREST drop it.
+func TestRESTKeepsWatchVerb(t *testing.T) {
+	var s rest.Storage = &REST{}
+
+	_, isWatcher := s.(rest.Watcher)
+	assert.True(t, isWatcher, "REST (dispatcher-backed resources) must keep advertising the watch verb")
+	_, isLister := s.(rest.Lister)
+	assert.True(t, isLister)
+}

--- a/pkg/registry/softwarecomposition/configurationscansummary/rest.go
+++ b/pkg/registry/softwarecomposition/configurationscansummary/rest.go
@@ -10,8 +10,10 @@ import (
 	"k8s.io/apiserver/pkg/storage"
 )
 
-// NewREST returns a RESTStorage object that will work against API services.
-func NewREST(scheme *runtime.Scheme, storageImpl storage.Interface, optsGetter generic.RESTOptionsGetter) (*registry.REST, error) {
+// NewREST returns a read-only RESTStorage object that will work against API services.
+// ConfigurationScanSummary objects are computed on the fly: watch and mutations are not
+// supported, so the watch and mutating verbs are deliberately not advertised in discovery.
+func NewREST(scheme *runtime.Scheme, storageImpl storage.Interface, optsGetter generic.RESTOptionsGetter) (*registry.ReadOnlyREST, error) {
 	strategy := NewStrategy(scheme)
 
 	dryRunnableStorage := genericregistry.DryRunnableStorage{Codec: nil, Storage: storageImpl}
@@ -36,5 +38,5 @@ func NewREST(scheme *runtime.Scheme, storageImpl storage.Interface, optsGetter g
 	if err := store.CompleteWithOptions(options); err != nil {
 		return nil, err
 	}
-	return &registry.REST{Store: store}, nil
+	return registry.NewReadOnlyREST(store), nil
 }

--- a/pkg/registry/softwarecomposition/generatednetworkpolicy/etcd.go
+++ b/pkg/registry/softwarecomposition/generatednetworkpolicy/etcd.go
@@ -10,8 +10,10 @@ import (
 	"k8s.io/apiserver/pkg/storage"
 )
 
-// NewREST returns a RESTStorage object that will work against API services.
-func NewREST(scheme *runtime.Scheme, storageImpl storage.Interface, optsGetter generic.RESTOptionsGetter) (*registry.REST, error) {
+// NewREST returns a read-only RESTStorage object that will work against API services.
+// GeneratedNetworkPolicy objects are computed on the fly: watch and mutations are not
+// supported, so the watch and mutating verbs are deliberately not advertised in discovery.
+func NewREST(scheme *runtime.Scheme, storageImpl storage.Interface, optsGetter generic.RESTOptionsGetter) (*registry.ReadOnlyREST, error) {
 	strategy := NewStrategy(scheme)
 
 	dryRunnableStorage := genericregistry.DryRunnableStorage{Codec: nil, Storage: storageImpl}
@@ -37,5 +39,5 @@ func NewREST(scheme *runtime.Scheme, storageImpl storage.Interface, optsGetter g
 		return nil, err
 	}
 
-	return &registry.REST{Store: store}, nil
+	return registry.NewReadOnlyREST(store), nil
 }

--- a/pkg/registry/softwarecomposition/vulnerabilitysummary/etcd.go
+++ b/pkg/registry/softwarecomposition/vulnerabilitysummary/etcd.go
@@ -1,4 +1,4 @@
-package workloadconfigurationscansummary
+package vulnerabilitysummary
 
 import (
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition"

--- a/pkg/registry/softwarecomposition/vulnerabilitysummary/etcd.go
+++ b/pkg/registry/softwarecomposition/vulnerabilitysummary/etcd.go
@@ -10,8 +10,10 @@ import (
 	"k8s.io/apiserver/pkg/storage"
 )
 
-// NewREST returns a RESTStorage object that will work against API services.
-func NewREST(scheme *runtime.Scheme, storageImpl storage.Interface, optsGetter generic.RESTOptionsGetter) (*registry.REST, error) {
+// NewREST returns a read-only RESTStorage object that will work against API services.
+// VulnerabilitySummary objects are computed on the fly: watch and mutations are not
+// supported, so the watch and mutating verbs are deliberately not advertised in discovery.
+func NewREST(scheme *runtime.Scheme, storageImpl storage.Interface, optsGetter generic.RESTOptionsGetter) (*registry.ReadOnlyREST, error) {
 	strategy := NewStrategy(scheme)
 
 	dryRunnableStorage := genericregistry.DryRunnableStorage{Codec: nil, Storage: storageImpl}
@@ -36,5 +38,5 @@ func NewREST(scheme *runtime.Scheme, storageImpl storage.Interface, optsGetter g
 	if err := store.CompleteWithOptions(options); err != nil {
 		return nil, err
 	}
-	return &registry.REST{Store: store}, nil
+	return registry.NewReadOnlyREST(store), nil
 }

--- a/pkg/registry/softwarecomposition/vulnerabilitysummary/strategy.go
+++ b/pkg/registry/softwarecomposition/vulnerabilitysummary/strategy.go
@@ -1,4 +1,4 @@
-package workloadconfigurationscansummary
+package vulnerabilitysummary
 
 import (
 	"context"


### PR DESCRIPTION
> **Stacked on #330** — contains only the top two commits; GitHub will retarget this PR to `main` automatically when #330 merges.

## Summary

Hybrid watch strategy follow-up to #330: **keep the watch verb where watch genuinely works** (the dispatcher-backed resources that node-agent, synchronizer, and operator rely on) and **stop advertising it where it can never work** — the three computed ("virtual CRD") resources that are generated on the fly and never stored:

- `configurationscansummaries`
- `vulnerabilitysummaries`
- `generatednetworkpolicies`

After #330 these resources serve an *idle* watch (open, event-free) — harmless but dishonest: discovery advertises `watch`, the server accepts, and no event ever arrives. The same applies to the mutating verbs: the storage layer rejects all mutations on computed resources, yet discovery advertised them.

## How

The endpoints installer decides verbs per resource by **type assertion** on the registered `rest.Storage` object (`installer.go`: `storage.(rest.Watcher)` etc.). The new `registry.ReadOnlyREST` wraps `*genericregistry.Store` as a **field instead of embedding it** (embedding re-promotes `Watch` and friends), explicitly delegating only:

`rest.Storage` · `rest.Scoper` · `rest.Getter` · `rest.Lister` (incl. `ConvertToTable`, so `kubectl get` tables keep working) · `rest.SingularNameProvider`

Discovery for the three resources therefore lists exactly **`get,list`** — the same pattern as `metrics.k8s.io`. Effects:

- **Rancher steve** gates informer setup on `IsListWatchable` (requires both `list`+`watch` verbs) → it now skips these resources entirely instead of holding silent watches.
- **Clients that try `?watch=true` anyway** get a clean pre-stream **405 MethodNotSupported** (`handlers/get.go`), with standard reflector backoff.
- **No kubescape component is affected**: node-agent, synchronizer, and operator only watch dispatcher-backed resources (verified), which are untouched — pinned by a keep-side regression test asserting `registry.REST` still satisfies `rest.Watcher`.

Also fixes a copy-pasted package name: `vulnerabilitysummary/` declared `package workloadconfigurationscansummary` (hidden by the import alias).

## Testing

- `TestReadOnlyRESTInterfaceSurface` pins the installer-visible interface surface (not Watcher/Creater/Updater/GracefulDeleter/CollectionDeleter; is Getter/Lister/Scoper/SingularNameProvider)
- `TestRESTKeepsWatchVerb` — keep-side regression guard
- Compile-time `var _` guards for the required interfaces
- Full suite green (`make test`), `go vet` clean
- Manual check after deploy: `kubectl api-resources -o wide` shows `get,list` for the three resources; steve no longer logs watch attempts for them

## Release note

```release-note
Computed resources (ConfigurationScanSummary, VulnerabilitySummary, GeneratedNetworkPolicy) now advertise only get and list verbs; watch and mutation attempts receive 405 MethodNotSupported instead of silently doing nothing.
```

Refs #318, #320 · Stacked on #330

🤖 Generated with [Claude Code](https://claude.com/claude-code)