### PR TITLE
feat: surface apiserver logs via KS_LOGGER_LEVEL=debug; document >=1.28 requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,21 @@ for its operation. These custom reources might store internal Kubescape
 configuration, scan artifacts, computed snapshots etc that help the entire
 Kubescape in-cluster solution operate.
 
+## Requirements
+
+- **Kubernetes >= 1.28.** Storage is an aggregated APIServer built on recent
+  `k8s.io/apiserver` libraries. On older clusters (e.g. 1.26) the delegated
+  authentication informer never completes its cache sync against the control
+  plane, so `/readyz` stays at `[-]informer-sync` and the pod never becomes
+  Ready — surfacing as `MissingEndpoints` on the APIService. The
+  kubescape-operator Helm chart enforces this via a `kubeVersion` constraint.
+- **IPv6-only / dual-stack clusters** are supported. The server binds `::` by
+  default (`serverBindAddress`), which also serves IPv4 when `bindv6only=0`;
+  set `serverBindAddress: "0.0.0.0"` to force IPv4-only.
+- **Debugging:** set `KS_LOGGER_LEVEL=debug` to surface the underlying
+  Kubernetes apiserver logs (serving, aggregation, informer-sync); they are
+  muted to `Fatal` otherwise.
+
 ## Fetch sample-apiserver and its dependencies
 
 Like the rest of Kubernetes, sample-apiserver has used

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 
 	utilsmetadata "github.com/armosec/utils-k8s-go/armometadata"
 	"github.com/go-logr/zapr"
@@ -40,9 +41,17 @@ import (
 func main() {
 	flag.Parse()
 
-	if logger, err := zap.NewProduction(); err == nil {
-		logger = logger.WithOptions(zap.IncreaseLevel(zap.FatalLevel))
-		klog.SetLogger(zapr.NewLogger(logger))
+	if zl, err := zap.NewProduction(); err == nil {
+		// klog carries the Kubernetes apiserver internals (serving, aggregation,
+		// informer-sync, post-start hooks). It is muted to Fatal by default to keep
+		// logs quiet, but that hides the very diagnostics needed to debug startup /
+		// readyz failures. Set KS_LOGGER_LEVEL=debug to surface them.
+		klogLevel := zap.FatalLevel
+		if strings.EqualFold(os.Getenv("KS_LOGGER_LEVEL"), "debug") {
+			klogLevel = zap.InfoLevel
+		}
+		zl = zl.WithOptions(zap.IncreaseLevel(klogLevel))
+		klog.SetLogger(zapr.NewLogger(zl))
 	}
 
 	ctx := genericapiserver.SetupSignalContext()


### PR DESCRIPTION
## Why
While debugging a customer's IPv6-only cluster (follow-up to #333), the storage pod was `NotReady` with `MissingEndpoints` and **only 4 log lines** — no clue why. Root cause turned out to be a **Kubernetes 1.26 cluster** (storage requires **>= 1.28**): the delegated-authentication informer never completes its cache sync against the older control plane, so `/readyz` is stuck at `[-]informer-sync`.

The reason it took so long to find: `main.go` unconditionally muted **klog** (the Kubernetes apiserver's own logger — serving, aggregation, informer-sync, post-start hooks) to `Fatal`, dropping the reflector error that would have named the cause immediately.

## Changes
- **`main.go`** — gate the klog level on `KS_LOGGER_LEVEL`. At `debug`, surface apiserver logs; otherwise keep the quiet `Fatal` default (no behavior change unless opted in). The chart already plumbs `KS_LOGGER_LEVEL` from `logger.level`.
- **`README.md`** — document the **>= 1.28** requirement (with the exact `informer-sync` / `MissingEndpoints` failure signature), the IPv6 `serverBindAddress` behavior, and the `KS_LOGGER_LEVEL=debug` knob.

## Testing
- `go build ./...` and `go vet .` pass.
- Default behavior unchanged (klog stays `Fatal`); `KS_LOGGER_LEVEL=debug` now lets apiserver diagnostics through.

## Related
- #333 (merged) — IPv6-only bind address + cert SAN.
- A companion PR on `kubescape/helm-charts` adds a `kubeVersion: ">=1.28.0-0"` guard so 1.26 installs fail fast instead of silently wedging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Requirements section specifying minimum Kubernetes version (1.28+)
  * Added configuration guidance for IPv6-only and dual-stack cluster setups
  * Documented informer cache sync behavior considerations for older Kubernetes versions

* **New Features**
  * Added debug-level logging support via KS_LOGGER_LEVEL=debug environment variable for improved troubleshooting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->