### PR TITLE
feat: add suppression provenance fields to IgnoreRule (#357)

### DIFF
--- a/pkg/apis/softwarecomposition/grype_types.go
+++ b/pkg/apis/softwarecomposition/grype_types.go
@@ -94,6 +94,17 @@ type IgnoreRule struct {
 	Vulnerability string
 	FixState      string
 	Package       *IgnoreRulePackage
+
+	// SourceKind, SourceName and SourceNamespace identify the object that
+	// caused this suppression (e.g. "SecurityException", its name, and
+	// namespace for a namespaced object).
+	SourceKind      string
+	SourceName      string
+	SourceNamespace string
+	// Justification and ImpactStatement carry the stated reason for the
+	// suppression, in VEX vocabulary.
+	Justification   string
+	ImpactStatement string
 }
 
 type IgnoreRulePackage struct {

--- a/pkg/apis/softwarecomposition/v1beta1/generated.pb.go
+++ b/pkg/apis/softwarecomposition/v1beta1/generated.pb.go
@@ -2908,6 +2908,31 @@ func (m *IgnoreRule) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
+	i -= len(m.ImpactStatement)
+	copy(dAtA[i:], m.ImpactStatement)
+	i = encodeVarintGenerated(dAtA, i, uint64(len(m.ImpactStatement)))
+	i--
+	dAtA[i] = 0x42
+	i -= len(m.Justification)
+	copy(dAtA[i:], m.Justification)
+	i = encodeVarintGenerated(dAtA, i, uint64(len(m.Justification)))
+	i--
+	dAtA[i] = 0x3a
+	i -= len(m.SourceNamespace)
+	copy(dAtA[i:], m.SourceNamespace)
+	i = encodeVarintGenerated(dAtA, i, uint64(len(m.SourceNamespace)))
+	i--
+	dAtA[i] = 0x32
+	i -= len(m.SourceName)
+	copy(dAtA[i:], m.SourceName)
+	i = encodeVarintGenerated(dAtA, i, uint64(len(m.SourceName)))
+	i--
+	dAtA[i] = 0x2a
+	i -= len(m.SourceKind)
+	copy(dAtA[i:], m.SourceKind)
+	i = encodeVarintGenerated(dAtA, i, uint64(len(m.SourceKind)))
+	i--
+	dAtA[i] = 0x22
 	if m.Package != nil {
 		{
 			size, err := m.Package.MarshalToSizedBuffer(dAtA[:i])
@@ -9965,6 +9990,16 @@ func (m *IgnoreRule) Size() (n int) {
 	l = len(m.Vulnerability)
 	n += 1 + l + sovGenerated(uint64(l))
 	l = len(m.FixState)
+	n += 1 + l + sovGenerated(uint64(l))
+	l = len(m.SourceKind)
+	n += 1 + l + sovGenerated(uint64(l))
+	l = len(m.SourceName)
+	n += 1 + l + sovGenerated(uint64(l))
+	l = len(m.SourceNamespace)
+	n += 1 + l + sovGenerated(uint64(l))
+	l = len(m.Justification)
+	n += 1 + l + sovGenerated(uint64(l))
+	l = len(m.ImpactStatement)
 	n += 1 + l + sovGenerated(uint64(l))
 	if m.Package != nil {
 		l = m.Package.Size()
@@ -22681,6 +22716,166 @@ func (m *IgnoreRule) Unmarshal(dAtA []byte) error {
 			if err := m.Package.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SourceKind", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.SourceKind = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SourceName", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.SourceName = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SourceNamespace", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.SourceNamespace = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 7:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Justification", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Justification = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 8:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ImpactStatement", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ImpactStatement = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/pkg/apis/softwarecomposition/v1beta1/grype_types.go
+++ b/pkg/apis/softwarecomposition/v1beta1/grype_types.go
@@ -94,6 +94,17 @@ type IgnoreRule struct {
 	Vulnerability string             `json:"vulnerability,omitempty" protobuf:"bytes,1,opt,name=vulnerability"`
 	FixState      string             `json:"fix-state,omitempty" protobuf:"bytes,2,opt,name=fixstate"`
 	Package       *IgnoreRulePackage `json:"package,omitempty" protobuf:"bytes,3,opt,name=package"`
+
+	// SourceKind, SourceName and SourceNamespace identify the object that
+	// caused this suppression (e.g. "SecurityException", its name, and
+	// namespace for a namespaced object).
+	SourceKind      string `json:"sourceKind,omitempty" protobuf:"bytes,4,opt,name=sourcekind"`
+	SourceName      string `json:"sourceName,omitempty" protobuf:"bytes,5,opt,name=sourcename"`
+	SourceNamespace string `json:"sourceNamespace,omitempty" protobuf:"bytes,6,opt,name=sourcenamespace"`
+	// Justification and ImpactStatement carry the stated reason for the
+	// suppression, in VEX vocabulary.
+	Justification   string `json:"justification,omitempty" protobuf:"bytes,7,opt,name=justification"`
+	ImpactStatement string `json:"impactStatement,omitempty" protobuf:"bytes,8,opt,name=impactstatement"`
 }
 
 type IgnoreRulePackage struct {

--- a/pkg/apis/softwarecomposition/v1beta1/grype_types_test.go
+++ b/pkg/apis/softwarecomposition/v1beta1/grype_types_test.go
@@ -37,3 +37,25 @@ func TestIgnoreRuleProvenanceFields(t *testing.T) {
 		assert.Equal(t, "allow-log4j", rule.SourceName, "mutating the clone must not affect the original")
 	})
 }
+
+
+func TestIgnoreRuleProtobufRoundTrip(t *testing.T) {
+	rule := IgnoreRule{
+		Vulnerability:   "CVE-2021-44228",
+		FixState:        "not-fixed",
+		Package:         &IgnoreRulePackage{Name: "log4j", Version: "2.14.0"},
+		SourceKind:      "SecurityException",
+		SourceName:      "allow-log4j",
+		SourceNamespace: "production",
+		Justification:   "vulnerable_code_not_present",
+		ImpactStatement: "Vulnerable component is not loaded into the memory",
+	}
+
+	data, err := rule.Marshal()
+	require.NoError(t, err)
+
+	var got IgnoreRule
+	require.NoError(t, got.Unmarshal(data))
+
+	assert.Equal(t, rule, got)
+}

--- a/pkg/apis/softwarecomposition/v1beta1/grype_types_test.go
+++ b/pkg/apis/softwarecomposition/v1beta1/grype_types_test.go
@@ -1,0 +1,39 @@
+package v1beta1
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIgnoreRuleProvenanceFields(t *testing.T) {
+	rule := IgnoreRule{
+		Vulnerability:   "CVE-2021-44228",
+		FixState:        "not-fixed",
+		SourceKind:      "SecurityException",
+		SourceName:      "allow-log4j",
+		SourceNamespace: "production",
+		Justification:   "vulnerable_code_not_present",
+		ImpactStatement: "Vulnerable component is not loaded into the memory",
+	}
+
+	t.Run("JSON round-trip preserves provenance fields", func(t *testing.T) {
+		raw, err := json.Marshal(rule)
+		require.NoError(t, err)
+		assert.Contains(t, string(raw), `"sourceKind":"SecurityException"`)
+
+		var got IgnoreRule
+		require.NoError(t, json.Unmarshal(raw, &got))
+		assert.Equal(t, rule, got)
+	})
+
+	t.Run("DeepCopy preserves provenance fields", func(t *testing.T) {
+		clone := rule.DeepCopy()
+		assert.Equal(t, rule, *clone)
+
+		clone.SourceName = "mutated"
+		assert.Equal(t, "allow-log4j", rule.SourceName, "mutating the clone must not affect the original")
+	})
+}

--- a/pkg/apis/softwarecomposition/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/softwarecomposition/v1beta1/zz_generated.conversion.go
@@ -3014,6 +3014,11 @@ func autoConvert_v1beta1_IgnoreRule_To_softwarecomposition_IgnoreRule(in *Ignore
 	out.Vulnerability = in.Vulnerability
 	out.FixState = in.FixState
 	out.Package = (*softwarecomposition.IgnoreRulePackage)(unsafe.Pointer(in.Package))
+	out.SourceKind = in.SourceKind
+	out.SourceName = in.SourceName
+	out.SourceNamespace = in.SourceNamespace
+	out.Justification = in.Justification
+	out.ImpactStatement = in.ImpactStatement
 	return nil
 }
 
@@ -3026,6 +3031,11 @@ func autoConvert_softwarecomposition_IgnoreRule_To_v1beta1_IgnoreRule(in *softwa
 	out.Vulnerability = in.Vulnerability
 	out.FixState = in.FixState
 	out.Package = (*IgnoreRulePackage)(unsafe.Pointer(in.Package))
+	out.SourceKind = in.SourceKind
+	out.SourceName = in.SourceName
+	out.SourceNamespace = in.SourceNamespace
+	out.Justification = in.Justification
+	out.ImpactStatement = in.ImpactStatement
 	return nil
 }
 

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -2622,6 +2622,36 @@ func schema_pkg_apis_softwarecomposition_v1beta1_IgnoreRule(ref common.Reference
 							Ref: ref(v1beta1.IgnoreRulePackage{}.OpenAPIModelName()),
 						},
 					},
+					"sourceKind": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"sourceName": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"sourceNamespace": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"justification": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"impactStatement": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
## Overview

`IgnoreRule` had only 3 fields (`Vulnerability`, `FixState`, `Package`),
with no way to record why or by what a vulnerability was suppressed.

kubevuln's recently-merged suppression-provenance system (kubevuln#488,
merged as kubevuln#495) already builds a real record of this -which
SecurityException matched, its scope, and its stated justification -but
that PR's own code comment confirms it can only log this, never store it,
because `IgnoreRule` has no fields for it.

This also affects the External VEX Ingestion project (kubevuln#387),
whose deliverables explicitly require "recording which document/statement
caused each suppression" - the same missing capability, for VEX
statements instead of SecurityExceptions.

## Before / After

**Before:**
```go
rule := IgnoreRule{
	Vulnerability: "CVE-2021-44228",
	SourceKind:    "SecurityException",
}
```
```
unknown field SourceKind in struct literal of type IgnoreRule
```

**After:** the same code compiles, and the field round-trips correctly
through both JSON and DeepCopy.

## Changes

Add generic, reusable provenance fields to `IgnoreRule`, in both the
internal and `v1beta1` versions:

```go
SourceKind      string // e.g. "SecurityException"
SourceName      string
SourceNamespace string
Justification   string
ImpactStatement string
```

No deepcopy regeneration needed - the generated `DeepCopyInto` does a
full value copy (`*out = *in`) before handling the one pointer field
(`Package`), so it already covers these new plain string fields
correctly. Verified with a test.

## Testing

`pkg/apis/softwarecomposition/v1beta1/grype_types_test.go` (new):
confirms the new fields survive a JSON round-trip, and confirms
`DeepCopy` correctly copies them without aliasing the original.

Full repo build and `go test ./...` pass with no failures.

## Follow-up

Once this is merged and released, a follow-up PR in `kubevuln` will wire
`buildSuppressionAttributes`/`logSuppression` (from #495) to actually
populate these new fields on `IgnoreRule`, instead of only logging them —
closing the gap that PR's own comment flagged.

## Related issues/PRs:

* Resolved #357

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Ignore rules now capture their source identity, including kind, name, and namespace.
  - Added optional VEX-related rationale details, including justification and impact statements.
  - These details are available across supported API versions.

- **Bug Fixes**
  - Improved preservation of ignore rule metadata when data is serialized, restored, or duplicated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->