### PR TITLE
feat: support IPv6-only clusters via configurable bind address

### DIFF
--- a/pkg/cmd/server/start.go
+++ b/pkg/cmd/server/start.go
@@ -121,6 +121,12 @@ func NewWardleServerOptions(out, errOut io.Writer, osFs afero.Fs, pool *sqlitemi
 	o.RecommendedOptions.SecureServing.ServerCert.CertKey.CertFile = o.StorageConfig.TlsServerCertFile
 	o.RecommendedOptions.SecureServing.ServerCert.CertKey.KeyFile = o.StorageConfig.TlsServerKeyFile
 	o.RecommendedOptions.SecureServing.BindPort = o.StorageConfig.ServerBindPort
+	// Bind address is config-driven (the binary takes no apiserver flags, see main.go's flag.Parse).
+	// Default "::" works on IPv6-only clusters and, with bindv6only=0 (Linux default), also accepts
+	// IPv4/dual-stack; set serverBindAddress: "0.0.0.0" to force IPv4-only binding.
+	if bindIP := netutils.ParseIPSloppy(o.StorageConfig.ServerBindAddress); bindIP != nil {
+		o.RecommendedOptions.SecureServing.BindAddress = bindIP
+	}
 
 	return o
 }
@@ -243,7 +249,7 @@ func (o *WardleServerOptions) Complete() error {
 // Config returns config for the api server given WardleServerOptions
 func (o *WardleServerOptions) Config() (*apiserver.Config, error) {
 	// TODO have a "real" external address
-	if err := o.RecommendedOptions.SecureServing.MaybeDefaultWithSelfSignedCerts("localhost", o.AlternateDNS, []net.IP{netutils.ParseIPSloppy("127.0.0.1")}); err != nil {
+	if err := o.RecommendedOptions.SecureServing.MaybeDefaultWithSelfSignedCerts("localhost", o.AlternateDNS, []net.IP{netutils.ParseIPSloppy("127.0.0.1"), netutils.ParseIPSloppy("::1")}); err != nil {
 		return nil, fmt.Errorf("error creating self-signed certificates: %v", err)
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -26,6 +26,7 @@ type Config struct {
 	MaxSniffingTime               time.Duration      `mapstructure:"maxSniffingTimePerContainer"`
 	RateLimitPerClient            float64            `mapstructure:"rateLimitPerClient"`
 	RateLimitTotal                int                `mapstructure:"rateLimitTotal"`
+	ServerBindAddress             string             `mapstructure:"serverBindAddress"`
 	ServerBindPort                int                `mapstructure:"serverBindPort"`
 	TlsClientCaFile               string             `mapstructure:"tlsClientCaFile"`
 	TlsServerCertFile             string             `mapstructure:"tlsServerCertFile"`
@@ -56,6 +57,7 @@ func LoadConfig(path string) (Config, error) {
 	v.SetDefault("maxApplicationProfileSize", 40000)
 	v.SetDefault("maxNetworkNeighborhoodSize", 40000)
 	v.SetDefault("rateLimitTotal", 10)
+	v.SetDefault("serverBindAddress", "::")
 	v.SetDefault("serverBindPort", 8443)
 	v.SetDefault("defaultQueueLength", 100)
 	v.SetDefault("defaultWorkerCount", 2)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -28,6 +28,7 @@ func TestLoadConfig(t *testing.T) {
 				MaxApplicationProfileSize:  40000,
 				MaxNetworkNeighborhoodSize: 40000,
 				RateLimitTotal:             10,
+				ServerBindAddress:          "::",
 				ServerBindPort:             8443,
 				KindQueues: map[string]KindQueueConfig{
 					"applicationprofiles": {


### PR DESCRIPTION
## Problem
The storage apiserver does not come up on **IPv6-only** clusters. Confirmed from a live pod: it listens on `0.0.0.0:8443` (the apiserver default), which cannot accept IPv6 connections.

Root cause: `SecureServing.BindAddress` is never set. The binary is **config-driven, not flag-driven** — `main.go` runs stdlib `flag.Parse()` with only `-kubeconfig` registered, so passing `--bind-address` to the process is rejected (`flag provided but not defined: -bind-address`). Configuration is the only available lever.

## Change
- Add a `serverBindAddress` config field (`pkg/config/config.go`) and wire it into `SecureServing.BindAddress` in `pkg/cmd/server/start.go`, mirroring how `serverBindPort` is already handled.
- **Default `"::"`** so IPv6-only clusters serve with no Helm changes. With `bindv6only=0` (the Linux default) `"::"` also accepts IPv4/dual-stack traffic, so existing clusters keep working.
- Escape hatch: set `serverBindAddress: "0.0.0.0"` to force IPv4-only binding.
- Add `::1` to the self-signed cert loopback SANs (`start.go`) for IPv6 loopback TLS on the self-signed path.

## Testing
- `go build ./...` passes.
- `go test ./pkg/config/...` passes (updated `TestLoadConfig` expectation for the new default).
- Pending: maintainer/customer confirmation that the pod serves on a real IPv6-only cluster after deploy.

## Notes
- The `serverBindAddress` value flows through the existing config mount (`/etc/config/config.json`); the Helm chart can expose it but no chart change is required for the default to take effect.
- Follow-ups (not in this PR): IPv6-correct NetworkPolicy CIDR (`/128`) and IPv6-safe HTTPEndpoint URL parsing — data-correctness fixes tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable server bind address setting with IPv6 default
  * Enhanced self-signed certificate generation to support both IPv4 and IPv6 loopback addresses for improved compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->