### PR TITLE
docs: document metadata-only LIST and the fullSpec resourceVersion toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,43 @@ Metadata are stored in JSON format, and should be unmarshalled to the appropriat
 GetList() operations should support pagination, we are using ROWID to sort the results and limit the number
 of rows returned. On subsequent calls, the client provides the last ROWID to get the next page.
 
-Note that `GetList()` returns the list of objects with a `nil` Spec for performance reasons, as the CRDs are quite big.
+Note that `GetList()` returns the list of objects with an empty `Spec` for
+performance reasons, as the CRDs are quite big: only the metadata blob is read
+from SQLite, the payload on disk is not loaded. This is why a `LIST` and a `GET`
+of the same object can differ over the REST API — a listed object comes back
+with its spec fields at their zero values (for example a
+`VulnerabilityManifestSummary` reports all severity counts as `0`), while a
+direct `GET` returns the real spec.
+
+#### Requesting the full spec on a LIST
+
+The behavior is controlled by two reserved `resourceVersion` values, defined in
+`pkg/apis/softwarecomposition/register.go`:
+
+| `resourceVersion` | LIST behavior |
+| --- | --- |
+| _(unset)_ or `metadata` | metadata only — spec fields come back zero-valued (default) |
+| `fullSpec` | each object is loaded with its full payload |
+
+`resourceVersion` is an ordinary list query parameter, so this works from any
+REST client, not only the Go client. For example, to get the complete severity
+counts for every `VulnerabilityManifestSummary` in a namespace:
+
+```sh
+kubectl get --raw \
+  '/apis/spdx.softwarecomposition.kubescape.io/v1beta1/namespaces/kubescape/vulnerabilitymanifestsummaries?resourceVersion=fullSpec'
+```
+
+Caveats:
+- The typed `kubectl get <resource>` path does not let you set this, so plain
+  `kubectl get ... -o json`, `jsonpath` and `custom-columns` always see the
+  metadata-only (zeroed) view. Use `kubectl get --raw` with the query
+  parameter, or a client that sets `ListOptions.ResourceVersion`.
+- `fullSpec` loads the full payload for every listed object and is queued, so it
+  is significantly more expensive than the default metadata-only LIST.
+- `fullSpec` is rejected on LIST for `applicationprofiles` and
+  `networkneighborhoods` (the server returns an error); it is honored for the
+  summary resources.
 
 ### Filesystem layout
 


### PR DESCRIPTION
<!-- armosec-pr: v=1 via=manual -->

## Summary

Documents the intentional metadata-only behavior of `LIST` on the aggregated APIServer and the reserved `fullSpec` / `metadata` `resourceVersion` values, so consumers understand why `LIST` and `GET` of the same object differ over the REST API. Docs-only, no code changes.

## Why

Reported in #346: `LIST` and `GET` of the same object return different data over the raw Kubernetes REST API — e.g. `VulnerabilityManifestSummary.spec.severities` comes back all-zero on `LIST` but correct on `GET`. This is by design (LIST reads only the metadata blob for performance and never loads the payload), but it was only mentioned as a one-line internal note ("`GetList()` returns … a `nil` Spec") that:

- reads as a Go-internal detail, not observable REST/`kubectl` behavior;
- says "nil Spec" while consumers actually see zero-valued fields, so nobody connects the symptom to it;
- never mentions the `fullSpec` escape hatch.

## Change

Expands that note into a user-facing explanation plus a **"Requesting the full spec on a LIST"** subsection covering:

- the two reserved `resourceVersion` values (`metadata` default, `fullSpec`);
- that `fullSpec` is a plain list query parameter usable from any REST client (`kubectl get --raw '…?resourceVersion=fullSpec'`), not only the Go client;
- caveats: the typed `kubectl get` path can't set it (so `-o json`/jsonpath/custom-columns always see zeros), `fullSpec` is heavier and queued, and it is rejected on LIST for `applicationprofiles` / `networkneighborhoods`.

Closes #346

🤖 Generated with [Claude Code](https://claude.com/claude-code)

AI-skills: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that `GetList()` returns metadata-only objects with an empty `Spec` by default.
  * Added guidance for requesting full resource specifications in `LIST` responses.
  * Documented supported `resourceVersion` values, usage examples, client method considerations, and resource-type limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->