### PR TITLE
fix(storage): fail fast on lock contention instead of hanging to the request timeout

### DIFF
--- a/docs/features/containerprofile-locking-hardening.md
+++ b/docs/features/containerprofile-locking-hardening.md
@@ -1,0 +1,68 @@
+# ContainerProfile locking hardening (fail-fast lock backstop)
+
+## Summary
+
+Every lock/rlock acquisition in `pkg/registry/file/storage.go` (`CreateWithConn`,
+`DeleteWithConn`, `GetWithConn`, the `get()` noLock path, `GuaranteedUpdateWithConn`, and
+`appendGobObjectFromFile`'s list path) is now bound to a hardcoded **5s** child context
+(`lockTimeout`). If the per-key `MapMutex` (`pkg/utils/mutex.go`) cannot be acquired within
+that window, the request fails fast with `apierrors.NewServerTimeout` (HTTP 500, Reason
+`ServerTimeout`, `Details.RetryAfterSeconds = 1`) instead of the previous
+`apierrors.NewTimeoutError(msg, 0)`.
+
+The per-key `MapMutex` primitive itself is unchanged and confirmed correct; this is purely a
+bound on how long a caller waits for it.
+
+## Why it matters
+
+Before this change, a contended lock acquisition had no independent backstop and could block
+up to the outer apiserver request deadline (~60s). The caller then saw a plain request timeout
+with **no `Retry-After` signal**, so client-go had nothing to base a backoff decision on —
+under sustained contention this produced retry storms rather than smooth backoff.
+
+`apierrors.NewServerTimeout(..., retryAfterSeconds=1)` sets `Details.RetryAfterSeconds`, which
+the apiserver turns into a `Retry-After: 1` HTTP header. client-go's retry logic honors that
+header, so contended requests now fail in ~5s with an explicit "retry in 1s" signal instead of
+hanging silently for up to a minute.
+
+## How it works
+
+- `lockTimeout` (`pkg/registry/file/storage.go`) is a package-level `var`, not a `const`, set
+  to `5 * time.Second`. It is never mutated at runtime; unit tests override it to a few
+  milliseconds to exercise the real timeout path without a real 5s wait.
+- `newLockTimeoutError(op, key, err)` builds the `apierrors.NewServerTimeout` error, logging the
+  underlying `err` (e.g. `context.DeadlineExceeded`) at Debug alongside `op`/`key` so a
+  contended-vs-cancelled acquisition can be told apart post-hoc.
+- Each entry-acquisition call site wraps the caller's `ctx` in
+  `context.WithTimeout(ctx, lockTimeout)` before calling `s.locks.Lock`/`RLock`, and returns
+  `newLockTimeoutError(...)` on failure instead of the previous `apierrors.NewTimeoutError`.
+- **Migration-path re-acquisitions are intentionally left unbounded/unchanged.** The gob
+  external-migration retry logic inside `get()` and the write-lock upgrade inside
+  `appendGobObjectFromFile` re-acquire a lock to run (or restore) a migration and must keep
+  their existing `fmt.Errorf(...)` error returns — a timeout on a lock-*restore* path could
+  leave lock accounting unmatched (e.g. a caller's deferred `RUnlock` left without a
+  corresponding acquire). Correctness beats fail-fast on those specific paths.
+
+## Scope / limitations
+
+- The 5s bound and the 1s `Retry-After` value are hardcoded defaults, not operator-configurable.
+- This only bounds *storage-layer* lock acquisition inside this process. It does not change
+  node-agent's own workqueue-requeue/backoff behavior on receiving the error — that is a
+  separate-repo concern and out of scope here.
+- The existing `lockDuration > 1s` Debug logs at each acquisition site
+  (`storage.go`, e.g. in `CreateWithConn`/`DeleteWithConn`/`GetWithConn`/`GuaranteedUpdateWithConn`)
+  remain the observability hook for correlating slow-but-successful acquisitions against the new
+  fail-fast timeouts.
+
+## Verifying
+
+- Unit tests in `pkg/registry/file/storage_test.go`:
+  - `Test_newLockTimeoutError` pins the status/reason/`RetryAfterSeconds` shape of the error
+    directly.
+  - `TestStorageImpl_LockContentionReturnsServerTimeout` overrides `lockTimeout` to
+    `10 * time.Millisecond`, holds a key's write lock, and asserts a concurrent `Get` on the
+    same key returns `apierrors.IsServerTimeout(err) == true` with HTTP-mapped status 500 and
+    `RetryAfterSeconds == 1`.
+- In production, look for the `lock acquisition timed out` Debug log line (op/key/underlying
+  err) correlated with client-observed HTTP 500s carrying a `Retry-After` header, instead of
+  requests hanging for the full request deadline.

--- a/pkg/registry/file/storage.go
+++ b/pkg/registry/file/storage.go
@@ -52,6 +52,46 @@ var (
 	ObjectTooLargeError  = errors.New("object is too large")
 )
 
+// lockTimeout is the hardcoded backstop for lock acquisition. It sits well under the
+// ~60s outer apiserver request deadline so a contended request fails fast with a
+// Retry-After signal instead of hanging to the full request timeout.
+//
+// NOTE: this is a package-level var, not a const, so unit tests can shrink it to a few
+// milliseconds and exercise the real timeout path without a real 5s wait. It is never
+// mutated at runtime; only tests override it (and restore it via defer).
+var lockTimeout = 5 * time.Second
+
+// newLockTimeoutError returns a ServerTimeout (HTTP 500, Reason=ServerTimeout) carrying a
+// positive RetryAfterSeconds so the apiserver emits a Retry-After header that client-go's
+// retry logic honors. op is "create"/"get"/"update"/"delete"/"list".
+//
+// The underlying err (e.g. context.DeadlineExceeded from the child context) is folded into
+// the observability trail rather than discarded: log it at Debug with the op/key so a
+// contended-vs-cancelled acquisition can be told apart post-hoc. NewServerTimeout does not
+// take a wrapped cause, so err is logged here (not embedded in the StatusError).
+func newLockTimeoutError(op, key string, err error) *apierrors.StatusError {
+	logger.L().Debug("lock acquisition timed out",
+		helpers.String("op", op), helpers.String("key", key), helpers.Error(err))
+	return apierrors.NewServerTimeout(
+		schema.GroupResource{Group: "spdx.softwarecomposition.kubescape.io", Resource: resourceFromKey(key)},
+		op, 1)
+}
+
+// resourceFromKey extracts an approximate plural resource name from a storage key for use
+// in the error's informational Details/message; correctness rides on RetryAfterSeconds, so
+// an approximate resource string is acceptable.
+func resourceFromKey(key string) string {
+	_, _, kind, _, _, _ := K8sPathToKeys(key)
+	kind = strings.ToLower(kind)
+	if kind == "" {
+		return "containerprofiles"
+	}
+	if !strings.HasSuffix(kind, "s") {
+		kind += "s"
+	}
+	return kind
+}
+
 type objState struct {
 	obj  runtime.Object
 	meta *storage.ResponseMeta
@@ -272,9 +312,11 @@ func (s *StorageImpl) CreateWithConn(ctx context.Context, conn *sqlite.Conn, key
 	defer span.End()
 	_, spanLock := otel.Tracer("").Start(ctx, "waiting for lock")
 	beforeLock := time.Now()
-	err := s.locks.Lock(ctx, key)
+	lockCtx, lockCancel := context.WithTimeout(ctx, lockTimeout)
+	defer lockCancel()
+	err := s.locks.Lock(lockCtx, key)
 	if err != nil {
-		return apierrors.NewTimeoutError(fmt.Sprintf("lock: %v", err), 0)
+		return newLockTimeoutError("create", key, err)
 	}
 	defer s.locks.Unlock(key)
 	spanLock.End()
@@ -349,9 +391,11 @@ func (s *StorageImpl) DeleteWithConn(ctx context.Context, conn *sqlite.Conn, key
 	defer span.End()
 	_, spanLock := otel.Tracer("").Start(ctx, "waiting for lock")
 	beforeLock := time.Now()
-	err := s.locks.Lock(ctx, key)
+	lockCtx, lockCancel := context.WithTimeout(ctx, lockTimeout)
+	defer lockCancel()
+	err := s.locks.Lock(lockCtx, key)
 	if err != nil {
-		return apierrors.NewTimeoutError(fmt.Sprintf("lock: %v", err), 0)
+		return newLockTimeoutError("delete", key, err)
 	}
 	defer s.locks.Unlock(key)
 	spanLock.End()
@@ -425,9 +469,11 @@ func (s *StorageImpl) GetWithConn(ctx context.Context, conn *sqlite.Conn, key st
 	defer span.End()
 	_, spanLock := otel.Tracer("").Start(ctx, "waiting for lock")
 	beforeLock := time.Now()
-	err := s.locks.RLock(ctx, key)
+	lockCtx, lockCancel := context.WithTimeout(ctx, lockTimeout)
+	defer lockCancel()
+	err := s.locks.RLock(lockCtx, key)
 	if err != nil {
-		return apierrors.NewTimeoutError(fmt.Sprintf("rlock: %v", err), 0)
+		return newLockTimeoutError("get", key, err)
 	}
 	defer s.locks.RUnlock(key)
 	spanLock.End()
@@ -475,8 +521,10 @@ func (s *StorageImpl) get(ctx context.Context, conn *sqlite.Conn, key string, op
 	// calling RUnlock itself so the defer becomes a no-op.
 	ownedRLock := false
 	if lockState == noLock {
-		if err := s.locks.RLock(ctx, key); err != nil {
-			return apierrors.NewTimeoutError(fmt.Sprintf("rlock: %v", err), 0)
+		lockCtx, lockCancel := context.WithTimeout(ctx, lockTimeout)
+		defer lockCancel()
+		if err := s.locks.RLock(lockCtx, key); err != nil {
+			return newLockTimeoutError("get", key, err)
 		}
 		ownedRLock = true
 		defer func() {
@@ -853,10 +901,12 @@ func (s *StorageImpl) GuaranteedUpdateWithConn(
 	defer span.End()
 	_, spanLock := otel.Tracer("").Start(ctx, "waiting for lock")
 	beforeLock := time.Now()
-	err := s.locks.Lock(ctx, key)
+	lockCtx, lockCancel := context.WithTimeout(ctx, lockTimeout)
+	defer lockCancel()
+	err := s.locks.Lock(lockCtx, key)
 	if err != nil {
 		logger.L().Debug("GuaranteedUpdate - lock failed", helpers.Error(err), helpers.String("key", key))
-		return apierrors.NewTimeoutError(fmt.Sprintf("lock: %v", err), 0)
+		return newLockTimeoutError("update", key, err)
 	}
 	defer s.locks.Unlock(key)
 	spanLock.End()
@@ -1054,9 +1104,11 @@ func (s *StorageImpl) GetByCluster(ctx context.Context, apiVersion, kind string,
 // appendGobObjectFromFile unmarshalls a Gob file into a runtime.Object and appends it to the underlying list object.
 func (s *StorageImpl) appendGobObjectFromFile(ctx context.Context, path string, v reflect.Value) error {
 	key := s.keyFromPath(path)
-	err := s.locks.RLock(ctx, key)
+	lockCtx, lockCancel := context.WithTimeout(ctx, lockTimeout)
+	defer lockCancel()
+	err := s.locks.RLock(lockCtx, key)
 	if err != nil {
-		return apierrors.NewTimeoutError(fmt.Sprintf("rlock: %v", err), 0)
+		return newLockTimeoutError("list", key, err)
 	}
 	defer s.locks.RUnlock(key)
 	payloadFile, err := s.openPayloadFileWithFallback(path, os.O_RDONLY, 0)

--- a/pkg/registry/file/storage.go
+++ b/pkg/registry/file/storage.go
@@ -69,11 +69,21 @@ var lockTimeout = 5 * time.Second
 // the observability trail rather than discarded: log it at Debug with the op/key so a
 // contended-vs-cancelled acquisition can be told apart post-hoc. NewServerTimeout does not
 // take a wrapped cause, so err is logged here (not embedded in the StatusError).
+//
+// If err is context.Canceled (the caller's own ctx was cancelled, e.g. a client disconnect,
+// rather than lockTimeout's child context expiring), a Retry-After signal is misleading --
+// there is no client left to retry -- so this returns a plain InternalError without one
+// instead of ServerTimeout.
 func newLockTimeoutError(op, key string, err error) *apierrors.StatusError {
+	if errors.Is(err, context.Canceled) {
+		logger.L().Debug("lock acquisition cancelled",
+			helpers.String("op", op), helpers.String("key", key), helpers.Error(err))
+		return apierrors.NewInternalError(fmt.Errorf("%s %s: lock acquisition cancelled: %w", op, key, err))
+	}
 	logger.L().Debug("lock acquisition timed out",
 		helpers.String("op", op), helpers.String("key", key), helpers.Error(err))
 	return apierrors.NewServerTimeout(
-		schema.GroupResource{Group: "spdx.softwarecomposition.kubescape.io", Resource: resourceFromKey(key)},
+		schema.GroupResource{Group: softwarecomposition.GroupName, Resource: resourceFromKey(key)},
 		op, 1)
 }
 
@@ -315,11 +325,11 @@ func (s *StorageImpl) CreateWithConn(ctx context.Context, conn *sqlite.Conn, key
 	lockCtx, lockCancel := context.WithTimeout(ctx, lockTimeout)
 	defer lockCancel()
 	err := s.locks.Lock(lockCtx, key)
+	spanLock.End()
 	if err != nil {
 		return newLockTimeoutError("create", key, err)
 	}
 	defer s.locks.Unlock(key)
-	spanLock.End()
 	lockDuration := time.Since(beforeLock)
 	if lockDuration > time.Second {
 		logger.L().Debug("Create", helpers.String("key", key), helpers.String("lockDuration", lockDuration.String()))
@@ -394,11 +404,11 @@ func (s *StorageImpl) DeleteWithConn(ctx context.Context, conn *sqlite.Conn, key
 	lockCtx, lockCancel := context.WithTimeout(ctx, lockTimeout)
 	defer lockCancel()
 	err := s.locks.Lock(lockCtx, key)
+	spanLock.End()
 	if err != nil {
 		return newLockTimeoutError("delete", key, err)
 	}
 	defer s.locks.Unlock(key)
-	spanLock.End()
 	lockDuration := time.Since(beforeLock)
 	if lockDuration > time.Second {
 		logger.L().Debug("Delete", helpers.String("key", key), helpers.String("lockDuration", lockDuration.String()))
@@ -472,11 +482,11 @@ func (s *StorageImpl) GetWithConn(ctx context.Context, conn *sqlite.Conn, key st
 	lockCtx, lockCancel := context.WithTimeout(ctx, lockTimeout)
 	defer lockCancel()
 	err := s.locks.RLock(lockCtx, key)
+	spanLock.End()
 	if err != nil {
 		return newLockTimeoutError("get", key, err)
 	}
 	defer s.locks.RUnlock(key)
-	spanLock.End()
 	lockDuration := time.Since(beforeLock)
 	if lockDuration > time.Second {
 		logger.L().Debug("Get", helpers.String("key", key), helpers.String("lockDuration", lockDuration.String()))
@@ -904,12 +914,12 @@ func (s *StorageImpl) GuaranteedUpdateWithConn(
 	lockCtx, lockCancel := context.WithTimeout(ctx, lockTimeout)
 	defer lockCancel()
 	err := s.locks.Lock(lockCtx, key)
+	spanLock.End()
 	if err != nil {
 		logger.L().Debug("GuaranteedUpdate - lock failed", helpers.Error(err), helpers.String("key", key))
 		return newLockTimeoutError("update", key, err)
 	}
 	defer s.locks.Unlock(key)
-	spanLock.End()
 	lockDuration := time.Since(beforeLock)
 	if lockDuration > time.Second {
 		logger.L().Debug("GuaranteedUpdate/", helpers.String("key", key), helpers.String("lockDuration", lockDuration.String()))

--- a/pkg/registry/file/storage_test.go
+++ b/pkg/registry/file/storage_test.go
@@ -708,6 +708,19 @@ func Test_newLockTimeoutError(t *testing.T) {
 	assert.EqualValues(t, 1, status.Details.RetryAfterSeconds)
 }
 
+// Test_newLockTimeoutError_Cancelled covers the context.Canceled branch: a caller disconnect
+// should not be reported as ServerTimeout with a Retry-After hint, since there is no client
+// left to retry.
+func Test_newLockTimeoutError_Cancelled(t *testing.T) {
+	err := newLockTimeoutError("get", "/spdx.softwarecomposition.kubescape.io/containerprofiles/kubescape/toto", context.Canceled)
+	require.NotNil(t, err)
+	assert.False(t, apierrors.IsServerTimeout(err), "cancelled acquisition should not be reported as ServerTimeout, got %v", err)
+	assert.True(t, apierrors.IsInternalError(err), "expected an InternalError, got %v", err)
+	status := err.Status()
+	require.NotNil(t, status.Details)
+	assert.Zero(t, status.Details.RetryAfterSeconds, "cancelled acquisition should carry no RetryAfterSeconds hint")
+}
+
 func TestStorageImpl_LockContentionReturnsServerTimeout(t *testing.T) {
 	old := lockTimeout
 	lockTimeout = 10 * time.Millisecond

--- a/pkg/registry/file/storage_test.go
+++ b/pkg/registry/file/storage_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/gob"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"testing"
 	"time"
 
@@ -16,6 +17,7 @@ import (
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/storage"
@@ -693,4 +695,46 @@ func Test_calculateChecksum(t *testing.T) {
 			assert.Equalf(t, tt.want, got, "CalculateChecksum(%v)", tt.obj)
 		})
 	}
+}
+
+func Test_newLockTimeoutError(t *testing.T) {
+	err := newLockTimeoutError("get", "/spdx.softwarecomposition.kubescape.io/containerprofiles/kubescape/toto", fmt.Errorf("boom"))
+	require.NotNil(t, err)
+	assert.True(t, apierrors.IsServerTimeout(err), "expected a ServerTimeout error, got %v", err)
+	status := err.Status()
+	assert.Equal(t, int32(http.StatusInternalServerError), status.Code)
+	assert.Equal(t, v1.StatusReasonServerTimeout, status.Reason)
+	require.NotNil(t, status.Details)
+	assert.EqualValues(t, 1, status.Details.RetryAfterSeconds)
+}
+
+func TestStorageImpl_LockContentionReturnsServerTimeout(t *testing.T) {
+	old := lockTimeout
+	lockTimeout = 10 * time.Millisecond
+	defer func() { lockTimeout = old }()
+
+	pool := NewTestPool(t.TempDir())
+	require.NotNil(t, pool)
+	defer func(pool *sqlitemigration.Pool) {
+		_ = pool.Close()
+	}(pool)
+	sch := scheme.Scheme
+	require.NoError(t, softwarecomposition.AddToScheme(sch))
+	s := NewStorageImpl(afero.NewMemMapFs(), DefaultStorageRoot, pool, nil, sch).(*StorageImpl)
+
+	key := "/spdx.softwarecomposition.kubescape.io/sbomsyfts/kubescape/toto"
+	// Hold the write lock on key so a concurrent Get contends and times out.
+	require.NoError(t, s.locks.Lock(context.Background(), key))
+	defer s.locks.Unlock(key)
+
+	err := s.Get(context.Background(), key, storage.GetOptions{}, &v1beta1.SBOMSyft{})
+	require.Error(t, err)
+	assert.True(t, apierrors.IsServerTimeout(err), "expected a ServerTimeout error, got %v", err)
+
+	statusErr, ok := err.(*apierrors.StatusError)
+	require.True(t, ok, "expected *apierrors.StatusError, got %T", err)
+	status := statusErr.Status()
+	assert.Equal(t, int32(http.StatusInternalServerError), status.Code)
+	require.NotNil(t, status.Details)
+	assert.EqualValues(t, 1, status.Details.RetryAfterSeconds)
 }


### PR DESCRIPTION
## Summary

- Bounds every entry-acquisition lock/rlock call (`CreateWithConn`, `DeleteWithConn`, `GetWithConn`, `get()`'s noLock RLock, `GuaranteedUpdateWithConn`, `appendGobObjectFromFile`) to a hardcoded 5s child context instead of the outer (~60s) request context.
- On timeout, returns `apierrors.NewServerTimeout(..., retryAfterSeconds=1)` instead of `apierrors.NewTimeoutError(msg, 0)`, so the apiserver emits a `Retry-After` header that client-go's retry logic honors.
- Migration-path lock re-acquisition sites are deliberately left on the unbounded ctx with their existing error returns — bounding a lock-restore path risks leaving lock accounting unmatched.
- Adds `docs/features/containerprofile-locking-hardening.md` documenting the new HTTP 500 `ServerTimeout` + `Retry-After:1` contract.

## Context

Root-caused via a multi-agent investigation of `armosec/shared-workflows` CI failures (`relevantCVEs`, `network_policy_known_servers` timing out with 504s under load). This is PR 1 of a stack of independently-revertable fixes; see #2/#3/#4 (stacked on this one) for the CollapseConfig cache, consolidator connection scoping, and pool-exhaustion fail-fast.

## Test plan
- [x] `go build ./...`, `go vet`, `gofmt` clean
- [x] `go test ./pkg/registry/file/...` and `-race` variant pass
- [x] New unit tests: `Test_newContentionTimeoutError`, `TestStorageImpl_LockContentionReturnsServerTimeout`
- [x] Live Helm e2e validation (built `quay.io/matthiasb_1/storage:test`, deployed against `armosec/shared-workflows` system tests): `relevantCVEs` now passes cleanly (was failing with 504s)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Lock contention now fails fast with a consistent server timeout response instead of hanging or returning a generic timeout.
  * Responses now include a short retry hint to help clients back off more smoothly.
  * Several storage operations were updated to apply the same timeout behavior across reads, writes, deletes, updates, and listings.

* **Documentation**
  * Added guidance on the new locking behavior, expected timeout responses, and how to verify contention-related issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->