### PR TITLE
fix: parse IPv6 hosts correctly in AnalyzeURL

### DIFF
--- a/pkg/registry/file/dynamicpathdetector/analyze_endpoints.go
+++ b/pkg/registry/file/dynamicpathdetector/analyze_endpoints.go
@@ -3,6 +3,7 @@ package dynamicpathdetector
 import (
 	"encoding/json"
 	"fmt"
+	"net/netip"
 	"net/url"
 	"strings"
 
@@ -81,7 +82,7 @@ func ProcessEndpoint(endpoint *types.HTTPEndpoint, analyzer *PathAnalyzer, newEn
 
 func AnalyzeURL(urlString string, analyzer *PathAnalyzer) (string, error) {
 	if !strings.HasPrefix(urlString, "http://") && !strings.HasPrefix(urlString, "https://") {
-		urlString = "http://" + urlString
+		urlString = "http://" + addBracketsIfIPv6(urlString)
 	}
 
 	if err := isValidURL(urlString); err != nil {
@@ -100,6 +101,50 @@ func AnalyzeURL(urlString string, analyzer *PathAnalyzer) (string, error) {
 		path = "/"
 	}
 	return ":" + port + path, nil
+}
+
+// addBracketsIfIPv6 looks at the authority part (before the first "/") of a
+// scheme-less input and brackets it if it is a bare IPv6 address, so that
+// url.Parse reads it as a host instead of splitting on every colon in the
+// address. Non-IPv6 input, and input that is already bracketed, is returned
+// unchanged.
+func addBracketsIfIPv6(urlString string) string {
+	authority := urlString
+	rest := ""
+	if idx := strings.IndexByte(urlString, '/'); idx >= 0 {
+		authority = urlString[:idx]
+		rest = urlString[idx:]
+	}
+
+	if strings.HasPrefix(authority, "[") {
+		return urlString
+	}
+
+	if addr, err := netip.ParseAddr(authority); err == nil && addr.Is6() {
+		return "[" + authority + "]" + rest
+	}
+
+	if idx := strings.LastIndex(authority, ":"); idx >= 0 {
+		host := authority[:idx]
+		port := authority[idx+1:]
+		if addr, err := netip.ParseAddr(host); err == nil && addr.Is6() && isAllDigits(port) {
+			return "[" + host + "]:" + port + rest
+		}
+	}
+
+	return urlString
+}
+
+func isAllDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 // splitEndpointPortAndPath splits the canonical `:<port><path>` form

--- a/pkg/registry/file/dynamicpathdetector/analyze_endpoints_internal_test.go
+++ b/pkg/registry/file/dynamicpathdetector/analyze_endpoints_internal_test.go
@@ -6,6 +6,40 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// TestAnalyzeURL_IPv6Hosts pins AnalyzeURL's handling of scheme-less input
+// whose authority is an IPv6 address. Before this, a bare IPv6 host was
+// mis-parsed because "http://" was prepended blindly, and url.Parse then
+// split on every colon in the address instead of just the port separator.
+// The host itself is discarded downstream (only the port and path make it
+// into the ":<port><path>" output), so these cases assert on that, not on
+// the parsed host.
+func TestAnalyzeURL_IPv6Hosts(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"bare_loopback", "::1/health", ":/health"},
+		{"bare_ipv6_no_port", "2001:db8::1/health", ":/health"},
+		{"trailing_hextet_not_a_port", "2001:db8::8080/x", ":/x"},
+		{"already_bracketed_with_port", "[2001:db8::1]:8080/x", ":8080/x"},
+		{"unbracketed_ipv6_with_trailing_group", "2001:db8::1:8080/x", ":/x"},
+		{"ipv4_host_with_port_regression", "example.com:80/users/123", ":80/users/123"},
+		{"canonical_form_regression", ":80/users/123", ":80/users/123"},
+		{"scheme_pass_through_regression", "http://example.com:80/x", ":80/x"},
+		{"ipv4_with_port_regression", "192.168.1.1:8080/path", ":8080/path"},
+	}
+
+	analyzer := NewPathAnalyzer(10)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := AnalyzeURL(tt.input, analyzer)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got, "AnalyzeURL(%q)", tt.input)
+		})
+	}
+}
+
 // TestSplitEndpointPortAndPath_DefensiveContract pins the inputs that
 // AnalyzeURL is supposed to produce (`:<port><path>`) AND the defensive
 // behavior for bare-path / empty / no-leading-slash inputs that may


### PR DESCRIPTION
Part of #334 (AC-3)

AnalyzeURL adds http:// to any input that has no scheme, then hands it to url.Parse. For a bare IPv6 host this is wrong, because url.Parse needs the host inside brackets to tell it apart from the colons used as the port separator. Without brackets, something like ::1/health was parsed as host ":" and port "1", instead of host "::1" with no port at all.

This adds a step before the http:// prefix goes on: look at the authority part of the input, meaning everything before the first slash, and if it parses as an IPv6 address, wrap it in brackets. If the authority splits on its last colon into an IPv6 host and an all digit port, only the host part gets bracketed, so the port is kept. Anything that is not IPv6, or is already bracketed, is left alone.

The parsed host itself is discarded later in AnalyzeURL, only the port and path end up in the output, so the test asserts on that output. I used the same set of cases listed in the issue, IPv6 with and without a port, an IPv6 address with a trailing all digit group that looks like a port but isn't, and a few IPv4 and hostname cases to check nothing there changed.

Ran go test on the package and gofmt, both clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of scheme-less IPv6 addresses, including addresses with numeric ports.
  * Preserved correct behavior for bracketed IPv6 addresses, IPv4 addresses, and URLs with schemes.
  * Ensured IPv6 hosts are parsed with the expected ports and paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->