### PR TITLE
fix: use /128 CIDR for single IPv6 peers instead of /32

### DIFF
--- a/pkg/apis/softwarecomposition/networkpolicy/v2/networkpolicy.go
+++ b/pkg/apis/softwarecomposition/networkpolicy/v2/networkpolicy.go
@@ -597,7 +597,11 @@ func buildIPAddressesPeers(ipAddresses []string, dns string, knownServers softwa
 }
 
 func getSingleIP(ipAddress string) *softwarecomposition.IPBlock {
-	ipBlock := &softwarecomposition.IPBlock{CIDR: ipAddress + "/32"}
+	suffix := "/32"
+	if ip := net.ParseIP(ipAddress); ip != nil && ip.To4() == nil {
+		suffix = "/128"
+	}
+	ipBlock := &softwarecomposition.IPBlock{CIDR: ipAddress + suffix}
 	return ipBlock
 }
 

--- a/pkg/apis/softwarecomposition/networkpolicy/v2/networkpolicy_test.go
+++ b/pkg/apis/softwarecomposition/networkpolicy/v2/networkpolicy_test.go
@@ -2286,13 +2286,24 @@ func TestGenerateEgressRule_IPAddressVsIPAddresses(t *testing.T) {
 }
 
 func TestGetSingleIP(t *testing.T) {
-	ipAddress := "192.168.1.1"
-	expected := &softwarecomposition.IPBlock{CIDR: "192.168.1.1/32"}
+	tests := []struct {
+		name      string
+		ipAddress string
+		expected  string
+	}{
+		{"IPv4", "192.168.1.1", "192.168.1.1/32"},
+		{"IPv6", "2001:db8::1", "2001:db8::1/128"},
+		{"IPv4-mapped IPv6", "::ffff:1.2.3.4", "::ffff:1.2.3.4/32"},
+		{"malformed", "not-an-ip", "not-an-ip/32"},
+	}
 
-	result := getSingleIP(ipAddress)
-
-	if result.CIDR != expected.CIDR {
-		t.Errorf("getSingleIP() = %v, want %v", result, expected)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getSingleIP(tt.ipAddress)
+			if result.CIDR != tt.expected {
+				t.Errorf("getSingleIP(%q) = %v, want %v", tt.ipAddress, result.CIDR, tt.expected)
+			}
+		})
 	}
 }
 func TestRemoveLabels(t *testing.T) {


### PR DESCRIPTION
Part of #334 (AC-2)

getSingleIP always added /32 to the address it was given, no matter what kind of address it was. That is correct for IPv4 but wrong for IPv6, where a single host needs a /128 prefix. A single IPv6 peer such as 2001:db8::1 was ending up as 2001:db8::1/32, which is not a valid single host CIDR for IPv6 and corrupts the generated NetworkPolicy.

This checks the address family and uses /128 for IPv6 and /32 for everything else, including IPv4-mapped addresses and input that fails to parse, which both keep the old /32 behavior.

I converted the existing single-case test into a table test covering IPv4, IPv6, IPv4-mapped IPv6, and malformed input.

Ran go test on the package and gofmt, both clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected single-IP network policy handling for IPv6 addresses by generating `/128` CIDRs.
  - Preserved `/32` CIDRs for IPv4 addresses and other supported inputs.

- **Tests**
  - Expanded coverage for IPv4, IPv6, IPv4-mapped IPv6, and malformed addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->