### PR TITLE
fix(consolidation): emit consolidated slug only when aggregated profiles change

### DIFF
--- a/docs/features/container-profile-consolidation-emit.md
+++ b/docs/features/container-profile-consolidation-emit.md
@@ -1,0 +1,37 @@
+# Container-profile consolidation: emit slug only on change
+
+## Summary
+
+During time-series consolidation, `ContainerProfileProcessor.consolidateKeyTimeSeries`
+(`pkg/registry/file/containerprofile_processor.go`) sends the consolidated workload
+**slug** to `ConsolidatedSlugChannel` **only when the run actually produced new
+aggregated data** — i.e. when the aggregated ApplicationProfile / NetworkNeighborhood
+were rewritten this tick. For k8s host type the consumer (event-ingester-service's
+container-profile consolidator) turns each slug into a downstream `onFinish` message
+that ultimately upserts `container_statuses`.
+
+## Behavior
+
+- `updateProfile` and `processTimeSeriesInTransaction` return `aggregatedUpdated bool`.
+  It mirrors the existing `newData` gate: aggregated AP/NN are only rewritten via
+  `updateAggregatedProfiles` when new time-series data arrived this run.
+- `consolidateKeyTimeSeries` emits the slug only when
+  `HostType == Kubernetes && aggregatedUpdated`.
+- Idle / already-consolidated workloads (a series with `has_data=false` and no new
+  entries) therefore produce **no** emission, instead of re-emitting every 30s tick.
+
+## Why
+
+Emitting on every run for every workload floods the downstream
+`synchronizer-finished-v1` topic and makes the `container_statuses` upsert path
+re-process unchanged workloads. Under high concurrency those upserts deadlock
+(SQLSTATE 40P01); when the consumer treated the deadlock as a hard error and
+re-queued the message, the backlog wedged (observed ~1.17M backlog, 0 drain in
+prod-ap-southeast-2). Gating the emission on real change removes the churn at the
+source; the downstream deadlock is separately hardened with retry + deterministic
+lock ordering in `postgres-connector`.
+
+## Related code
+
+- `pkg/registry/file/containerprofile_processor.go` — `consolidateKeyTimeSeries`,
+  `processTimeSeriesInTransaction`, `updateProfile`, `sendConsolidatedSlugToChannel`.

--- a/pkg/registry/file/containerprofile_emit_gate_test.go
+++ b/pkg/registry/file/containerprofile_emit_gate_test.go
@@ -1,0 +1,60 @@
+package file
+
+import (
+	"context"
+	"testing"
+
+	"github.com/armosec/armoapi-go/armotypes"
+	helpersv1 "github.com/kubescape/k8s-interface/instanceidhandler/v1/helpers"
+	"github.com/kubescape/storage/pkg/apis/softwarecomposition"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// idleWorkloadStorage models a workload whose time series is already consolidated
+// (a single has_data=false entry) and whose observed profile is valid (carries an
+// InstanceID). A consolidation run over it produces NO new data, so the aggregated
+// AP/NN are not rewritten — and therefore no downstream onFinish should be emitted.
+type idleWorkloadStorage struct {
+	*fakeStorage
+	profile softwarecomposition.ContainerProfile
+}
+
+func (s *idleWorkloadStorage) ListTimeSeriesContainers(ctx context.Context, key string) (map[string][]softwarecomposition.TimeSeriesContainers, error) {
+	return map[string][]softwarecomposition.TimeSeriesContainers{
+		"series-1": {{Status: helpersv1.Learning, HasData: false, PreviousReportTimestamp: "", ReportTimestamp: "2026-01-23T12:27:20Z", TsSuffix: "s1"}},
+	}, nil
+}
+
+func (s *idleWorkloadStorage) GetContainerProfile(ctx context.Context, key string) (softwarecomposition.ContainerProfile, error) {
+	return s.profile, nil
+}
+
+// TestConsolidateKeyTimeSeries_NoEmitWhenNoNewData pins the inflow-reduction fix:
+// consolidateKeyTimeSeries must emit a consolidated slug (which drives a downstream
+// AP/NN onFinish, and ultimately a container_statuses upsert) ONLY when the run
+// actually produced new aggregated data. An idle/unchanged workload re-emitting on
+// every run is what floods synchronizer-finished-v1 and feeds the container_statuses
+// deadlock storm.
+func TestConsolidateKeyTimeSeries_NoEmitWhenNoNewData(t *testing.T) {
+	ch := make(chan ConsolidatedSlugData, 4)
+	profile := softwarecomposition.ContainerProfile{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				helpersv1.InstanceIDMetadataKey: "apiVersion-apps/v1/namespace-default/kind-Deployment/name-test-app",
+			},
+		},
+	}
+	spy := &idleWorkloadStorage{fakeStorage: &fakeStorage{}, profile: profile}
+
+	p := &ContainerProfileProcessor{
+		HostType:                armotypes.HostTypeKubernetes,
+		ConsolidatedSlugChannel: ch,
+	}
+	p.ContainerProfileStorage = spy
+
+	err := p.consolidateKeyTimeSeries(context.Background(), "spdx/v1beta1/containerprofile/default/deployment-test-app", false)
+	require.NoError(t, err)
+	assert.Len(t, ch, 0, "no new data consolidated → must not emit a slug (would flood the topic and container_statuses)")
+}

