### PR TITLE
fix(storage): stop pinning one connection for the whole ContainerProfile consolidation pass

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	go.uber.org/goleak v1.3.0
 	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.27.1
+	golang.org/x/sync v0.20.0
 	golang.org/x/text v0.37.0
 	k8s.io/api v0.35.0
 	k8s.io/apimachinery v0.35.0
@@ -196,7 +197,6 @@ require (
 	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/term v0.43.0 // indirect
 	golang.org/x/time v0.15.0 // indirect

--- a/main.go
+++ b/main.go
@@ -99,7 +99,7 @@ func main() {
 
 	// setup storage components
 	osFs := afero.NewOsFs()
-	pool := file.NewPool(filepath.Join(file.DefaultStorageRoot, "metadata.sq3"), 0) // If less than 1, a reasonable default is used.
+	pool := file.NewPool(filepath.Join(file.DefaultStorageRoot, "metadata.sq3"), file.DefaultPoolSize)
 
 	// setup watcher
 	watchDispatcher := file.NewWatchDispatcher()

--- a/pkg/registry/file/containerprofile_processor.go
+++ b/pkg/registry/file/containerprofile_processor.go
@@ -23,6 +23,7 @@ import (
 	"github.com/kubescape/storage/pkg/registry/file/callstack"
 	"github.com/kubescape/storage/pkg/registry/file/dynamicpathdetector"
 	"github.com/kubescape/storage/pkg/utils"
+	"golang.org/x/sync/errgroup"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/storage"
@@ -50,6 +51,14 @@ type ContainerProfileProcessor struct {
 	// production wiring may swap to a provider that reads the cluster-scoped
 	// CollapseConfiguration "default" CR.
 	CollapseSettings dynamicpathdetector.CollapseSettingsProvider
+	// Workers bounds how many keys ConsolidateTimeSeries processes concurrently,
+	// each on its own pool connection. Kept a fraction of the pool size so the
+	// background consolidation never starves REST traffic of connections.
+	Workers int
+	// consolidateKey is the per-key consolidation entrypoint dispatched by
+	// ConsolidateTimeSeries. nil means use consolidateKeyTimeSeries; tests
+	// override it to count invocations or inject per-key failures.
+	consolidateKey func(ctx context.Context, key string, expired bool) error
 }
 
 func NewContainerProfileProcessor(cfg config.Config, cleanupHandler *ResourcesCleanupHandler) *ContainerProfileProcessor {
@@ -66,6 +75,7 @@ func NewContainerProfileProcessor(cfg config.Config, cleanupHandler *ResourcesCl
 		Interval:                30 * time.Second,
 		MaxContainerProfileSize: cfg.MaxApplicationProfileSize,
 		CollapseSettings:        dynamicpathdetector.DefaultCollapseSettings,
+		Workers:                 max(1, DefaultPoolSize/4),
 	}
 }
 
@@ -274,39 +284,78 @@ func (a *ContainerProfileProcessor) cleanup() error {
 // Expired time series are always marked as Completed/Partial unless they were already Completed/Full,
 // ensuring incomplete profiles don't remain in a Learning state indefinitely.
 func (a *ContainerProfileProcessor) ConsolidateTimeSeries(ctx context.Context) error {
-	ctx, cleanup, err := a.ContainerProfileStorage.WithConnection(ctx)
+	// Phase 0: list keys under a short-lived connection, then release it so the
+	// per-key workers below each acquire their own connection from the pool.
+	listCtx, cleanup, err := a.ContainerProfileStorage.WithConnection(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to begin transaction: %w", err)
+		return fmt.Errorf("failed to take connection for listing: %w", err)
 	}
-	defer cleanup()
-
-	// Phase 1: Process expired time series
-	// These are marked as Completed/Partial (unless already Completed/Full)
-	expired, err := a.ContainerProfileStorage.ListTimeSeriesExpired(ctx, a.DeleteThreshold)
+	// Phase 1: expired time series (past deleteThreshold), marked Completed/Partial.
+	expired, err := a.ContainerProfileStorage.ListTimeSeriesExpired(listCtx, a.DeleteThreshold)
 	if err != nil {
-		return fmt.Errorf("failed to list time: %w", err)
+		cleanup()
+		return fmt.Errorf("failed to list expired time series: %w", err)
 	}
+	// Phase 2: active time series with data, following the normal completion flow.
+	withData, err := a.ContainerProfileStorage.ListTimeSeriesWithData(listCtx)
+	if err != nil {
+		cleanup()
+		return fmt.Errorf("failed to list active time series: %w", err)
+	}
+	cleanup()
 
-	for _, key := range expired {
-		if err := a.consolidateKeyTimeSeries(ctx, key, true); err != nil {
-			return err
+	// De-duplicate into one work set keyed by storage key. The time_series table
+	// holds many rows per (kind,namespace,name) key and neither list applies
+	// DISTINCT/GROUP BY, so a key can appear multiple times within one list and
+	// in both lists. Expired precedence: a key present in both lists (or multiple
+	// times within either list) is processed EXACTLY ONCE, as expired — preserving
+	// today's expired-first semantics and avoiding two workers racing one key.
+	type workItem struct {
+		key     string
+		expired bool
+	}
+	seen := make(map[string]int, len(expired)+len(withData))
+	work := make([]workItem, 0, len(expired)+len(withData))
+	add := func(key string, exp bool) {
+		if i, ok := seen[key]; ok {
+			if exp {
+				work[i].expired = true // upgrade to expired (expired precedence)
+			}
+			return
 		}
+		seen[key] = len(work)
+		work = append(work, workItem{key: key, expired: exp})
+	}
+	for _, k := range expired {
+		add(k, true)
+	}
+	for _, k := range withData {
+		add(k, false)
 	}
 
-	// Phase 2: Process active time series with data
-	// These follow normal completion flow based on their status
-	withData, err := a.ContainerProfileStorage.ListTimeSeriesWithData(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to list time: %w", err)
+	workers := a.Workers
+	if workers < 1 {
+		workers = 1
 	}
 
-	for _, key := range withData {
-		if err := a.consolidateKeyTimeSeries(ctx, key, false); err != nil {
-			return err
-		}
+	// Use a plain errgroup.Group (NOT errgroup.WithContext) and pass the PARENT
+	// ctx to every worker. WithConnection -> pool.Take binds each connection's
+	// interrupt to the passed ctx; a cancel-on-first-error group context would
+	// interrupt and roll back every other worker's in-flight transaction. A
+	// zero-value Group still returns the first error from Wait but never cancels,
+	// so each key's transaction commits or fails independently.
+	consolidate := a.consolidateKeyTimeSeries
+	if a.consolidateKey != nil {
+		consolidate = a.consolidateKey
 	}
-
-	return nil
+	var g errgroup.Group
+	g.SetLimit(workers)
+	for _, it := range work {
+		g.Go(func() error {
+			return consolidate(ctx, it.key, it.expired)
+		})
+	}
+	return g.Wait()
 }
 
 // consolidateKeyTimeSeries consolidates time series data for a single key.
@@ -315,6 +364,14 @@ func (a *ContainerProfileProcessor) ConsolidateTimeSeries(ctx context.Context) e
 // When expired=true, the resulting profile will be marked as Completed/Partial (unless already Completed/Full).
 func (a *ContainerProfileProcessor) consolidateKeyTimeSeries(ctx context.Context, key string, expired bool) error {
 	logger.L().Debug("ContainerProfileProcessor.consolidateKeyTimeSeries - consolidating data for key", loggerhelpers.String("key", key), loggerhelpers.Interface("expired", expired))
+
+	// Each unit of work owns its own pool connection so keys can be consolidated
+	// concurrently, each transaction running on its own *sqlite.Conn.
+	ctx, cleanup, err := a.ContainerProfileStorage.WithConnection(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to take connection for key %s: %w", key, err)
+	}
+	defer cleanup()
 
 	timeSeries, err := a.ContainerProfileStorage.ListTimeSeriesContainers(ctx, key)
 	if err != nil {

--- a/pkg/registry/file/containerprofile_processor_test.go
+++ b/pkg/registry/file/containerprofile_processor_test.go
@@ -3,7 +3,9 @@ package file
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -17,6 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/storage"
+	"zombiezen.com/go/sqlite"
 	"zombiezen.com/go/sqlite/sqlitemigration"
 )
 
@@ -112,6 +115,213 @@ func TestConsolidateData(t *testing.T) {
 	// Clean up
 	pool.Put(conn)
 	assert.NoError(t, pool.Close())
+}
+
+// newConsolidationTestProcessor builds a ContainerProfileProcessor backed by an
+// in-memory-ish temp SQLite pool for the AC3 concurrency tests. The returned
+// cleanup closes the pool.
+func newConsolidationTestProcessor(t *testing.T, deleteThreshold time.Duration) (*ContainerProfileProcessor, *sqlitemigration.Pool, func()) {
+	t.Helper()
+	pool := NewTestPool(t.TempDir())
+	require.NotNil(t, pool)
+
+	sch := scheme.Scheme
+	require.NoError(t, softwarecomposition.AddToScheme(sch))
+	processor := &ContainerProfileProcessor{
+		DeleteThreshold:         deleteThreshold,
+		MaxContainerProfileSize: 40000,
+		Workers:                 4,
+	}
+	s := &StorageImpl{
+		appFs:           afero.NewMemMapFs(),
+		pool:            pool,
+		locks:           utils.NewMapMutex[string](),
+		processor:       processor,
+		root:            DefaultStorageRoot,
+		scheme:          sch,
+		versioner:       storage.APIObjectVersioner{},
+		watchDispatcher: NewWatchDispatcher(),
+	}
+	// Interval stays 0 so SetStorage does not spawn the background maintenance
+	// goroutine that would race the explicit ConsolidateTimeSeries calls.
+	processor.SetStorage(NewContainerProfileStorageImpl(s, pool))
+
+	return processor, pool, func() { _ = pool.Close() }
+}
+
+// seedTimeSeriesRow inserts a single time_series row so ConsolidateTimeSeries's
+// list queries observe it. Returns the storage key the list functions produce.
+func seedTimeSeriesRow(t *testing.T, pool *sqlitemigration.Pool, ns, name, seriesID, tsSuffix, reportTimestamp string, hasData bool) string {
+	t.Helper()
+	conn, err := pool.Take(context.TODO())
+	require.NoError(t, err)
+	defer pool.Put(conn)
+	err = WriteTimeSeriesEntry(conn, "containerprofile", ns, name, seriesID, tsSuffix, reportTimestamp, helpersv1.Learning, helpersv1.Partial, "", hasData)
+	require.NoError(t, err)
+	return K8sKeysToPath("", "spdx.softwarecomposition.kubescape.io", "containerprofile", "", ns, name)
+}
+
+// TestConsolidateTimeSeries_Concurrent_NoDeadlock drives the worker pool over
+// multiple keys (including several containers that share one workload apKey) and
+// asserts it completes without deadlock/race and leaves the pool fully returned.
+func TestConsolidateTimeSeries_Concurrent_NoDeadlock(t *testing.T) {
+	processor, pool, cleanup := newConsolidationTestProcessor(t, 0)
+	defer cleanup()
+	s := processor.ContainerProfileStorage.(*ContainerProfileStorageImpl).storageImpl
+
+	ctx, cancel := context.WithTimeout(context.TODO(), 15*time.Second)
+	defer cancel()
+
+	create := func(f string) {
+		content, err := os.ReadFile(f)
+		require.NoError(t, err)
+		var profile softwarecomposition.ContainerProfile
+		require.NoError(t, json.Unmarshal(content, &profile))
+		require.NoError(t, s.Create(ctx, "/spdx.softwarecomposition.kubescape.io/containerprofile/"+profile.Namespace+"/"+profile.Name, &profile, nil, 0))
+	}
+	// consolidate runs a pass under a deadlock guard (Workers=4, so keys sharing
+	// the multiple-containers workload apKey are processed concurrently).
+	consolidate := func() {
+		done := make(chan error, 1)
+		go func() { done <- processor.ConsolidateTimeSeries(ctx) }()
+		select {
+		case err := <-done:
+			assert.NoError(t, err)
+		case <-time.After(10 * time.Second):
+			t.Fatal("ConsolidateTimeSeries did not complete in time - possible deadlock")
+		}
+	}
+	// Same staged create/consolidate flow as TestConsolidateData (known-good final
+	// state), but with a concurrent worker pool exercising per-key isolation.
+	create("testdata/p1.json")
+	create("testdata/p2.json")
+	create("testdata/p3.json")
+	create("testdata/p4.json")
+	consolidate()
+	create("testdata/p5.json")
+	create("testdata/p6.json")
+	create("testdata/p7.json")
+	consolidate()
+	create("testdata/p8.json")
+	create("testdata/p9.json")
+	consolidate()
+	create("testdata/p10.json")
+	create("testdata/p11.json")
+	create("testdata/p12.json")
+	consolidate()
+
+	// The multiple-containers workload consolidated correctly into one application profile.
+	ap := softwarecomposition.ApplicationProfile{}
+	conn, err := pool.Take(ctx)
+	require.NoError(t, err)
+	err = s.GetWithConn(ctx, conn, "/spdx.softwarecomposition.kubescape.io/applicationprofiles/node-agent-test-hjjz/replicaset-multiple-containers-deployment-d4b8dd5fd", storage.GetOptions{}, &ap)
+	pool.Put(conn)
+	require.NoError(t, err)
+	delete(ap.Annotations, helpersv1.SyncChecksumMetadataKey)
+	assert.Equal(t, map[string]string{
+		helpersv1.CompletionMetadataKey: helpersv1.Full,
+		helpersv1.InstanceIDMetadataKey: "apiVersion-apps/v1/namespace-node-agent-test-hjjz/kind-ReplicaSet/name-multiple-containers-deployment-d4b8dd5fd",
+		helpersv1.StatusMetadataKey:     helpersv1.Completed,
+		helpersv1.WlidMetadataKey:       "wlid://cluster-kind-kind/namespace-node-agent-test-hjjz/deployment-multiple-containers-deployment",
+	}, ap.Annotations)
+
+	// No connection leak: every pool connection must be re-acquirable promptly.
+	acqCtx, acqCancel := context.WithTimeout(ctx, 3*time.Second)
+	defer acqCancel()
+	var conns []*sqlite.Conn
+	for i := 0; i < DefaultPoolSize; i++ {
+		c, err := pool.Take(acqCtx)
+		require.NoErrorf(t, err, "failed to re-acquire connection %d - pool leak", i)
+		conns = append(conns, c)
+	}
+	for _, c := range conns {
+		pool.Put(c)
+	}
+}
+
+// TestConsolidateTimeSeries_Dedup asserts a key that appears multiple times
+// within one list and across both the expired and withData lists is processed
+// exactly once, with expired precedence.
+func TestConsolidateTimeSeries_Dedup(t *testing.T) {
+	processor, pool, cleanup := newConsolidationTestProcessor(t, time.Hour)
+	defer cleanup()
+
+	old := time.Now().Add(-2 * time.Hour).String()      // < now-1h threshold => expired
+	recent := time.Now().Add(-1 * time.Minute).String() // > threshold => not expired
+
+	// keyA: two rows, both expired AND hasData => appears twice in each list and in both lists.
+	keyA := seedTimeSeriesRow(t, pool, "ns-a", "name-a", "series-a", "1", old, true)
+	seedTimeSeriesRow(t, pool, "ns-a", "name-a", "series-a", "2", old, true)
+	// keyB: recent + hasData => only in withData list.
+	keyB := seedTimeSeriesRow(t, pool, "ns-b", "name-b", "series-b", "1", recent, true)
+	// keyC: expired + no data => only in expired list.
+	keyC := seedTimeSeriesRow(t, pool, "ns-c", "name-c", "series-c", "1", old, false)
+
+	var mu sync.Mutex
+	count := map[string]int{}
+	expiredSeen := map[string]bool{}
+	processor.consolidateKey = func(_ context.Context, key string, expired bool) error {
+		mu.Lock()
+		defer mu.Unlock()
+		count[key]++
+		expiredSeen[key] = expired
+		return nil
+	}
+
+	require.NoError(t, processor.ConsolidateTimeSeries(context.TODO()))
+
+	assert.Equal(t, 3, len(count), "each unique key must be dispatched once")
+	assert.Equal(t, 1, count[keyA])
+	assert.Equal(t, 1, count[keyB])
+	assert.Equal(t, 1, count[keyC])
+	assert.True(t, expiredSeen[keyA], "keyA present in both lists must run as expired (expired precedence)")
+	assert.False(t, expiredSeen[keyB])
+	assert.True(t, expiredSeen[keyC])
+}
+
+// TestConsolidateTimeSeries_ErrorIsolation asserts that when exactly one key
+// fails, the other keys still complete (no cross-worker cancellation) while
+// ConsolidateTimeSeries surfaces the failure. A cancel-on-first-error group
+// context (the errgroup.WithContext regression) would cancel the parent ctx the
+// other workers observe, so they would not record completion.
+func TestConsolidateTimeSeries_ErrorIsolation(t *testing.T) {
+	processor, pool, cleanup := newConsolidationTestProcessor(t, time.Hour)
+	defer cleanup()
+
+	recent := time.Now().Add(-1 * time.Minute).String()
+	var keys []string
+	for _, n := range []string{"k0", "k1", "k2", "k3"} {
+		keys = append(keys, seedTimeSeriesRow(t, pool, "ns", n, "series", "1", recent, true))
+	}
+	poison := keys[2]
+
+	var committed sync.Map
+	injected := errors.New("injected failure")
+	processor.consolidateKey = func(ctx context.Context, key string, _ bool) error {
+		if key == poison {
+			return injected
+		}
+		// A cancelled parent ctx (WithContext regression) surfaces here before commit.
+		select {
+		case <-time.After(50 * time.Millisecond):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+		committed.Store(key, true)
+		return nil
+	}
+
+	err := processor.ConsolidateTimeSeries(context.TODO())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, injected)
+
+	var n int
+	committed.Range(func(k, _ any) bool {
+		assert.NotEqual(t, poison, k)
+		n++
+		return true
+	})
+	assert.Equal(t, len(keys)-1, n, "all non-failing keys must commit despite one failure")
 }
 
 func Test_isZeroTime(t *testing.T) {

--- a/pkg/registry/file/sqlite.go
+++ b/pkg/registry/file/sqlite.go
@@ -21,10 +21,19 @@ var (
 	ErrMetadataNotFound = errors.New("metadata not found")
 )
 
+// DefaultPoolSize is the SQLite connection pool capacity used when NewPool is
+// called with a non-positive size. It is made explicit (rather than relying on
+// sqlitex's implicit default) so the consolidator's worker bound can be derived
+// from a single knowable constant.
+const DefaultPoolSize = 10
+
 // NewPool creates a new SQLite connection pool at the given path.
 // It returns an error if the connection cannot be opened or the database cannot be initialized.
 // It is your responsibility to call conn.Close() when you no longer need conn.
 func NewPool(path string, size int) *sqlitemigration.Pool {
+	if size < 1 {
+		size = DefaultPoolSize
+	}
 	return sqlitemigration.NewPool(path,
 		sqlitemigration.Schema{
 			Migrations: []string{


### PR DESCRIPTION
## Summary

- `ConsolidateTimeSeries` held a single pooled `*sqlite.Conn` for its entire serial pass over every active time-series key, starving REST `Create`/`Get`/`Update` calls competing for the same connection pool (default size 10, shared between REST and the consolidator).
- Scopes the outer connection to just the two listing calls (`ListTimeSeriesExpired`/`ListTimeSeriesWithData`), then gives each key its own connection inside `consolidateKeyTimeSeries` and dispatches keys through a bounded worker pool (`errgroup.Group` + `SetLimit(workers)`, `workers = max(1, DefaultPoolSize/4) = 2`), reserving the rest of the pool for REST traffic.
- Two correctness requirements surfaced during design review (2 rounds of Architect/Critic consensus) and are implemented here:
  - **De-duplication**: `ListTimeSeriesExpired`/`ListTimeSeriesWithData` have no `DISTINCT`/`GROUP BY` and the same storage key can appear multiple times within one list and across both lists. Keys are unioned into one de-duplicated work set with expired-precedence, so every key is dispatched exactly once.
  - **Error isolation**: uses a plain `errgroup.Group` (not `errgroup.WithContext`) with the parent `ctx` passed to every worker, so one key's failure doesn't roll back every other concurrently-running worker's in-flight transaction (which `errgroup.WithContext`'s cancel-on-error semantics would otherwise cause via `pool.Take`'s `conn.SetInterrupt`).
- Makes the pool size an explicit, referenceable constant (`DefaultPoolSize = 10`) rather than an implicit library default.
- `golang.org/x/sync` promoted from indirect to direct in `go.mod` (already vendored; `go.sum`/`vendor/modules.txt` unchanged).

The verified lock-ordering invariant (workload-`apKey` always acquired before member-`cpKey` reads) and the `MapMutex` primitive itself are unchanged — this only changes where connections are acquired and how keys are dispatched.

## Context

Stacked on #343 (CollapseConfig TTL cache). Part of a stack of independently-revertable fixes for the ContainerProfile 504 regression; see #342 for the shared root-cause context and validation methodology.

## Test plan
- [x] `go build ./...`, `go vet`, `gofmt` clean
- [x] `go test -race ./pkg/registry/file/...` passes, including a dedicated concurrency test suite (no-deadlock/isolation over shared-`apKey` keys, exactly-once dedup with expired-precedence, error-isolation with N-1 keys committing when one fails)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>