### PR TITLE
fix: validate OpenVulnerabilityExchangeContainer spec (#355)

### DIFF
--- a/pkg/registry/softwarecomposition/openvulnerabilityexchange/strategy.go
+++ b/pkg/registry/softwarecomposition/openvulnerabilityexchange/strategy.go
@@ -59,16 +59,27 @@ func (OpenVulnerabilityExchangeContainerStrategy) PrepareForCreate(_ context.Con
 func (OpenVulnerabilityExchangeContainerStrategy) PrepareForUpdate(_ context.Context, _, _ runtime.Object) {
 }
 
-func (OpenVulnerabilityExchangeContainerStrategy) Validate(_ context.Context, obj runtime.Object) field.ErrorList {
-	vexContainer := obj.(*softwarecomposition.OpenVulnerabilityExchangeContainer)
+// validateVEXSpec is shared by Validate and ValidateUpdate so the same
+// rules are enforced on both create and update.
+//
+// Only spec.author is required. spec.statements is intentionally not
+// required: kubevuln's createVEX builds the statement list from scan
+// matches, so an image with zero findings produces a valid VEX document
+// with an empty statement list (see #355 discussion).
+func validateVEXSpec(vexContainer *softwarecomposition.OpenVulnerabilityExchangeContainer) field.ErrorList {
 	var allErrors field.ErrorList
 	if vexContainer.Spec.Author == "" {
 		allErrors = append(allErrors, field.Required(field.NewPath("spec", "author"), "must not be empty"))
 	}
-	if len(vexContainer.Spec.Statements) == 0 {
-		allErrors = append(allErrors, field.Required(field.NewPath("spec", "statements"), "must contain at least one statement"))
-	}
 	return allErrors
+}
+
+func (OpenVulnerabilityExchangeContainerStrategy) Validate(_ context.Context, obj runtime.Object) field.ErrorList {
+	vexContainer, ok := obj.(*softwarecomposition.OpenVulnerabilityExchangeContainer)
+	if !ok {
+		return field.ErrorList{field.InternalError(field.NewPath(""), fmt.Errorf("expected OpenVulnerabilityExchangeContainer, got %T", obj))}
+	}
+	return validateVEXSpec(vexContainer)
 }
 
 // WarningsOnCreate returns warnings for the creation of the given object.
@@ -87,8 +98,12 @@ func (OpenVulnerabilityExchangeContainerStrategy) AllowUnconditionalUpdate() boo
 func (OpenVulnerabilityExchangeContainerStrategy) Canonicalize(_ runtime.Object) {
 }
 
-func (OpenVulnerabilityExchangeContainerStrategy) ValidateUpdate(_ context.Context, _, _ runtime.Object) field.ErrorList {
-	return field.ErrorList{}
+func (OpenVulnerabilityExchangeContainerStrategy) ValidateUpdate(_ context.Context, obj, _ runtime.Object) field.ErrorList {
+	vexContainer, ok := obj.(*softwarecomposition.OpenVulnerabilityExchangeContainer)
+	if !ok {
+		return field.ErrorList{field.InternalError(field.NewPath(""), fmt.Errorf("expected OpenVulnerabilityExchangeContainer, got %T", obj))}
+	}
+	return validateVEXSpec(vexContainer)
 }
 
 // WarningsOnUpdate returns warnings for the given update.

--- a/pkg/registry/softwarecomposition/openvulnerabilityexchange/strategy.go
+++ b/pkg/registry/softwarecomposition/openvulnerabilityexchange/strategy.go
@@ -59,8 +59,16 @@ func (OpenVulnerabilityExchangeContainerStrategy) PrepareForCreate(_ context.Con
 func (OpenVulnerabilityExchangeContainerStrategy) PrepareForUpdate(_ context.Context, _, _ runtime.Object) {
 }
 
-func (OpenVulnerabilityExchangeContainerStrategy) Validate(_ context.Context, _ runtime.Object) field.ErrorList {
-	return field.ErrorList{}
+func (OpenVulnerabilityExchangeContainerStrategy) Validate(_ context.Context, obj runtime.Object) field.ErrorList {
+	vexContainer := obj.(*softwarecomposition.OpenVulnerabilityExchangeContainer)
+	var allErrors field.ErrorList
+	if vexContainer.Spec.Author == "" {
+		allErrors = append(allErrors, field.Required(field.NewPath("spec", "author"), "must not be empty"))
+	}
+	if len(vexContainer.Spec.Statements) == 0 {
+		allErrors = append(allErrors, field.Required(field.NewPath("spec", "statements"), "must contain at least one statement"))
+	}
+	return allErrors
 }
 
 // WarningsOnCreate returns warnings for the creation of the given object.

--- a/pkg/registry/softwarecomposition/openvulnerabilityexchange/strategy_test.go
+++ b/pkg/registry/softwarecomposition/openvulnerabilityexchange/strategy_test.go
@@ -1,0 +1,76 @@
+package openvulnerabilityexchange
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kubescape/storage/pkg/apis/softwarecomposition"
+)
+
+func TestValidate_RequiresAuthorAndStatements(t *testing.T) {
+	cases := []struct {
+		name      string
+		obj       *softwarecomposition.OpenVulnerabilityExchangeContainer
+		wantPaths map[string]int
+	}{
+		{
+			name: "empty spec is rejected on both fields",
+			obj:  &softwarecomposition.OpenVulnerabilityExchangeContainer{},
+			wantPaths: map[string]int{
+				"spec.author":     1,
+				"spec.statements": 1,
+			},
+		},
+		{
+			name: "missing statements only",
+			obj: &softwarecomposition.OpenVulnerabilityExchangeContainer{
+				Spec: softwarecomposition.VEX{
+					Metadata: softwarecomposition.Metadata{Author: "kubescape.io"},
+				},
+			},
+			wantPaths: map[string]int{
+				"spec.statements": 1,
+			},
+		},
+		{
+			name: "missing author only",
+			obj: &softwarecomposition.OpenVulnerabilityExchangeContainer{
+				Spec: softwarecomposition.VEX{
+					Statements: []softwarecomposition.Statement{{}},
+				},
+			},
+			wantPaths: map[string]int{
+				"spec.author": 1,
+			},
+		},
+		{
+			name: "valid spec has no errors",
+			obj: &softwarecomposition.OpenVulnerabilityExchangeContainer{
+				Spec: softwarecomposition.VEX{
+					Metadata:   softwarecomposition.Metadata{Author: "kubescape.io"},
+					Statements: []softwarecomposition.Statement{{}},
+				},
+			},
+			wantPaths: map[string]int{},
+		},
+	}
+
+	s := OpenVulnerabilityExchangeContainerStrategy{}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := s.Validate(context.TODO(), tt.obj)
+			got := map[string]int{}
+			for _, e := range errs {
+				got[e.Field]++
+			}
+			if len(got) != len(tt.wantPaths) {
+				t.Fatalf("got paths %v, want %v", got, tt.wantPaths)
+			}
+			for path, count := range tt.wantPaths {
+				if got[path] != count {
+					t.Errorf("path %s: got %d errors, want %d", path, got[path], count)
+				}
+			}
+		})
+	}
+}

--- a/pkg/registry/softwarecomposition/openvulnerabilityexchange/strategy_test.go
+++ b/pkg/registry/softwarecomposition/openvulnerabilityexchange/strategy_test.go
@@ -7,44 +7,30 @@ import (
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition"
 )
 
-func TestValidate_RequiresAuthorAndStatements(t *testing.T) {
+func TestValidate_RequiresAuthor(t *testing.T) {
 	cases := []struct {
 		name      string
 		obj       *softwarecomposition.OpenVulnerabilityExchangeContainer
 		wantPaths map[string]int
 	}{
 		{
-			name: "empty spec is rejected on both fields",
+			name: "empty spec is rejected for missing author",
 			obj:  &softwarecomposition.OpenVulnerabilityExchangeContainer{},
-			wantPaths: map[string]int{
-				"spec.author":     1,
-				"spec.statements": 1,
-			},
-		},
-		{
-			name: "missing statements only",
-			obj: &softwarecomposition.OpenVulnerabilityExchangeContainer{
-				Spec: softwarecomposition.VEX{
-					Metadata: softwarecomposition.Metadata{Author: "kubescape.io"},
-				},
-			},
-			wantPaths: map[string]int{
-				"spec.statements": 1,
-			},
-		},
-		{
-			name: "missing author only",
-			obj: &softwarecomposition.OpenVulnerabilityExchangeContainer{
-				Spec: softwarecomposition.VEX{
-					Statements: []softwarecomposition.Statement{{}},
-				},
-			},
 			wantPaths: map[string]int{
 				"spec.author": 1,
 			},
 		},
 		{
-			name: "valid spec has no errors",
+			name: "author set, zero statements is valid (clean-image scan)",
+			obj: &softwarecomposition.OpenVulnerabilityExchangeContainer{
+				Spec: softwarecomposition.VEX{
+					Metadata: softwarecomposition.Metadata{Author: "kubescape.io"},
+				},
+			},
+			wantPaths: map[string]int{},
+		},
+		{
+			name: "author and statements both set is valid",
 			obj: &softwarecomposition.OpenVulnerabilityExchangeContainer{
 				Spec: softwarecomposition.VEX{
 					Metadata:   softwarecomposition.Metadata{Author: "kubescape.io"},
@@ -72,5 +58,25 @@ func TestValidate_RequiresAuthorAndStatements(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestValidateUpdate_RequiresAuthor(t *testing.T) {
+	s := OpenVulnerabilityExchangeContainerStrategy{}
+
+	missingAuthor := &softwarecomposition.OpenVulnerabilityExchangeContainer{}
+	errs := s.ValidateUpdate(context.TODO(), missingAuthor, missingAuthor)
+	if len(errs) != 1 || errs[0].Field != "spec.author" {
+		t.Fatalf("expected exactly one spec.author error, got %v", errs)
+	}
+
+	valid := &softwarecomposition.OpenVulnerabilityExchangeContainer{
+		Spec: softwarecomposition.VEX{
+			Metadata: softwarecomposition.Metadata{Author: "kubescape.io"},
+		},
+	}
+	errs = s.ValidateUpdate(context.TODO(), valid, valid)
+	if len(errs) != 0 {
+		t.Fatalf("expected no errors for a valid update, got %v", errs)
 	}
 }


### PR DESCRIPTION
## Overview

`OpenVulnerabilityExchangeContainerStrategy.Validate()` discarded the
object it was given and always returned an empty error list, silently
accepting a completely empty or malformed `VEX` spec.

This adds real validation, following the same pattern already used by
`NetworkNeighborhoodStrategy.Validate()`: require a non-empty `Author`.
The same check now also runs on `ValidateUpdate`, since kubevuln's
steady-state path is update, not create.

## Before

```
errors found: 0
```
(on a completely empty spec)

## After

```
errors found: 1
  - spec.author: Required value: must not be empty
```
(zero-statement specs with an author set — e.g. a clean-image scan
with nothing to report — are correctly accepted, not rejected)

## Testing

`strategy_test.go` covers: missing author, a valid spec with zero
statements (the clean-image scan case), a valid spec with statements,
and both create and update paths.

## Update (per review)

The original version of this PR also required at least one statement,
which incorrectly rejected valid zero-finding scans from kubevuln's
`createVEX`. That check has been removed. Validation is now shared
between `Validate` and `ValidateUpdate` via a single helper, and the
type assertion uses the safer comma-ok form.

## Related issues/PRs:

* Resolved #355

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes
```