--- a/pkg/registry/file/containerprofile_processor.go
+++ b/pkg/registry/file/containerprofile_processor.go
@@ -326,15 +326,18 @@ func (a *ContainerProfileProcessor) consolidateKeyTimeSeries(ctx context.Context
 		return err
 	}
 
-	processed, err := a.processTimeSeriesInTransaction(ctx, timeSeries, key, profile, prefix, root, id, expired)
+	processed, aggregatedUpdated, err := a.processTimeSeriesInTransaction(ctx, timeSeries, key, profile, prefix, root, id, expired)
 	if err != nil {
 		return err
 	}
 
-	// Send consolidated slug to channel before deleting processed time series
-	// This allows downstream processing even if the ingester dies after consolidation
-	// Only send for k8s host type
-	if a.HostType == armotypes.HostTypeKubernetes {
+	// Send consolidated slug to channel before deleting processed time series.
+	// This allows downstream processing even if the ingester dies after consolidation.
+	// Only send for k8s host type, and only when this run actually rewrote the
+	// aggregated AP/NN — otherwise the downstream onFinish is pure churn (it re-reads
+	// unchanged AP/NN and re-upserts identical container_statuses rows), which floods
+	// synchronizer-finished-v1 and drives the container_statuses deadlock storm.
+	if a.HostType == armotypes.HostTypeKubernetes && aggregatedUpdated {
 		if err := a.sendConsolidatedSlugToChannel(ctx, profile, id); err != nil {
 			return err
 		}
@@ -425,20 +428,20 @@ func (a *ContainerProfileProcessor) loadOrInitializeProfile(ctx context.Context,
 // processTimeSeriesInTransaction processes time series data within a database transaction
 func (a *ContainerProfileProcessor) processTimeSeriesInTransaction(ctx context.Context,
 	timeSeries map[string][]softwarecomposition.TimeSeriesContainers, key string,
-	profile softwarecomposition.ContainerProfile, prefix, root string, id armotypes.ProfileIdentifier, expired bool) ([]string, error) {
+	profile softwarecomposition.ContainerProfile, prefix, root string, id armotypes.ProfileIdentifier, expired bool) ([]string, bool, error) {
 
 	endFn, err := a.ContainerProfileStorage.BeginTransaction(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to begin nested transaction: %w", err)
+		return nil, false, fmt.Errorf("failed to begin nested transaction: %w", err)
 	}
-	processed, err := a.updateProfile(ctx, timeSeries, key, profile, prefix, root, id, expired)
+	processed, aggregatedUpdated, err := a.updateProfile(ctx, timeSeries, key, profile, prefix, root, id, expired)
 	endFn(&err)
 
 	if err != nil {
-		return nil, fmt.Errorf("failed to process time series data for key %s (transaction rolled back): %w", key, err)
+		return nil, false, fmt.Errorf("failed to process time series data for key %s (transaction rolled back): %w", key, err)
 	}
 
-	return processed, nil
+	return processed, aggregatedUpdated, nil
 }
 
 // deleteProcessedTimeSeries removes processed time series profiles from storage.
@@ -459,8 +462,11 @@ func (a *ContainerProfileProcessor) deleteProcessedTimeSeries(ctx context.Contex
 	return nil
 }
 
-func (a *ContainerProfileProcessor) updateProfile(ctx context.Context, timeSeries map[string][]softwarecomposition.TimeSeriesContainers, key string, profile softwarecomposition.ContainerProfile, prefix, root string, id armotypes.ProfileIdentifier, expired bool) ([]string, error) {
-	var processed []string
+// updateProfile consolidates the time series into the profile and persists the
+// derived artifacts. It returns aggregatedUpdated=true only when the aggregated
+// AP/NN were rewritten this run (i.e. new data arrived), which is the signal the
+// caller uses to decide whether a downstream onFinish is worth emitting.
+func (a *ContainerProfileProcessor) updateProfile(ctx context.Context, timeSeries map[string][]softwarecomposition.TimeSeriesContainers, key string, profile softwarecomposition.ContainerProfile, prefix, root string, id armotypes.ProfileIdentifier, expired bool) (processed []string, aggregatedUpdated bool, err error) {
 	creationTimestamp := metav1.Now()
 	var newData bool
 
@@ -468,7 +474,7 @@ func (a *ContainerProfileProcessor) updateProfile(ctx context.Context, timeSerie
 	for seriesID := range timeSeries {
 		processResult, err := a.processTimeSeries(ctx, timeSeries, seriesID, key, &profile, &creationTimestamp, expired)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 		processed = append(processed, processResult.processed...)
 		if processResult.hasNewData {
@@ -483,7 +489,7 @@ func (a *ContainerProfileProcessor) updateProfile(ctx context.Context, timeSerie
 		// Without an InstanceID annotation we cannot derive the workload slug,
 		// so neither the observed save nor the merged refresh have a target.
 		logger.L().Debug("ContainerProfileProcessor.updateProfile - skip saving invalid profile", loggerhelpers.String("key", key), loggerhelpers.Interface("profile", profile))
-		return processed, nil
+		return processed, false, nil
 	}
 
 	// Persist the canonical observed CP only when time-series consolidation
@@ -494,7 +500,7 @@ func (a *ContainerProfileProcessor) updateProfile(ctx context.Context, timeSerie
 			profile.CreationTimestamp = creationTimestamp
 		}
 		if err := a.ContainerProfileStorage.SaveContainerProfile(ctx, key, &profile); err != nil {
-			return nil, err
+			return nil, false, err
 		}
 	} else {
 		logger.L().Debug("ContainerProfileProcessor.updateProfile - no new data, observed CP unchanged", loggerhelpers.String("key", key))
@@ -510,7 +516,7 @@ func (a *ContainerProfileProcessor) updateProfile(ctx context.Context, timeSerie
 		// Refresh failures are surfaced so the transaction rolls back; a half-
 		// applied merged write paired with a successful observed save would be
 		// worse than retrying the whole tick.
-		return nil, err
+		return nil, false, err
 	}
 
 	// Aggregated AP/NN derive from the effective CP so all downstream outputs
@@ -520,11 +526,13 @@ func (a *ContainerProfileProcessor) updateProfile(ctx context.Context, timeSerie
 	// aggregator already serves a different (downstream-policy) audience.
 	if newData {
 		if err := a.updateAggregatedProfiles(ctx, key, effective, prefix, root, id, creationTimestamp); err != nil {
-			return nil, err
+			return nil, false, err
 		}
 	}
 
-	return processed, nil
+	// aggregatedUpdated mirrors newData: the aggregated AP/NN (what the downstream
+	// onFinish consumer reads) are only rewritten when new data arrived this run.
+	return processed, newData, nil
 }
 
 // refreshMergedProfile rebuilds the merged (effective) ContainerProfile from


### PR DESCRIPTION
## Problem

`ContainerProfileProcessor.consolidateKeyTimeSeries` emitted a consolidated slug on **every** consolidation run for **every** k8s workload — even when the run produced no new data. Each slug drives a downstream AP/NN `onFinish` message (event-ingester-service) and ultimately a `container_statuses` upsert.

For idle / already-consolidated workloads this re-emits the same `onFinish` on every 30s tick. In prod (`prod-ap-southeast-2`) this flooded the `synchronizer-finished-v1` topic and fed a `container_statuses` deadlock storm downstream: ~97% of one customer's `container_statuses` rows were rewritten hourly despite averaging ~26 days old.

The aggregated AP/NN are only rewritten when there is new data (`updateAggregatedProfiles` is already gated on `newData`), so emitting on a no-new-data run is pure churn.

## Change

- `updateProfile` and `processTimeSeriesInTransaction` now return `aggregatedUpdated bool`, mirroring the existing `newData` gate on `updateAggregatedProfiles`.
- `consolidateKeyTimeSeries` emits the slug only when `HostType == Kubernetes && aggregatedUpdated`.
- Idle / already-consolidated workloads (a `has_data=false` series with no new entries) now emit nothing instead of re-emitting every tick.

## Tests

- New `TestConsolidateKeyTimeSeries_NoEmitWhenNoNewData` (written test-first: fails on the old code, which emitted with zero new data; passes after the gate).
- Full `pkg/registry/file` suite passes, including the sqlite-backed `TestConsolidateData`.

## Docs

- Adds `docs/features/container-profile-consolidation-emit.md` describing the gating.

## Notes

This is the source-side half of a broader fix. Downstream, the `container_statuses` upsert is separately hardened with deadlock retry + deterministic lock ordering in `postgres-connector`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)