### PR TITLE
test: deflake TestCompareDynamic_ZeroAllocHotPath

### DIFF
--- a/pkg/registry/file/dynamicpathdetector/tests/compare_dynamic_memoise_test.go
+++ b/pkg/registry/file/dynamicpathdetector/tests/compare_dynamic_memoise_test.go
@@ -307,22 +307,19 @@ func TestCompareDynamic_ZeroAllocHotPath(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			// Warm-up to absorb any one-off setup cost.
-			for i := 0; i < 100; i++ {
+			// testing.AllocsPerRun pins GOMAXPROCS(1) during measurement and
+			// integer-divides total mallocs by the run count, so a stray
+			// allocation from a background runtime goroutine (GC assist, sysmon,
+			// the testing timer) landing in the measurement window floors to 0
+			// instead of flaking the assertion. A genuine per-call allocation
+			// still produces ~1.0 (one per run) and fails the contract.
+			const runs = 10_000
+			allocs := testing.AllocsPerRun(runs, func() {
 				_ = dynamicpathdetector.CompareDynamic(tc.dyn, tc.reg)
-			}
-			var before, after runtime.MemStats
-			runtime.GC()
-			runtime.ReadMemStats(&before)
-			const iters = 10_000
-			for i := 0; i < iters; i++ {
-				_ = dynamicpathdetector.CompareDynamic(tc.dyn, tc.reg)
-			}
-			runtime.ReadMemStats(&after)
-			allocs := after.Mallocs - before.Mallocs
-			require.Equalf(t, uint64(0), allocs,
-				"%s: %d allocs across %d iters — 0/1-`*` shapes MUST be zero-allocation",
-				tc.name, allocs, iters)
+			})
+			require.Zerof(t, allocs,
+				"%s: %.4f allocs/call — 0/1-`*` shapes MUST be zero-allocation per Matthias upstream PR #323",
+				tc.name, allocs)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

`TestCompareDynamic_ZeroAllocHotPath` (`pkg/registry/file/dynamicpathdetector/tests`) is flaky. It was the cause of the intermittent `pr-created / test` failures (e.g. on #339, which is unrelated — it only touches summary-storage aggregation).

## Root cause

The test measured allocations by diffing the **process-global** `runtime.MemStats.Mallocs` counter around a 10,000-iteration loop:

```go
runtime.ReadMemStats(&before)
for i := 0; i < iters; i++ { _ = CompareDynamic(...) }
runtime.ReadMemStats(&after)
require.Equal(t, uint64(0), after.Mallocs-before.Mallocs)
```

`Mallocs` is process-wide, so a single allocation from a background runtime goroutine (GC assist, sysmon, the testing timer) landing inside the measurement window flips the delta to `1` and fails the assertion. The microsecond-scale window makes it rare but nonzero — the failure was observed flipping between different subtests across runs (`literal_mismatch` in CI, `literal_exact_match` locally), the signature of a flake rather than a regression.

## Fix

Switch to `testing.AllocsPerRun`, which pins `GOMAXPROCS(1)` during measurement and **integer-divides** total mallocs by the run count. A stray sub-`runs` allocation now floors to `0` instead of flaking, while a genuine per-call allocation still yields ~1.0 and fails the zero-alloc contract. The contract is preserved; only the noise is removed.

## Verification

- 30/30 isolated runs green (previously ~PASS/PASS/FAIL/FAIL/PASS).
- Full `go test ./...` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated a performance-oriented test to use a more reliable allocation check.
  * The zero-allocation assertion now uses per-run allocation measurement with clearer failure messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->